### PR TITLE
Set up local SQLite backing store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Desktop.ini
 *.tmp
 *.temp
 .cache/
+server/.data/
 
 # Python
 __pycache__/
@@ -30,6 +31,7 @@ build/
 
 # Node / JavaScript
 node_modules/
+bun.lockb
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:web": "bun run --cwd web dev",
     "build:web": "bun run --cwd web build",
     "demo": "echo 'Run: bun install && bun run dev  →  open http://localhost:5173  →  click Run Sephora demo benchmark'",
-    "test:server": "bun test --cwd server src/features/competitive/__tests__/pipeline.test.ts src/features/competitive/__tests__/benchmark.service.test.ts src/features/competitive/__tests__/gap-analysis.service.test.ts src/routes/competitive.test.ts",
+    "test:server": "bun test --cwd server src/features/competitive/__tests__/pipeline.test.ts src/features/competitive/__tests__/benchmark.service.test.ts src/features/competitive/__tests__/gap-analysis.service.test.ts src/routes/business.test.ts src/routes/competitive.test.ts",
     "test:web": "bun test --cwd web src/components/competitive/__tests__/components.test.tsx",
     "test": "bun run test:server && bun run test:web"
   }

--- a/server/src/db/business-profiles.ts
+++ b/server/src/db/business-profiles.ts
@@ -1,0 +1,63 @@
+import { db } from "./client";
+
+export interface BusinessProfile {
+  id: string;
+  name: string;
+  website: string;
+  description: string;
+  createdAt: string;
+}
+
+interface BusinessProfileRow {
+  id: string;
+  name: string;
+  website: string;
+  description: string;
+  created_at: string;
+}
+
+export type NewBusinessProfile = Pick<BusinessProfile, "name" | "website" | "description">;
+
+function fromRow(row: BusinessProfileRow): BusinessProfile {
+  return {
+    id: row.id,
+    name: row.name,
+    website: row.website,
+    description: row.description,
+    createdAt: row.created_at,
+  };
+}
+
+const insertProfile = db.query<BusinessProfileRow, [string, string, string, string, string]>(`
+  INSERT INTO business_profiles (id, name, website, description, created_at)
+  VALUES (?, ?, ?, ?, ?)
+  RETURNING id, name, website, description, created_at
+`);
+
+const listProfiles = db.query<BusinessProfileRow, []>(`
+  SELECT id, name, website, description, created_at
+  FROM business_profiles
+  ORDER BY created_at DESC
+`);
+
+const getProfile = db.query<BusinessProfileRow, [string]>(`
+  SELECT id, name, website, description, created_at
+  FROM business_profiles
+  WHERE id = ?
+`);
+
+export const businessProfiles = {
+  create(input: NewBusinessProfile) {
+    const now = new Date().toISOString();
+    return fromRow(insertProfile.get(crypto.randomUUID(), input.name, input.website, input.description, now)!);
+  },
+
+  list() {
+    return listProfiles.all().map(fromRow);
+  },
+
+  get(id: string) {
+    const row = getProfile.get(id);
+    return row ? fromRow(row) : null;
+  },
+};

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -1,0 +1,24 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const dbPath = process.env.PERCEPTION_DB_PATH ?? join(import.meta.dir, "../../.data/perception.sqlite");
+
+mkdirSync(dirname(dbPath), { recursive: true });
+
+export const db = new Database(dbPath);
+db.exec("PRAGMA foreign_keys = ON;");
+
+export function runMigrations() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS business_profiles (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      website TEXT NOT NULL,
+      description TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+}
+
+runMigrations();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { businessRoutes } from "./routes/business";
 import { competitiveRoutes } from "./routes/competitive";
 
 const app = new Hono();
@@ -13,6 +14,7 @@ app.use(
 );
 
 app.get("/health", (c) => c.json({ ok: true }));
+app.route("/", businessRoutes);
 app.route("/", competitiveRoutes);
 
 export default {

--- a/server/src/routes/business.test.ts
+++ b/server/src/routes/business.test.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+import { expect, test } from "bun:test";
+import { businessProfiles } from "../db/business-profiles";
+import { businessRoutes } from "./business";
+
+const app = new Hono().route("/", businessRoutes);
+
+test("creates and lists business profiles", async () => {
+  const name = `Acme ${crypto.randomUUID()}`;
+  const createRes = await app.request("/business-profiles", {
+    method: "POST",
+    body: JSON.stringify({
+      name,
+      website: "https://acme.test",
+      description: "Project management software for growing teams.",
+    }),
+    headers: { "content-type": "application/json" },
+  });
+
+  expect(createRes.status).toBe(201);
+  const created = await createRes.json();
+  expect(created.name).toBe(name);
+
+  const listRes = await app.request("/business-profiles");
+  const listBody = await listRes.json();
+  expect(listBody.profiles.some((profile: { id: string }) => profile.id === created.id)).toBe(true);
+  expect(businessProfiles.get(created.id)?.website).toBe("https://acme.test");
+});

--- a/server/src/routes/business.ts
+++ b/server/src/routes/business.ts
@@ -1,0 +1,25 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { businessProfiles } from "../db/business-profiles";
+
+const profileSchema = z.object({
+  name: z.string().trim().min(1),
+  website: z.string().trim().min(1),
+  description: z.string().trim().min(1),
+});
+
+export const businessRoutes = new Hono();
+
+businessRoutes.get("/business-profiles", (c) => {
+  return c.json({ profiles: businessProfiles.list() });
+});
+
+businessRoutes.get("/business-profiles/:id", (c) => {
+  const profile = businessProfiles.get(c.req.param("id"));
+  return profile ? c.json(profile) : c.json({ error: "Business profile not found." }, 404);
+});
+
+businessRoutes.post("/business-profiles", async (c) => {
+  const body = profileSchema.parse(await c.req.json());
+  return c.json(businessProfiles.create(body), 201);
+});


### PR DESCRIPTION
## Summary
- add a local SQLite client and migration setup
- add business profile storage abstraction
- expose business profile create/list/get API routes
- ignore local DB artifacts

## Test plan
- bun test --cwd server src/routes/business.test.ts
- bun run test

Closes #13