### PR TITLE
Integrate benchmarking demo into dashboard

### DIFF
--- a/server/src/db/business-profiles.ts
+++ b/server/src/db/business-profiles.ts
@@ -46,6 +46,27 @@ const getProfile = db.query<BusinessProfileRow, [string]>(`
   WHERE id = ?
 `);
 
+interface CompetitorRow {
+  name: string;
+}
+
+const deleteCompetitors = db.query<null, [string]>(`
+  DELETE FROM business_competitors
+  WHERE business_profile_id = ?
+`);
+
+const insertCompetitor = db.query<null, [string, number, string, string]>(`
+  INSERT INTO business_competitors (business_profile_id, position, name, updated_at)
+  VALUES (?, ?, ?, ?)
+`);
+
+const listCompetitors = db.query<CompetitorRow, [string]>(`
+  SELECT name
+  FROM business_competitors
+  WHERE business_profile_id = ?
+  ORDER BY position
+`);
+
 export const businessProfiles = {
   create(input: NewBusinessProfile) {
     const now = new Date().toISOString();
@@ -59,5 +80,18 @@ export const businessProfiles = {
   get(id: string) {
     const row = getProfile.get(id);
     return row ? fromRow(row) : null;
+  },
+
+  competitors(id: string) {
+    return listCompetitors.all(id).map((row) => row.name);
+  },
+
+  saveCompetitors(id: string, names: string[]) {
+    const now = new Date().toISOString();
+    db.transaction(() => {
+      deleteCompetitors.run(id);
+      names.forEach((name, index) => insertCompetitor.run(id, index, name, now));
+    })();
+    return this.competitors(id);
   },
 };

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -18,6 +18,15 @@ export function runMigrations() {
       description TEXT NOT NULL,
       created_at TEXT NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS business_competitors (
+      business_profile_id TEXT NOT NULL,
+      position INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (business_profile_id, position),
+      FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE
+    );
   `);
 }
 

--- a/server/src/routes/business.test.ts
+++ b/server/src/routes/business.test.ts
@@ -26,3 +26,20 @@ test("creates and lists business profiles", async () => {
   expect(listBody.profiles.some((profile: { id: string }) => profile.id === created.id)).toBe(true);
   expect(businessProfiles.get(created.id)?.website).toBe("https://acme.test");
 });
+
+test("saves competitors for a business profile", async () => {
+  const profile = businessProfiles.create({
+    name: `Bench ${crypto.randomUUID()}`,
+    website: "https://bench.test",
+    description: "Benchmarking test profile.",
+  });
+
+  const response = await app.request(`/business-profiles/${profile.id}/competitors`, {
+    method: "PUT",
+    body: JSON.stringify({ competitorNames: ["A", "B", "C", "D", "E"] }),
+    headers: { "content-type": "application/json" },
+  });
+
+  expect(response.status).toBe(200);
+  expect((await response.json()).competitorNames).toEqual(["A", "B", "C", "D", "E"]);
+});

--- a/server/src/routes/business.ts
+++ b/server/src/routes/business.ts
@@ -23,3 +23,23 @@ businessRoutes.post("/business-profiles", async (c) => {
   const body = profileSchema.parse(await c.req.json());
   return c.json(businessProfiles.create(body), 201);
 });
+
+const competitorsSchema = z.object({
+  competitorNames: z.array(z.string().trim().min(1)).length(5),
+});
+
+businessRoutes.get("/business-profiles/:id/competitors", (c) => {
+  if (!businessProfiles.get(c.req.param("id"))) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  return c.json({ competitorNames: businessProfiles.competitors(c.req.param("id")) });
+});
+
+businessRoutes.put("/business-profiles/:id/competitors", async (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  const body = competitorsSchema.parse(await c.req.json());
+  return c.json({ competitorNames: businessProfiles.saveCompetitors(id, body.competitorNames) });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -143,6 +143,20 @@ export function ProfileDashboard({
       <aside className="sidebar">
         <strong>Perception</strong>
         <label>
+          Business
+          <select
+            aria-label="Active business profile"
+            value={profile.id}
+            onChange={(event) => onSelectProfile(event.target.value)}
+          >
+            {profiles.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
           Section
           <select value={activePage} onChange={(event) => onSelectPage(event.target.value as PageKey)}>
             {pages.map(([key, label]) => (
@@ -160,17 +174,6 @@ export function ProfileDashboard({
             <p className="muted">Business profile</p>
             <h1>{profile.name}</h1>
           </div>
-          <select
-            aria-label="Active business profile"
-            value={profile.id}
-            onChange={(event) => onSelectProfile(event.target.value)}
-          >
-            {profiles.map((item) => (
-              <option key={item.id} value={item.id}>
-                {item.name}
-              </option>
-            ))}
-          </select>
           <button type="button" onClick={onAddProfile}>
             New profile
           </button>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import "./app.css";
+import { CompetitivePage } from "./pages/competitive";
 import type { BusinessProfile } from "./types";
 
 const API_BASE =
@@ -175,21 +176,25 @@ export function ProfileDashboard({
           </button>
         </header>
 
-        <article className="panel">
-          <p className="muted">{page[1]}</p>
-          <h2>{profile.name}</h2>
-          <p>{page[2]}</p>
-          <dl>
-            <div>
-              <dt>Website</dt>
-              <dd>{profile.website}</dd>
-            </div>
-            <div>
-              <dt>Description</dt>
-              <dd>{profile.description}</dd>
-            </div>
-          </dl>
-        </article>
+        {activePage === "benchmarking" ? (
+          <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
+        ) : (
+          <article className="panel">
+            <p className="muted">{page[1]}</p>
+            <h2>{profile.name}</h2>
+            <p>{page[2]}</p>
+            <dl>
+              <div>
+                <dt>Website</dt>
+                <dd>{profile.website}</dd>
+              </div>
+              <div>
+                <dt>Description</dt>
+                <dd>{profile.description}</dd>
+              </div>
+            </dl>
+          </article>
+        )}
 
         {error && <p className="error">{error}</p>}
       </section>

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -105,10 +105,6 @@ button:disabled {
   border-bottom: 1px solid #d8d8d2;
 }
 
-.topbar select {
-  max-width: 260px;
-}
-
 .panel {
   display: grid;
   gap: 12px;
@@ -157,9 +153,5 @@ dt {
   .topbar {
     align-items: stretch;
     flex-direction: column;
-  }
-
-  .topbar select {
-    max-width: none;
   }
 }

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -1,17 +1,29 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 interface Props {
   onCreate: (input: { accountBrandName: string; competitorNames: string[] }) => Promise<void>;
+  accountBrandName?: string;
   busy?: boolean;
+  competitorNames?: string[];
+  onSave?: (names: string[]) => Promise<void>;
 }
 
 /** Demo cohort: Sephora vs five beauty retail competitors */
 const DEFAULT_ACCOUNT = "Sephora";
 const DEFAULT_COMPETITORS = ["Ulta", "Bluemercury", "SpaceNK", "SallyBeauty", "Olive Young"];
 
-export function CompetitiveSetPicker({ onCreate, busy }: Props) {
-  const [accountBrandName, setAccountBrandName] = useState(DEFAULT_ACCOUNT);
-  const [competitorNames, setCompetitorNames] = useState<string[]>(DEFAULT_COMPETITORS);
+export function CompetitiveSetPicker({
+  accountBrandName: initialAccountBrandName = DEFAULT_ACCOUNT,
+  busy,
+  competitorNames: savedCompetitors,
+  onCreate,
+  onSave,
+}: Props) {
+  const [accountBrandName, setAccountBrandName] = useState(initialAccountBrandName);
+  const [competitorNames, setCompetitorNames] = useState<string[]>(savedCompetitors ?? DEFAULT_COMPETITORS);
+
+  useEffect(() => setAccountBrandName(initialAccountBrandName), [initialAccountBrandName]);
+  useEffect(() => setCompetitorNames(savedCompetitors ?? DEFAULT_COMPETITORS), [savedCompetitors]);
 
   const canSubmit = useMemo(() => {
     return accountBrandName.trim().length > 0 && competitorNames.every((name) => name.trim().length > 0);
@@ -42,13 +54,18 @@ export function CompetitiveSetPicker({ onCreate, busy }: Props) {
           />
         </label>
       ))}
-      <button
-        type="button"
-        onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
-        disabled={!canSubmit || busy}
-      >
-        {busy ? "Running 20-question benchmark..." : "Run benchmark"}
-      </button>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button type="button" onClick={() => onSave?.(competitorNames)} disabled={!canSubmit || busy || !onSave}>
+          Save competitors
+        </button>
+        <button
+          type="button"
+          onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
+          disabled={!canSubmit || busy}
+        >
+          {busy ? "Running 20-question benchmark..." : "Run benchmark"}
+        </button>
+      </div>
       {busy && (
         <p style={{ marginBottom: 0, color: "#555" }}>
           Generating brand-perception summaries and comparisons. This can take a bit while the server fans out the LLM

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -37,11 +37,18 @@ function createInitialProgressBoxes(labels: Record<string, string>) {
   );
 }
 
-export function CompetitivePage() {
+export function CompetitivePage({
+  businessProfileId,
+  businessName,
+}: {
+  businessProfileId?: string;
+  businessName?: string;
+}) {
   const [busy, setBusy] = useState(false);
   const [accountBrandId, setAccountBrandId] = useState<string>("");
-  const [accountBrandName, setAccountBrandName] = useState<string>("Sephora");
+  const [accountBrandName, setAccountBrandName] = useState<string>(businessName ?? "Sephora");
   const [competitorBrandIds, setCompetitorBrandIds] = useState<string[]>([]);
+  const [savedCompetitors, setSavedCompetitors] = useState<string[]>([]);
   const [brandLabels, setBrandLabels] = useState<Record<string, string>>({});
   const [overview, setOverview] = useState<OverviewResponse | null>(null);
   const [trends, setTrends] = useState<TrendsResponse | null>(null);
@@ -60,6 +67,32 @@ export function CompetitivePage() {
       progressSourceRef.current = null;
     };
   }, []);
+
+  useEffect(() => {
+    setAccountBrandName(businessName ?? "Sephora");
+  }, [businessName]);
+
+  useEffect(() => {
+    if (!businessProfileId) {
+      return;
+    }
+    fetch(`${API_BASE}/business-profiles/${businessProfileId}/competitors`)
+      .then((res) => (res.ok ? res.json() : { competitorNames: [] }))
+      .then((body: { competitorNames: string[] }) => setSavedCompetitors(body.competitorNames))
+      .catch(() => setSavedCompetitors([]));
+  }, [businessProfileId]);
+
+  async function saveCompetitors(names: string[]) {
+    setSavedCompetitors(names);
+    if (!businessProfileId) {
+      return;
+    }
+    await fetch(`${API_BASE}/business-profiles/${businessProfileId}/competitors`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ competitorNames: names.map((name) => name.trim()) }),
+    });
+  }
 
   function closeProgressStream() {
     progressSourceRef.current?.close();
@@ -153,6 +186,7 @@ export function CompetitivePage() {
     try {
       const windowStart = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
       const windowEndAfterRun = () => new Date().toISOString();
+      await saveCompetitors(input.competitorNames);
 
       const setRes = await fetch(`${API_BASE}/competitive-sets`, {
         method: "POST",
@@ -245,7 +279,7 @@ export function CompetitivePage() {
 
   return (
     <main style={{ maxWidth: 1100, margin: "0 auto", padding: 24, fontFamily: "Inter, Arial, sans-serif" }}>
-      <h1>Competitive Benchmarking — Demo</h1>
+      <h1>Competitive Benchmarking</h1>
       <p style={{ marginTop: 0 }}>
         Each run uses <strong>10 brand-specific prompts</strong> (with each retailer’s name) plus{" "}
         <strong>10 category-wide prompts</strong> (leader, best, most reliable, etc.), all answered per retailer;
@@ -254,7 +288,13 @@ export function CompetitivePage() {
         <strong>SallyBeauty</strong>, and <strong>Olive Young</strong>.
       </p>
 
-      <CompetitiveSetPicker onCreate={createSet} busy={busy} />
+      <CompetitiveSetPicker
+        accountBrandName={businessName}
+        busy={busy}
+        competitorNames={savedCompetitors.length ? savedCompetitors : undefined}
+        onCreate={createSet}
+        onSave={saveCompetitors}
+      />
       {error && <p style={{ color: "crimson" }}>{error}</p>}
 
       {(Object.keys(progressByBrand).length > 0 || judgeLines.length > 0 || busy) && (


### PR DESCRIPTION
## Summary
- render the existing competitive benchmarking demo inside the Benchmarking tab
- persist five competitors for each business profile
- add profile competitor GET/PUT routes
- move the business profile selector into the left sidebar

## Test plan
- bun run test
- bun run build:web

Closes #16