### PR TITLE
Add LLM provider abstraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:web": "bun run --cwd web dev",
     "build:web": "bun run --cwd web build",
     "demo": "echo 'Run: bun install && bun run dev  →  open http://localhost:5173  →  click Run Sephora demo benchmark'",
-    "test:server": "bun test --cwd server src/features/competitive/__tests__/pipeline.test.ts src/features/competitive/__tests__/benchmark.service.test.ts src/features/competitive/__tests__/gap-analysis.service.test.ts src/routes/business.test.ts src/routes/competitive.test.ts",
+    "test:server": "bun test --cwd server src/features/competitive/__tests__/pipeline.test.ts src/features/competitive/__tests__/benchmark.service.test.ts src/features/competitive/__tests__/gap-analysis.service.test.ts src/lib/llm-providers.test.ts src/routes/business.test.ts src/routes/competitive.test.ts",
     "test:web": "bun test --cwd web src/__tests__/app.test.tsx src/components/competitive/__tests__/components.test.tsx",
     "test": "bun run test:server && bun run test:web"
   }

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -27,6 +27,23 @@ export function runMigrations() {
       PRIMARY KEY (business_profile_id, position),
       FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE
     );
+
+    CREATE TABLE IF NOT EXISTS business_setup_state (
+      business_profile_id TEXT PRIMARY KEY,
+      monitoring_status TEXT NOT NULL,
+      error TEXT,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS monitoring_prompts (
+      id TEXT PRIMARY KEY,
+      business_profile_id TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      mention_sentiment TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE
+    );
   `);
 }
 

--- a/server/src/db/monitoring-prompts.ts
+++ b/server/src/db/monitoring-prompts.ts
@@ -1,0 +1,100 @@
+import { db } from "./client";
+
+export type MonitoringStatus = "generating" | "ready" | "error";
+export type MentionSentiment = "positive" | "negative" | "neutral";
+
+export interface MonitoringPrompt {
+  id: string;
+  businessProfileId: string;
+  prompt: string;
+  mentionSentiment: MentionSentiment;
+  createdAt: string;
+}
+
+interface PromptRow {
+  id: string;
+  business_profile_id: string;
+  prompt: string;
+  mention_sentiment: MentionSentiment;
+  created_at: string;
+}
+
+interface StateRow {
+  monitoring_status: MonitoringStatus;
+  error: string | null;
+}
+
+function fromRow(row: PromptRow): MonitoringPrompt {
+  return {
+    id: row.id,
+    businessProfileId: row.business_profile_id,
+    prompt: row.prompt,
+    mentionSentiment: row.mention_sentiment,
+    createdAt: row.created_at,
+  };
+}
+
+const upsertState = db.query<null, [string, MonitoringStatus, string | null, string]>(`
+  INSERT INTO business_setup_state (business_profile_id, monitoring_status, error, updated_at)
+  VALUES (?, ?, ?, ?)
+  ON CONFLICT(business_profile_id) DO UPDATE SET
+    monitoring_status = excluded.monitoring_status,
+    error = excluded.error,
+    updated_at = excluded.updated_at
+`);
+
+const getState = db.query<StateRow, [string]>(`
+  SELECT monitoring_status, error
+  FROM business_setup_state
+  WHERE business_profile_id = ?
+`);
+
+const insertPrompt = db.query<PromptRow, [string, string, string, MentionSentiment, string]>(`
+  INSERT INTO monitoring_prompts (id, business_profile_id, prompt, mention_sentiment, created_at)
+  VALUES (?, ?, ?, ?, ?)
+  RETURNING id, business_profile_id, prompt, mention_sentiment, created_at
+`);
+
+const deletePrompts = db.query<null, [string]>(`
+  DELETE FROM monitoring_prompts
+  WHERE business_profile_id = ?
+`);
+
+const listPrompts = db.query<PromptRow, [string]>(`
+  SELECT id, business_profile_id, prompt, mention_sentiment, created_at
+  FROM monitoring_prompts
+  WHERE business_profile_id = ?
+  ORDER BY created_at ASC
+`);
+
+function fakeSentiment(index: number): MentionSentiment {
+  return (["positive", "neutral", "negative"] as const)[index % 3]!;
+}
+
+export const monitoringPrompts = {
+  add(businessProfileId: string, prompt: string) {
+    return fromRow(insertPrompt.get(crypto.randomUUID(), businessProfileId, prompt, fakeSentiment(Date.now()), new Date().toISOString())!);
+  },
+
+  list(businessProfileId: string) {
+    return listPrompts.all(businessProfileId).map(fromRow);
+  },
+
+  replaceAll(businessProfileId: string, prompts: string[]) {
+    db.transaction(() => {
+      deletePrompts.run(businessProfileId);
+      prompts.forEach((prompt, index) => {
+        insertPrompt.get(crypto.randomUUID(), businessProfileId, prompt, fakeSentiment(index), new Date().toISOString());
+      });
+    })();
+    return this.list(businessProfileId);
+  },
+
+  setStatus(businessProfileId: string, status: MonitoringStatus, error: string | null = null) {
+    upsertState.run(businessProfileId, status, error, new Date().toISOString());
+  },
+
+  state(businessProfileId: string) {
+    return getState.get(businessProfileId) ?? { monitoring_status: "ready" as const, error: null };
+  },
+};

--- a/server/src/features/monitoring/prompt-generation.ts
+++ b/server/src/features/monitoring/prompt-generation.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { BusinessProfile } from "../../db/business-profiles";
+import { monitoringPrompts } from "../../db/monitoring-prompts";
+import { callStructuredLLM } from "../../lib/llm-providers";
+
+const promptResultSchema = z.object({
+  prompts: z.array(z.string().min(8)).length(5),
+});
+
+function fallbackPrompts(profile: BusinessProfile) {
+  return [
+    `What are the best tools like ${profile.name}?`,
+    `Which companies help with ${profile.description}?`,
+    `Compare ${profile.name} with alternatives`,
+    `What should I use for ${profile.website}?`,
+    `Best solution for teams needing ${profile.description}`,
+  ];
+}
+
+export async function generateMonitoringPrompts(profile: BusinessProfile) {
+  monitoringPrompts.setStatus(profile.id, "generating");
+  try {
+    const result = await callStructuredLLM({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      prompt: `Generate exactly 5 natural language chatbot queries where this business might show up.
+
+Business name: ${profile.name}
+Website: ${profile.website}
+Description: ${profile.description}
+
+Make the prompts realistic things a buyer would type into ChatGPT, Claude, Gemini, or Perplexity.
+Return only the structured prompt list.`,
+      schema: promptResultSchema,
+      schemaName: "monitoring_prompt_list",
+      useSearch: true,
+      mockValue: { prompts: fallbackPrompts(profile) },
+    });
+    monitoringPrompts.replaceAll(profile.id, result.prompts);
+    monitoringPrompts.setStatus(profile.id, "ready");
+  } catch (error) {
+    monitoringPrompts.replaceAll(profile.id, fallbackPrompts(profile));
+    monitoringPrompts.setStatus(profile.id, "error", error instanceof Error ? error.message : "Prompt generation failed.");
+  }
+}

--- a/server/src/lib/llm-providers.test.ts
+++ b/server/src/lib/llm-providers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { callLLM, isLLMProviderConfigured } from "./llm-providers";
+import { z } from "zod";
+import { callLLM, callStructuredLLM, isLLMProviderConfigured } from "./llm-providers";
 
 describe("llm providers", () => {
   test("calls the selected mock provider with one prompt", async () => {
@@ -17,5 +18,18 @@ describe("llm providers", () => {
 
   test("reports mock configured", () => {
     expect(isLLMProviderConfigured("mock")).toBeTrue();
+  });
+
+  test("returns mock structured data", async () => {
+    const schema = z.object({ prompts: z.array(z.string()) });
+    const data = await callStructuredLLM({
+      provider: "mock",
+      prompt: "Generate prompts",
+      schema,
+      schemaName: "prompt_list",
+      mockValue: { prompts: ["best analytics tool"] },
+    });
+
+    expect(data.prompts).toEqual(["best analytics tool"]);
   });
 });

--- a/server/src/lib/llm-providers.test.ts
+++ b/server/src/lib/llm-providers.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { callLLM, isLLMProviderConfigured } from "./llm-providers";
+
+describe("llm providers", () => {
+  test("calls the selected mock provider with one prompt", async () => {
+    const chunks: string[] = [];
+    const text = await callLLM({
+      provider: "mock",
+      model: "demo-model",
+      prompt: "Summarize Perception in one sentence.",
+      onDelta: (chunk) => chunks.push(chunk),
+    });
+
+    expect(text.includes("Summarize Perception")).toBeTrue();
+    expect(chunks.length).toBe(1);
+  });
+
+  test("reports mock configured", () => {
+    expect(isLLMProviderConfigured("mock")).toBeTrue();
+  });
+});

--- a/server/src/lib/llm-providers.ts
+++ b/server/src/lib/llm-providers.ts
@@ -1,0 +1,109 @@
+import OpenAI from "openai";
+
+export type LLMProviderName = "mock" | "openai";
+
+export interface LLMMessage {
+  role: "system" | "user";
+  content: string;
+}
+
+export interface LLMCallInput {
+  maxOutputTokens?: number;
+  messages?: LLMMessage[];
+  model?: string;
+  onCompleted?: () => void;
+  onDelta?: (text: string) => void;
+  onStarted?: () => void;
+  prompt: string;
+  provider?: LLMProviderName;
+}
+
+interface LLMProvider {
+  call(input: Omit<LLMCallInput, "provider">): Promise<string>;
+  configured(): boolean;
+}
+
+const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
+const openAIClient = env.OPENAI_API_KEY ? new OpenAI({ apiKey: env.OPENAI_API_KEY }) : null;
+const STREAM_FLUSH_CHARS = 140;
+
+function flush(buffer: string, onDelta?: (text: string) => void) {
+  const text = buffer.trim();
+  if (text) {
+    onDelta?.(text);
+  }
+}
+
+const providers: Record<LLMProviderName, LLMProvider> = {
+  mock: {
+    configured: () => true,
+    async call(input) {
+      input.onStarted?.();
+      const text = `Mock ${input.model ?? "model"} response: ${input.prompt.slice(0, 120)}`;
+      input.onDelta?.(text);
+      input.onCompleted?.();
+      return text;
+    },
+  },
+
+  openai: {
+    configured: () => Boolean(openAIClient),
+    async call(input) {
+      if (!openAIClient) {
+        throw new Error("OpenAI client not configured.");
+      }
+
+      input.onStarted?.();
+      const runner = openAIClient.responses.stream({
+        model: input.model ?? "gpt-4.1-mini",
+        max_output_tokens: input.maxOutputTokens,
+        input: input.messages ?? [{ role: "user", content: input.prompt }],
+      });
+
+      let buffer = "";
+      let fullText = "";
+
+      runner.on("response.output_text.delta", (event) => {
+        fullText += event.delta;
+        buffer += event.delta;
+
+        let newlineIndex = buffer.indexOf("\n");
+        while (newlineIndex !== -1) {
+          flush(buffer.slice(0, newlineIndex), input.onDelta);
+          buffer = buffer.slice(newlineIndex + 1);
+          newlineIndex = buffer.indexOf("\n");
+        }
+
+        if (buffer.length >= STREAM_FLUSH_CHARS) {
+          flush(buffer, input.onDelta);
+          buffer = "";
+        }
+      });
+
+      const response = await runner.finalResponse();
+      flush(buffer, input.onDelta);
+      input.onCompleted?.();
+
+      return typeof response.output_text === "string" && response.output_text.trim()
+        ? response.output_text
+        : fullText;
+    },
+  },
+};
+
+export function configuredLLMProvider(): LLMProviderName {
+  return (env.LLM_PROVIDER as LLMProviderName | undefined) ?? "openai";
+}
+
+export function isLLMProviderConfigured(provider = configuredLLMProvider()) {
+  return providers[provider]?.configured() ?? false;
+}
+
+export async function callLLM(input: LLMCallInput) {
+  const providerName = input.provider ?? configuredLLMProvider();
+  const provider = providers[providerName];
+  if (!provider) {
+    throw new Error(`Unsupported LLM provider: ${providerName}`);
+  }
+  return provider.call(input);
+}

--- a/server/src/lib/llm-providers.ts
+++ b/server/src/lib/llm-providers.ts
@@ -128,6 +128,9 @@ const providers: Record<LLMProviderName, LLMProvider> = {
 };
 
 export function configuredLLMProvider(): LLMProviderName {
+  if (env.NODE_ENV === "test") {
+    return "mock";
+  }
   return (env.LLM_PROVIDER as LLMProviderName | undefined) ?? "openai";
 }
 

--- a/server/src/lib/llm-providers.ts
+++ b/server/src/lib/llm-providers.ts
@@ -1,4 +1,6 @@
 import OpenAI from "openai";
+import { zodTextFormat } from "openai/helpers/zod";
+import type { z } from "zod";
 
 export type LLMProviderName = "mock" | "openai";
 
@@ -16,10 +18,18 @@ export interface LLMCallInput {
   onStarted?: () => void;
   prompt: string;
   provider?: LLMProviderName;
+  useSearch?: boolean;
+}
+
+export interface StructuredLLMCallInput<T> extends LLMCallInput {
+  mockValue?: T;
+  schema: z.ZodType<T>;
+  schemaName: string;
 }
 
 interface LLMProvider {
   call(input: Omit<LLMCallInput, "provider">): Promise<string>;
+  structured<T>(input: Omit<StructuredLLMCallInput<T>, "provider">): Promise<T>;
   configured(): boolean;
 }
 
@@ -44,6 +54,14 @@ const providers: Record<LLMProviderName, LLMProvider> = {
       input.onCompleted?.();
       return text;
     },
+    async structured(input) {
+      input.onStarted?.();
+      input.onCompleted?.();
+      if (input.mockValue !== undefined) {
+        return input.mockValue;
+      }
+      return input.schema.parse({});
+    },
   },
 
   openai: {
@@ -58,6 +76,7 @@ const providers: Record<LLMProviderName, LLMProvider> = {
         model: input.model ?? "gpt-4.1-mini",
         max_output_tokens: input.maxOutputTokens,
         input: input.messages ?? [{ role: "user", content: input.prompt }],
+        tools: input.useSearch ? [{ type: "web_search" }] : undefined,
       });
 
       let buffer = "";
@@ -88,6 +107,23 @@ const providers: Record<LLMProviderName, LLMProvider> = {
         ? response.output_text
         : fullText;
     },
+    async structured(input) {
+      if (!openAIClient) {
+        throw new Error("OpenAI client not configured.");
+      }
+
+      input.onStarted?.();
+      const response = await openAIClient.responses.parse({
+        model: input.model ?? "gpt-4.1-mini",
+        input: input.messages ?? [{ role: "user", content: input.prompt }],
+        text: {
+          format: zodTextFormat(input.schema, input.schemaName),
+        },
+        tools: input.useSearch ? [{ type: "web_search" }] : undefined,
+      } as Parameters<typeof openAIClient.responses.parse>[0]);
+      input.onCompleted?.();
+      return input.schema.parse(response.output_parsed);
+    },
   },
 };
 
@@ -106,4 +142,13 @@ export async function callLLM(input: LLMCallInput) {
     throw new Error(`Unsupported LLM provider: ${providerName}`);
   }
   return provider.call(input);
+}
+
+export async function callStructuredLLM<T>(input: StructuredLLMCallInput<T>) {
+  const providerName = input.provider ?? configuredLLMProvider();
+  const provider = providers[providerName];
+  if (!provider) {
+    throw new Error(`Unsupported LLM provider: ${providerName}`);
+  }
+  return provider.structured(input);
 }

--- a/server/src/lib/llm.ts
+++ b/server/src/lib/llm.ts
@@ -1,14 +1,9 @@
-import OpenAI from "openai";
 import { z } from "zod";
 import type { ProgressReporter } from "../features/competitive/progress";
 import type { AIAnswer, Brand, ComparativeDelta, PromptRun } from "../features/competitive/types";
+import { callLLM, configuredLLMProvider, isLLMProviderConfigured, type LLMMessage } from "./llm-providers";
 
-type SupportedLLMProvider = "openai";
-
-const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
-const configuredProvider = (env.LLM_PROVIDER ?? "openai") as SupportedLLMProvider;
-const openAIApiKey = env.OPENAI_API_KEY;
-const openAIClient = configuredProvider === "openai" && openAIApiKey ? new OpenAI({ apiKey: openAIApiKey }) : null;
+const configuredProvider = configuredLLMProvider();
 
 const mentionSchema = z.object({
   brandId: z.string(),
@@ -29,20 +24,13 @@ const judgeOutputSchema = z.object({
 
 const BRAND_ANSWER_MAX_OUTPUT_TOKENS = 220;
 const JUDGE_MAX_OUTPUT_TOKENS = 900;
-const STREAM_FLUSH_CHARS = 140;
 
 function getProviderLabel() {
   return `llm:${configuredProvider}`;
 }
 
-function getStreamingClient() {
-  if (configuredProvider !== "openai") {
-    throw new Error(`Unsupported LLM provider: ${configuredProvider}`);
-  }
-  if (!openAIClient) {
-    return null;
-  }
-  return openAIClient;
+function shouldUseLocalMocks() {
+  return configuredProvider === "mock" || !isLLMProviderConfigured(configuredProvider);
 }
 
 function interpolateBrand(template: string, brandName: string) {
@@ -53,65 +41,35 @@ function compactLabel(value: string) {
   return value.replaceAll(/\s+/g, " ").trim().slice(0, 80);
 }
 
-function flushStreamBuffer(label: string, buffer: string, onDelta?: (text: string) => void) {
-  const text = buffer.trim();
-  if (!text) {
-    return;
-  }
-  console.log(`[${getProviderLabel()}] ${label}: ${text}`);
-  onDelta?.(text);
-}
-
 async function createStreamedResponse(input: {
   label: string;
   model: string;
   maxOutputTokens: number;
-  messages: Array<{ role: "system" | "user"; content: string }>;
+  messages: LLMMessage[];
   onStarted?: () => void;
   onDelta?: (text: string) => void;
   onCompleted?: () => void;
 }) {
-  const client = getStreamingClient();
-  if (!client) {
+  if (shouldUseLocalMocks()) {
     throw new Error(`${configuredProvider} client not configured.`);
   }
 
   console.log(`[${getProviderLabel()}] ${input.label}: started`);
-  input.onStarted?.();
-
-  const runner = client.responses.stream({
+  const outputText = await callLLM({
+    provider: configuredProvider,
     model: input.model,
-    max_output_tokens: input.maxOutputTokens,
-    input: input.messages,
+    maxOutputTokens: input.maxOutputTokens,
+    messages: input.messages,
+    prompt: input.messages.map((message) => message.content).join("\n\n"),
+    onStarted: input.onStarted,
+    onDelta: (text) => {
+      console.log(`[${getProviderLabel()}] ${input.label}: ${text}`);
+      input.onDelta?.(text);
+    },
+    onCompleted: input.onCompleted,
   });
-
-  let buffer = "";
-  let fullText = "";
-
-  runner.on("response.output_text.delta", (event) => {
-    fullText += event.delta;
-    buffer += event.delta;
-
-    let newlineIndex = buffer.indexOf("\n");
-    while (newlineIndex !== -1) {
-      flushStreamBuffer(input.label, buffer.slice(0, newlineIndex), input.onDelta);
-      buffer = buffer.slice(newlineIndex + 1);
-      newlineIndex = buffer.indexOf("\n");
-    }
-
-    if (buffer.length >= STREAM_FLUSH_CHARS) {
-      flushStreamBuffer(input.label, buffer, input.onDelta);
-      buffer = "";
-    }
-  });
-
-  const response = await runner.finalResponse();
-  flushStreamBuffer(input.label, buffer, input.onDelta);
   console.log(`[${getProviderLabel()}] ${input.label}: completed`);
-  input.onCompleted?.();
-  return typeof response.output_text === "string" && response.output_text.trim().length > 0
-    ? response.output_text
-    : fullText;
+  return outputText;
 }
 
 function extractJSONObject(text: string) {
@@ -154,7 +112,7 @@ export async function generateBrandAnswer(input: {
       ? interpolateBrand(input.promptRun.prompt, input.brand.name)
       : input.promptRun.prompt;
 
-  if (!getStreamingClient()) {
+  if (shouldUseLocalMocks()) {
     const kind = input.promptRun.promptKind;
     return `Mock perception summary for ${input.brand.name} (${kind}). "${questionText.slice(0, 90)}..."`;
   }
@@ -231,7 +189,7 @@ export async function judgeComparativeOutputs(input: {
   answers: AIAnswer[];
   reportProgress?: ProgressReporter;
 }): Promise<ComparativeDelta> {
-  if (!getStreamingClient()) {
+  if (shouldUseLocalMocks()) {
     const equalShare = 1 / input.answers.length;
     const shareOfVoiceByBrand: Record<string, number> = {};
     const sentimentByBrand: Record<string, number> = {};

--- a/server/src/routes/business.test.ts
+++ b/server/src/routes/business.test.ts
@@ -3,6 +3,8 @@ import { expect, test } from "bun:test";
 import { businessProfiles } from "../db/business-profiles";
 import { businessRoutes } from "./business";
 
+process.env.DISABLE_ONBOARDING_PROMPT_GENERATION = "1";
+
 const app = new Hono().route("/", businessRoutes);
 
 test("creates and lists business profiles", async () => {
@@ -42,4 +44,24 @@ test("saves competitors for a business profile", async () => {
 
   expect(response.status).toBe(200);
   expect((await response.json()).competitorNames).toEqual(["A", "B", "C", "D", "E"]);
+});
+
+test("adds monitoring prompts for a business profile", async () => {
+  const profile = businessProfiles.create({
+    name: `Monitor ${crypto.randomUUID()}`,
+    website: "https://monitor.test",
+    description: "Monitoring test profile.",
+  });
+
+  const response = await app.request(`/business-profiles/${profile.id}/monitoring-prompts`, {
+    method: "POST",
+    body: JSON.stringify({ prompt: "What is the best monitoring platform for AI search?" }),
+    headers: { "content-type": "application/json" },
+  });
+  expect(response.status).toBe(201);
+
+  const listRes = await app.request(`/business-profiles/${profile.id}/monitoring`);
+  const listBody = await listRes.json();
+  expect(listBody.prompts).toHaveLength(1);
+  expect(listBody.prompts[0].mentionSentiment).toBeTruthy();
 });

--- a/server/src/routes/business.ts
+++ b/server/src/routes/business.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { businessProfiles } from "../db/business-profiles";
+import { monitoringPrompts } from "../db/monitoring-prompts";
+import { generateMonitoringPrompts } from "../features/monitoring/prompt-generation";
 
 const profileSchema = z.object({
   name: z.string().trim().min(1),
@@ -21,7 +23,11 @@ businessRoutes.get("/business-profiles/:id", (c) => {
 
 businessRoutes.post("/business-profiles", async (c) => {
   const body = profileSchema.parse(await c.req.json());
-  return c.json(businessProfiles.create(body), 201);
+  const profile = businessProfiles.create(body);
+  if (process.env.DISABLE_ONBOARDING_PROMPT_GENERATION !== "1") {
+    void generateMonitoringPrompts(profile);
+  }
+  return c.json(profile, 201);
 });
 
 const competitorsSchema = z.object({
@@ -42,4 +48,30 @@ businessRoutes.put("/business-profiles/:id/competitors", async (c) => {
   }
   const body = competitorsSchema.parse(await c.req.json());
   return c.json({ competitorNames: businessProfiles.saveCompetitors(id, body.competitorNames) });
+});
+
+const promptSchema = z.object({
+  prompt: z.string().trim().min(8),
+});
+
+businessRoutes.get("/business-profiles/:id/monitoring", (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  const state = monitoringPrompts.state(id);
+  return c.json({
+    status: state.monitoring_status,
+    error: state.error,
+    prompts: monitoringPrompts.list(id),
+  });
+});
+
+businessRoutes.post("/business-profiles/:id/monitoring-prompts", async (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  const body = promptSchema.parse(await c.req.json());
+  return c.json(monitoringPrompts.add(id, body.prompt), 201);
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import "./app.css";
 import { CompetitivePage } from "./pages/competitive";
+import { MonitoringPage } from "./pages/monitoring";
 import type { BusinessProfile } from "./types";
 
 const API_BASE =
@@ -179,7 +180,9 @@ export function ProfileDashboard({
           </button>
         </header>
 
-        {activePage === "benchmarking" ? (
+        {activePage === "monitoring" ? (
+          <MonitoringPage profile={profile} />
+        ) : activePage === "benchmarking" ? (
           <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
         ) : (
           <article className="panel">

--- a/web/src/__tests__/app.test.tsx
+++ b/web/src/__tests__/app.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { App, OnboardingForm, ProfileDashboard } from "../App";
-import { MonitoringPage } from "../pages/monitoring";
+import { MonitoringPage, SentimentTrend } from "../pages/monitoring";
 
 describe("app onboarding", () => {
   test("renders business profile fields", () => {
@@ -52,5 +52,10 @@ describe("app onboarding", () => {
       />,
     );
     expect(html.includes("Generating starter prompts")).toBeTrue();
+  });
+
+  test("renders monitoring sentiment chart after load", () => {
+    const html = renderToStaticMarkup(<SentimentTrend />);
+    expect(html.includes("7 day sentiment trend")).toBeTrue();
   });
 });

--- a/web/src/__tests__/app.test.tsx
+++ b/web/src/__tests__/app.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { App, OnboardingForm, ProfileDashboard } from "../App";
+import { MonitoringPage } from "../pages/monitoring";
 
 describe("app onboarding", () => {
   test("renders business profile fields", () => {
@@ -36,5 +37,20 @@ describe("app onboarding", () => {
     );
     expect(html.includes("Benchmarking")).toBeTrue();
     expect(html.includes("Active business profile")).toBeTrue();
+  });
+
+  test("renders monitoring loading state", () => {
+    const html = renderToStaticMarkup(
+      <MonitoringPage
+        profile={{
+          id: "profile-1",
+          name: "Acme",
+          website: "https://acme.test",
+          description: "AI visibility software.",
+          createdAt: new Date().toISOString(),
+        }}
+      />,
+    );
+    expect(html.includes("Generating starter prompts")).toBeTrue();
   });
 });

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -119,6 +119,61 @@ button:disabled {
   max-width: 1040px;
 }
 
+.sentiment-card {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  background: #fbfbf8;
+  border: 1px solid #e0e0da;
+  border-radius: 8px;
+}
+
+.sentiment-card h3 {
+  margin: 0;
+}
+
+.sentiment-chart {
+  width: 100%;
+  max-height: 230px;
+}
+
+.neutral-line {
+  stroke: #9ca3af;
+  stroke-dasharray: 6 6;
+  stroke-width: 2;
+}
+
+.trend-line {
+  stroke-linecap: round;
+  stroke-width: 5;
+}
+
+.trend-positive {
+  stroke: #16a34a;
+}
+
+.trend-negative {
+  stroke: #dc2626;
+}
+
+.trend-dot {
+  stroke: white;
+  stroke-width: 2;
+}
+
+.trend-dot-positive {
+  fill: #16a34a;
+}
+
+.trend-dot-negative {
+  fill: #dc2626;
+}
+
+.chart-label {
+  fill: #66665f;
+  font-size: 12px;
+}
+
 .panel h2,
 .topbar h1 {
   margin: 0;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -136,7 +136,6 @@ button:disabled {
   display: block;
   width: 100%;
   height: auto;
-  max-height: 230px;
 }
 
 .neutral-line {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -133,7 +133,9 @@ button:disabled {
 }
 
 .sentiment-chart {
+  display: block;
   width: 100%;
+  height: auto;
   max-height: 230px;
 }
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -143,6 +143,11 @@ button:disabled {
   stroke-width: 2;
 }
 
+.grid-line {
+  stroke: #e5e7eb;
+  stroke-width: 1;
+}
+
 .trend-line {
   stroke-linecap: round;
   stroke-width: 5;
@@ -170,6 +175,11 @@ button:disabled {
 }
 
 .chart-label {
+  fill: #66665f;
+  font-size: 12px;
+}
+
+.axis-label {
   fill: #66665f;
   font-size: 12px;
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -115,6 +115,10 @@ button:disabled {
   border-radius: 8px;
 }
 
+.wide-panel {
+  max-width: 1040px;
+}
+
 .panel h2,
 .topbar h1 {
   margin: 0;
@@ -137,6 +141,59 @@ dt {
   text-transform: uppercase;
 }
 
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid #e4e4de;
+  vertical-align: top;
+}
+
+th {
+  color: #66665f;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.sentiment {
+  display: inline-block;
+  min-width: 76px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.sentiment-positive {
+  color: #14532d;
+  background: #dcfce7;
+}
+
+.sentiment-neutral {
+  color: #3f3f46;
+  background: #f4f4f5;
+}
+
+.sentiment-negative {
+  color: #7f1d1d;
+  background: #fee2e2;
+}
+
+.inline-form {
+  display: flex;
+  gap: 8px;
+}
+
+.inline-form input {
+  flex: 1;
+}
+
 .muted {
   color: #66665f;
 }
@@ -152,6 +209,10 @@ dt {
 
   .topbar {
     align-items: stretch;
+    flex-direction: column;
+  }
+
+  .inline-form {
     flex-direction: column;
   }
 }

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -8,6 +8,57 @@ function sentimentLabel(value: string) {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+const sentimentHistory = [-0.18, -0.08, 0.04, 0.12, 0.26, 0.18, -0.06].map((score, index) => ({
+  day: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][index]!,
+  score,
+}));
+
+export function SentimentTrend() {
+  const width = 700;
+  const height = 190;
+  const pad = 28;
+  const midY = height / 2;
+  const points = sentimentHistory.map((item, index) => {
+    const x = pad + (index * (width - pad * 2)) / (sentimentHistory.length - 1);
+    const y = midY - item.score * 130;
+    return { ...item, x, y };
+  });
+
+  return (
+    <section className="sentiment-card">
+      <div>
+        <p className="muted">Overall Sentiment</p>
+        <h3>Past 7 days</h3>
+      </div>
+      <svg className="sentiment-chart" viewBox={`0 0 ${width} ${height}`} role="img" aria-label="7 day sentiment trend">
+        <line className="neutral-line" x1={pad} x2={width - pad} y1={midY} y2={midY} />
+        {points.slice(0, -1).map((point, index) => {
+          const next = points[index + 1]!;
+          const positive = (point.score + next.score) / 2 >= 0;
+          return (
+            <line
+              key={point.day}
+              className={positive ? "trend-line trend-positive" : "trend-line trend-negative"}
+              x1={point.x}
+              x2={next.x}
+              y1={point.y}
+              y2={next.y}
+            />
+          );
+        })}
+        {points.map((point) => (
+          <g key={point.day}>
+            <circle className={point.score >= 0 ? "trend-dot trend-dot-positive" : "trend-dot trend-dot-negative"} cx={point.x} cy={point.y} r="5" />
+            <text className="chart-label" x={point.x} y={height - 4} textAnchor="middle">
+              {point.day}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </section>
+  );
+}
+
 export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
   const [data, setData] = useState<MonitoringResponse | null>(null);
   const [newPrompt, setNewPrompt] = useState("");
@@ -70,6 +121,7 @@ export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
       <p className="muted">Monitoring</p>
       <h2>{profile.name}</h2>
       <p>Track the prompts where this business should appear in chatbot answers.</p>
+      <SentimentTrend />
 
       <table>
         <thead>

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -8,19 +8,29 @@ function sentimentLabel(value: string) {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
-const sentimentHistory = [-0.18, -0.08, 0.04, 0.12, 0.26, 0.18, -0.06].map((score, index) => ({
-  day: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][index]!,
-  score,
-}));
+const sentimentHistory = [-0.18, -0.08, 0.04, 0.12, 0.26, 0.18, -0.06].map((score, index) => {
+  const date = new Date();
+  date.setDate(date.getDate() - (6 - index));
+  return {
+    date: date.toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+    score,
+  };
+});
+
+const yTicks = [-1, -0.5, 0, 0.5, 1];
 
 export function SentimentTrend() {
   const width = 700;
-  const height = 190;
-  const pad = 28;
-  const midY = height / 2;
+  const height = 220;
+  const padX = 48;
+  const padTop = 18;
+  const padBottom = 32;
+  const chartHeight = height - padTop - padBottom;
+  const yForScore = (score: number) => padTop + ((1 - score) / 2) * chartHeight;
+  const midY = yForScore(0);
   const points = sentimentHistory.map((item, index) => {
-    const x = pad + (index * (width - pad * 2)) / (sentimentHistory.length - 1);
-    const y = midY - item.score * 130;
+    const x = padX + (index * (width - padX * 2)) / (sentimentHistory.length - 1);
+    const y = yForScore(item.score);
     return { ...item, x, y };
   });
 
@@ -31,13 +41,23 @@ export function SentimentTrend() {
         <h3>Past 7 days</h3>
       </div>
       <svg className="sentiment-chart" viewBox={`0 0 ${width} ${height}`} role="img" aria-label="7 day sentiment trend">
-        <line className="neutral-line" x1={pad} x2={width - pad} y1={midY} y2={midY} />
+        {yTicks.map((tick) => {
+          const y = yForScore(tick);
+          return (
+            <g key={tick}>
+              <line className={tick === 0 ? "neutral-line" : "grid-line"} x1={padX} x2={width - padX} y1={y} y2={y} />
+              <text className="axis-label" x={padX - 12} y={y + 4} textAnchor="end">
+                {tick > 0 ? `+${tick}` : tick}
+              </text>
+            </g>
+          );
+        })}
         {points.slice(0, -1).map((point, index) => {
           const next = points[index + 1]!;
           const positive = (point.score + next.score) / 2 >= 0;
           return (
             <line
-              key={point.day}
+              key={point.date}
               className={positive ? "trend-line trend-positive" : "trend-line trend-negative"}
               x1={point.x}
               x2={next.x}
@@ -47,10 +67,10 @@ export function SentimentTrend() {
           );
         })}
         {points.map((point) => (
-          <g key={point.day}>
+          <g key={point.date}>
             <circle className={point.score >= 0 ? "trend-dot trend-dot-positive" : "trend-dot trend-dot-negative"} cx={point.x} cy={point.y} r="5" />
             <text className="chart-label" x={point.x} y={height - 4} textAnchor="middle">
-              {point.day}
+              {point.date}
             </text>
           </g>
         ))}

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -41,11 +41,21 @@ export function SentimentTrend() {
         <h3>Past 7 days</h3>
       </div>
       <svg className="sentiment-chart" viewBox={`0 0 ${width} ${height}`} role="img" aria-label="7 day sentiment trend">
+        {points.map((point) => (
+          <line
+            key={`grid-${point.date}`}
+            className="grid-line"
+            x1={point.x}
+            x2={point.x}
+            y1={padTop}
+            y2={height - padBottom}
+          />
+        ))}
         {yTicks.map((tick) => {
           const y = yForScore(tick);
           return (
             <g key={tick}>
-              <line className={tick === 0 ? "neutral-line" : "grid-line"} x1={padX} x2={width - padX} y1={y} y2={y} />
+              {tick === 0 && <line className="neutral-line" x1={padX} x2={width - padX} y1={y} y2={y} />}
               <text className="axis-label" x={padX - 12} y={y + 4} textAnchor="end">
                 {tick > 0 ? `+${tick}` : tick}
               </text>

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import type { BusinessProfile, MonitoringResponse } from "../types";
+
+const API_BASE =
+  import.meta.env.DEV === true ? "/api" : (import.meta.env.VITE_API_URL ?? "http://localhost:3000");
+
+function sentimentLabel(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
+  const [data, setData] = useState<MonitoringResponse | null>(null);
+  const [newPrompt, setNewPrompt] = useState("");
+  const [error, setError] = useState("");
+
+  async function load() {
+    const res = await fetch(`${API_BASE}/business-profiles/${profile.id}/monitoring`);
+    if (!res.ok) {
+      throw new Error("Could not load monitoring prompts.");
+    }
+    setData(await res.json());
+  }
+
+  useEffect(() => {
+    setData(null);
+    setError("");
+    load().catch((err) => setError(err instanceof Error ? err.message : "Could not load monitoring prompts."));
+  }, [profile.id]);
+
+  useEffect(() => {
+    if (data?.status !== "generating") {
+      return;
+    }
+    const id = setInterval(() => {
+      load().catch(() => undefined);
+    }, 2000);
+    return () => clearInterval(id);
+  }, [data?.status, profile.id]);
+
+  async function addPrompt() {
+    const prompt = newPrompt.trim();
+    if (!prompt) {
+      return;
+    }
+    const res = await fetch(`${API_BASE}/business-profiles/${profile.id}/monitoring-prompts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt }),
+    });
+    if (!res.ok) {
+      setError("Could not add prompt.");
+      return;
+    }
+    setNewPrompt("");
+    await load();
+  }
+
+  if (!data || (data.status === "generating" && data.prompts.length === 0)) {
+    return (
+      <article className="panel">
+        <p className="muted">Monitoring</p>
+        <h2>Generating starter prompts...</h2>
+        <p>Perception is creating chatbot queries for {profile.name} from the website and business description.</p>
+      </article>
+    );
+  }
+
+  return (
+    <article className="panel wide-panel">
+      <p className="muted">Monitoring</p>
+      <h2>{profile.name}</h2>
+      <p>Track the prompts where this business should appear in chatbot answers.</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Prompt</th>
+            <th>Mention</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.prompts.map((item) => (
+            <tr key={item.id}>
+              <td>{item.prompt}</td>
+              <td>
+                <span className={`sentiment sentiment-${item.mentionSentiment}`}>
+                  {sentimentLabel(item.mentionSentiment)}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="inline-form">
+        <input
+          placeholder="Add a prompt to monitor"
+          value={newPrompt}
+          onChange={(event) => setNewPrompt(event.target.value)}
+        />
+        <button type="button" onClick={addPrompt} disabled={!newPrompt.trim()}>
+          Add prompt
+        </button>
+      </div>
+
+      {data.status === "error" && <p className="error">{data.error ?? "Prompt generation fell back to sample data."}</p>}
+      {error && <p className="error">{error}</p>}
+    </article>
+  );
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -6,6 +6,20 @@ export interface BusinessProfile {
   createdAt: string;
 }
 
+export interface MonitoringPrompt {
+  id: string;
+  businessProfileId: string;
+  prompt: string;
+  mentionSentiment: "positive" | "negative" | "neutral";
+  createdAt: string;
+}
+
+export interface MonitoringResponse {
+  status: "generating" | "ready" | "error";
+  error: string | null;
+  prompts: MonitoringPrompt[];
+}
+
 export interface OverviewRow {
   brandId: string;
   shareOfVoice: number;


### PR DESCRIPTION
## Summary
- add a central LLM provider abstraction
- support OpenAI and mock providers under one call shape
- route existing benchmark LLM calls through the abstraction
- add structured response support
- add provider tests

## Test plan
- bun run test
- bun run build:web

Closes #18