### PR TITLE
Add dashboard shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:web": "bun run --cwd web build",
     "demo": "echo 'Run: bun install && bun run dev  →  open http://localhost:5173  →  click Run Sephora demo benchmark'",
     "test:server": "bun test --cwd server src/features/competitive/__tests__/pipeline.test.ts src/features/competitive/__tests__/benchmark.service.test.ts src/features/competitive/__tests__/gap-analysis.service.test.ts src/routes/business.test.ts src/routes/competitive.test.ts",
-    "test:web": "bun test --cwd web src/components/competitive/__tests__/components.test.tsx",
+    "test:web": "bun test --cwd web src/__tests__/app.test.tsx src/components/competitive/__tests__/components.test.tsx",
     "test": "bun run test:server && bun run test:web"
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Perception Competitive Benchmarking</title>
+    <title>Perception</title>
   </head>
   <body>
     <div id="root">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import "./app.css";
+import { CompetitivePage } from "./pages/competitive";
+import { MonitoringPage } from "./pages/monitoring";
+import { RecommendationsPage } from "./pages/recommendations";
+import { SourcesPage } from "./pages/sources";
+
+const navItems = [
+  { key: "monitoring", label: "Monitoring" },
+  { key: "benchmarking", label: "Benchmarking" },
+  { key: "recommendations", label: "Recommendations" },
+  { key: "sources", label: "Sources" },
+] as const;
+
+type PageKey = (typeof navItems)[number]["key"];
+
+function renderPage(page: PageKey) {
+  switch (page) {
+    case "monitoring":
+      return <MonitoringPage />;
+    case "benchmarking":
+      return <CompetitivePage />;
+    case "recommendations":
+      return <RecommendationsPage />;
+    case "sources":
+      return <SourcesPage />;
+  }
+}
+
+export function App() {
+  const [activePage, setActivePage] = useState<PageKey>("benchmarking");
+
+  return (
+    <main className="app-shell">
+      <aside className="sidebar" aria-label="Primary navigation">
+        <div className="brand-lockup">
+          <span className="brand-mark">P</span>
+          <div>
+            <strong>Perception</strong>
+            <span>AI visibility</span>
+          </div>
+        </div>
+
+        <nav className="nav-list">
+          {navItems.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              className={activePage === item.key ? "nav-item active" : "nav-item"}
+              onClick={() => setActivePage(item.key)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+      </aside>
+
+      <section className="workspace">{renderPage(activePage)}</section>
+    </main>
+  );
+}

--- a/web/src/__tests__/app.test.tsx
+++ b/web/src/__tests__/app.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { App } from "../App";
+import { MonitoringPage } from "../pages/monitoring";
+import { RecommendationsPage } from "../pages/recommendations";
+import { SourcesPage } from "../pages/sources";
+
+describe("dashboard shell", () => {
+  test("renders the main navigation", () => {
+    const html = renderToStaticMarkup(<App />);
+    expect(html.includes("Perception")).toBeTrue();
+    expect(html.includes("Monitoring")).toBeTrue();
+    expect(html.includes("Benchmarking")).toBeTrue();
+    expect(html.includes("Recommendations")).toBeTrue();
+    expect(html.includes("Sources")).toBeTrue();
+  });
+
+  test("renders placeholder pages", () => {
+    expect(renderToStaticMarkup(<MonitoringPage />).includes("Prompt monitoring")).toBeTrue();
+    expect(renderToStaticMarkup(<RecommendationsPage />).includes("Fix-it recommendations")).toBeTrue();
+    expect(renderToStaticMarkup(<SourcesPage />).includes("Source tracking")).toBeTrue();
+  });
+});

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,6 +1,13 @@
 :root {
   color: #172033;
   background: #ffffff;
+  --color-text: #172033;
+  --color-muted: #526071;
+  --color-line: #d8ebff;
+  --color-surface: #ffffff;
+  --color-soft: #f5fbff;
+  --color-blue: #bfe4ff;
+  --shadow-soft: 0 12px 32px rgba(23, 32, 51, 0.08);
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -32,8 +39,8 @@ input {
   display: flex;
   flex-direction: column;
   gap: 28px;
-  border-right: 1px solid #d8ebff;
-  background: #f5fbff;
+  border-right: 1px solid var(--color-line);
+  background: var(--color-soft);
   padding: 24px;
 }
 
@@ -63,8 +70,8 @@ input {
   height: 36px;
   place-items: center;
   border-radius: 8px;
-  background: #bfe4ff;
-  color: #172033;
+  background: var(--color-blue);
+  color: var(--color-text);
   font-weight: 700;
 }
 
@@ -78,7 +85,7 @@ input {
   border: 0;
   border-radius: 8px;
   background: transparent;
-  color: #526071;
+  color: var(--color-muted);
   cursor: pointer;
   padding: 10px 12px;
   text-align: left;
@@ -86,8 +93,8 @@ input {
 
 .nav-item:hover,
 .nav-item.active {
-  background: #d8ebff;
-  color: #172033;
+  background: var(--color-line);
+  color: var(--color-text);
 }
 
 .workspace {
@@ -105,7 +112,7 @@ input {
 
 .page-header p {
   max-width: 780px;
-  color: #526071;
+  color: var(--color-muted);
   line-height: 1.5;
   margin: 8px 0 0;
 }
@@ -117,9 +124,9 @@ input {
 }
 
 .placeholder-panel {
-  border: 1px solid #d8ebff;
+  border: 1px solid var(--color-line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--color-surface);
   padding: 20px;
 }
 
@@ -128,7 +135,7 @@ input {
 }
 
 .placeholder-panel p {
-  color: #526071;
+  color: var(--color-muted);
   line-height: 1.5;
   margin: 0;
 }
@@ -140,7 +147,7 @@ input {
 
   .sidebar {
     border-right: 0;
-    border-bottom: 1px solid #d8ebff;
+    border-bottom: 1px solid var(--color-line);
   }
 
   .nav-list {
@@ -149,5 +156,182 @@ input {
 
   .workspace {
     padding: 20px;
+  }
+}
+
+.panel {
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  padding: 18px;
+}
+
+.panel + .panel,
+.panel-grid + .panel,
+.run-panel + .panel {
+  margin-top: 16px;
+}
+
+.panel h3,
+.panel h4 {
+  margin: 0 0 12px;
+}
+
+.panel h4 {
+  font-size: 14px;
+}
+
+.panel p {
+  color: var(--color-muted);
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.form-grid label {
+  display: grid;
+  gap: 6px;
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.text-input {
+  width: 100%;
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: 10px 12px;
+}
+
+.text-input:focus {
+  border-color: var(--color-blue);
+  outline: 2px solid var(--color-blue);
+  outline-offset: 1px;
+}
+
+.primary-button {
+  width: fit-content;
+  border: 1px solid var(--color-blue);
+  border-radius: 8px;
+  background: var(--color-blue);
+  color: var(--color-text);
+  cursor: pointer;
+  font-weight: 700;
+  padding: 10px 14px;
+}
+
+.primary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.muted {
+  color: var(--color-muted);
+}
+
+.error-text {
+  color: #9f1d32;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  border-bottom: 1px solid var(--color-line);
+  padding: 10px 0;
+}
+
+.data-table th {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.metric-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(140px, 1.4fr) 56px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+}
+
+.metric-row + .metric-row {
+  border-top: 1px solid var(--color-line);
+}
+
+.metric-track {
+  height: 9px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--color-line);
+}
+
+.metric-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-blue);
+}
+
+.run-panel {
+  margin-bottom: 16px;
+}
+
+.run-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.stream-box {
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-soft);
+  padding: 12px;
+}
+
+.stream-output {
+  margin: 0;
+  white-space: pre-wrap;
+  color: var(--color-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.raw-output {
+  overflow-x: auto;
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.gap-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.gap-list li + li {
+  margin-top: 8px;
+}
+
+@media (max-width: 980px) {
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-row {
+    grid-template-columns: 1fr;
   }
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,0 +1,153 @@
+:root {
+  color: #172033;
+  background: #ffffff;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background: #ffffff;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 248px minmax(0, 1fr);
+  min-height: 100vh;
+  background: #ffffff;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  border-right: 1px solid #d8ebff;
+  background: #f5fbff;
+  padding: 24px;
+}
+
+.brand-lockup {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-lockup strong,
+.brand-lockup span {
+  display: block;
+}
+
+.brand-lockup strong {
+  font-size: 18px;
+}
+
+.brand-lockup span {
+  color: #526071;
+  font-size: 13px;
+}
+
+.brand-mark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 8px;
+  background: #bfe4ff;
+  color: #172033;
+  font-weight: 700;
+}
+
+.nav-list {
+  display: grid;
+  gap: 8px;
+}
+
+.nav-item {
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #526071;
+  cursor: pointer;
+  padding: 10px 12px;
+  text-align: left;
+}
+
+.nav-item:hover,
+.nav-item.active {
+  background: #d8ebff;
+  color: #172033;
+}
+
+.workspace {
+  min-width: 0;
+  padding: 28px;
+}
+
+.page-frame {
+  max-width: 1120px;
+}
+
+.page-header {
+  margin-bottom: 20px;
+}
+
+.page-header p {
+  max-width: 780px;
+  color: #526071;
+  line-height: 1.5;
+  margin: 8px 0 0;
+}
+
+.page-header h1 {
+  font-size: 30px;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.placeholder-panel {
+  border: 1px solid #d8ebff;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 20px;
+}
+
+.placeholder-panel h2 {
+  margin: 0 0 8px;
+}
+
+.placeholder-panel p {
+  color: #526071;
+  line-height: 1.5;
+  margin: 0;
+}
+
+@media (max-width: 820px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: 0;
+    border-bottom: 1px solid #d8ebff;
+  }
+
+  .nav-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .workspace {
+    padding: 20px;
+  }
+}

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -18,31 +18,33 @@ export function CompetitiveSetPicker({ onCreate, busy }: Props) {
   }, [accountBrandName, competitorNames]);
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16, marginBottom: 20 }}>
-      <h3 style={{ marginTop: 0 }}>Competitive Set — Demo (5 competitors)</h3>
-      <label style={{ display: "block", marginBottom: 8 }}>
+    <section className="panel">
+      <h3>Competitive Set</h3>
+      <div className="form-grid">
+      <label>
         Your brand
         <input
+          className="text-input"
           value={accountBrandName}
           onChange={(e) => setAccountBrandName(e.target.value)}
-          style={{ width: "100%", marginTop: 4 }}
         />
       </label>
       {competitorNames.map((name, idx) => (
-        <label key={idx} style={{ display: "block", marginBottom: 8 }}>
+        <label key={idx}>
           Competitor {idx + 1}
           <input
+            className="text-input"
             value={name}
             onChange={(e) => {
               const next = [...competitorNames];
               next[idx] = e.target.value;
               setCompetitorNames(next);
             }}
-            style={{ width: "100%", marginTop: 4 }}
           />
         </label>
       ))}
       <button
+        className="primary-button"
         type="button"
         onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
         disabled={!canSubmit || busy}
@@ -50,11 +52,12 @@ export function CompetitiveSetPicker({ onCreate, busy }: Props) {
         {busy ? "Running 20-question benchmark..." : "Run benchmark"}
       </button>
       {busy && (
-        <p style={{ marginBottom: 0, color: "#555" }}>
+        <p className="muted">
           Generating brand-perception summaries and comparisons. This can take a bit while the server fans out the LLM
           calls.
         </p>
       )}
+      </div>
     </section>
   );
 }

--- a/web/src/components/competitive/FeatureGapTable.tsx
+++ b/web/src/components/competitive/FeatureGapTable.tsx
@@ -12,9 +12,9 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
   const label = (id: string) => brandLabels?.[id] ?? id;
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Feature Strengths & Weaknesses</h3>
-      <table width="100%" style={{ marginBottom: 16 }}>
+    <section className="panel">
+      <h3>Feature Strengths & Weaknesses</h3>
+      <table className="data-table">
         <thead>
           <tr>
             <th align="left">Brand</th>
@@ -34,7 +34,7 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
       {praiseGaps.length === 0 ? (
         <p>No feature praise gaps detected.</p>
       ) : (
-        <ul>
+        <ul className="gap-list">
           {praiseGaps.map((gap) => (
             <li key={gap.id}>
               {gap.competitorBrandId ? label(gap.competitorBrandId) : "Competitor"} praised on &quot;

--- a/web/src/components/competitive/SentimentComparison.tsx
+++ b/web/src/components/competitive/SentimentComparison.tsx
@@ -9,24 +9,20 @@ export function SentimentComparison({
 }) {
   const label = (id: string) => brandLabels?.[id] ?? id;
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Sentiment Comparison</h3>
-      <table width="100%">
-        <thead>
-          <tr>
-            <th align="left">Brand</th>
-            <th align="right">Sentiment</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td align="right">{row.sentiment.toFixed(2)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <section className="panel">
+      <h3>Sentiment Comparison</h3>
+      {rows.map((row) => {
+        const score = ((row.sentiment + 1) / 2) * 100;
+        return (
+          <div className="metric-row" key={row.brandId}>
+            <strong>{label(row.brandId)}</strong>
+            <div className="metric-track" aria-hidden="true">
+              <div className="metric-fill" style={{ width: `${Math.max(score, 4)}%` }} />
+            </div>
+            <span>{row.sentiment.toFixed(2)}</span>
+          </div>
+        );
+      })}
     </section>
   );
 }

--- a/web/src/components/competitive/ShareOfVoiceChart.tsx
+++ b/web/src/components/competitive/ShareOfVoiceChart.tsx
@@ -9,24 +9,17 @@ export function ShareOfVoiceChart({
 }) {
   const label = (id: string) => brandLabels?.[id] ?? id;
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Share of Voice</h3>
-      <table width="100%">
-        <thead>
-          <tr>
-            <th align="left">Brand</th>
-            <th align="right">SOV</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td align="right">{(row.shareOfVoice * 100).toFixed(1)}%</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <section className="panel">
+      <h3>Share of Voice</h3>
+      {rows.map((row) => (
+        <div className="metric-row" key={row.brandId}>
+          <strong>{label(row.brandId)}</strong>
+          <div className="metric-track" aria-hidden="true">
+            <div className="metric-fill" style={{ width: `${Math.max(row.shareOfVoice * 100, 4)}%` }} />
+          </div>
+          <span>{(row.shareOfVoice * 100).toFixed(1)}%</span>
+        </div>
+      ))}
     </section>
   );
 }

--- a/web/src/components/competitive/WhitespacePanel.tsx
+++ b/web/src/components/competitive/WhitespacePanel.tsx
@@ -5,8 +5,8 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
   const exclusion = gaps.filter((gap) => gap.gapType === "prompt_exclusion");
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Gap Analysis Highlights</h3>
+    <section className="panel">
+      <h3>Gap Analysis Highlights</h3>
       <p>
         Prompt Exclusion Gaps: <strong>{exclusion.length}</strong>
       </p>
@@ -14,7 +14,7 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
         Whitespace Opportunities: <strong>{whitespace.length}</strong>
       </p>
       {whitespace.length > 0 && (
-        <ul>
+        <ul className="gap-list">
           {whitespace.map((gap) => (
             <li key={gap.id}>
               Prompt run {gap.promptRunId} has no recommended brand; category {gap.categoryKey ?? "general"}.

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { CompetitivePage } from "./pages/competitive";
+import { App } from "./App";
 
 const root = document.getElementById("root");
 if (!root) {
@@ -9,6 +9,6 @@ if (!root) {
 
 createRoot(root).render(
   <React.StrictMode>
-    <CompetitivePage />
+    <App />
   </React.StrictMode>,
 );

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -244,15 +244,14 @@ export function CompetitivePage() {
   }
 
   return (
-    <main style={{ maxWidth: 1100, margin: "0 auto", padding: 24, fontFamily: "Inter, Arial, sans-serif" }}>
-      <h1>Competitive Benchmarking — Demo</h1>
-      <p style={{ marginTop: 0 }}>
-        Each run uses <strong>10 brand-specific prompts</strong> (with each retailer’s name) plus{" "}
-        <strong>10 category-wide prompts</strong> (leader, best, most reliable, etc.), all answered per retailer;
-        outputs are compared and rolled into share of voice and sentiment. Default slate:{" "}
-        <strong>Sephora</strong> vs <strong>Ulta</strong>, <strong>Bluemercury</strong>, <strong>SpaceNK</strong>,{" "}
-        <strong>SallyBeauty</strong>, and <strong>Olive Young</strong>.
-      </p>
+    <section className="page-frame">
+      <header className="page-header">
+        <h1>Competitive Benchmarking</h1>
+        <p>
+          Compare how AI answers describe your brand against five competitors, then surface share of voice, sentiment,
+          feature gaps, and whitespace opportunities.
+        </p>
+      </header>
 
       <CompetitiveSetPicker onCreate={createSet} busy={busy} />
       {error && <p style={{ color: "crimson" }}>{error}</p>}
@@ -339,6 +338,6 @@ export function CompetitivePage() {
             : "Run the benchmark to set the query window"}
         </p>
       </section>
-    </main>
+    </section>
   );
 }

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -254,31 +254,24 @@ export function CompetitivePage() {
       </header>
 
       <CompetitiveSetPicker onCreate={createSet} busy={busy} />
-      {error && <p style={{ color: "crimson" }}>{error}</p>}
+      {error && <p className="error-text">{error}</p>}
 
       {(Object.keys(progressByBrand).length > 0 || judgeLines.length > 0 || busy) && (
-        <section style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-          <h3 style={{ marginTop: 0 }}>Live Run Stream</h3>
-          <p style={{ marginTop: 0 }}>{progressStatus}</p>
+        <section className="panel run-panel">
+          <h3>Live Run Stream</h3>
+          <p>{progressStatus}</p>
           {judgeLines.length > 0 && (
-            <div style={{ marginBottom: 12, padding: 12, borderRadius: 6, background: "#fafafa" }}>
+            <div className="stream-box">
               <strong>Judge</strong>
-              <pre style={{ margin: "8px 0 0", whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                {judgeLines.join("\n")}
-              </pre>
+              <pre className="stream-output">{judgeLines.join("\n")}</pre>
             </div>
           )}
-          <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 12 }}>
+          <section className="run-grid">
             {Object.entries(progressByBrand).map(([brandId, box]) => (
-              <article
-                key={brandId}
-                style={{ border: "1px solid #ddd", borderRadius: 8, padding: 12, background: "#fff" }}
-              >
-                <h4 style={{ margin: "0 0 8px" }}>{box.brandName}</h4>
-                <p style={{ margin: "0 0 8px", color: "#555" }}>{box.status}</p>
-                <pre style={{ margin: 0, whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                  {box.lines.length ? box.lines.join("\n") : "Waiting for streamed output..."}
-                </pre>
+              <article key={brandId} className="stream-box">
+                <h4>{box.brandName}</h4>
+                <p>{box.status}</p>
+                <pre className="stream-output">{box.lines.length ? box.lines.join("\n") : "Waiting for streamed output..."}</pre>
               </article>
             ))}
           </section>
@@ -287,7 +280,7 @@ export function CompetitivePage() {
 
       {overview && (
         <>
-          <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginBottom: 16 }}>
+          <section className="panel-grid">
             <ShareOfVoiceChart rows={overview.rows} brandLabels={brandLabels} />
             <SentimentComparison rows={overview.rows} brandLabels={brandLabels} />
           </section>
@@ -297,18 +290,18 @@ export function CompetitivePage() {
             brandLabels={brandLabels}
             accountBrandName={accountBrandName}
           />
-          <section style={{ marginTop: 16 }}>
+          <section>
             <WhitespacePanel gaps={gaps} />
           </section>
         </>
       )}
 
-      <section style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Trend Snapshot (7 days)</h3>
+      <section className="panel">
+        <h3>Trend Snapshot (7 days)</h3>
         {!trends ? (
           <p>No trend data yet.</p>
         ) : (
-          <pre style={{ overflowX: "auto", margin: 0 }}>
+          <pre className="raw-output">
             {JSON.stringify(
               Object.fromEntries(
                 Object.entries(trends.seriesByBrand).map(([id, pts]) => [brandLabels[id] ?? id, pts]),
@@ -320,8 +313,8 @@ export function CompetitivePage() {
         )}
       </section>
 
-      <section style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Run Configuration</h3>
+      <section className="panel">
+        <h3>Run Configuration</h3>
         <p>
           Account: {accountBrandName} ({accountBrandId || "run to assign IDs"})
         </p>

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -1,0 +1,17 @@
+export function MonitoringPage() {
+  return (
+    <section className="page-frame">
+      <header className="page-header">
+        <h1>Monitoring</h1>
+        <p>Track the prompts where your brand should appear across AI-generated answers.</p>
+      </header>
+      <article className="placeholder-panel">
+        <h2>Prompt monitoring will live here</h2>
+        <p>
+          This page is ready for the MVP monitoring flow: saved prompts, latest answer status, sentiment, and mention
+          history.
+        </p>
+      </article>
+    </section>
+  );
+}

--- a/web/src/pages/recommendations.tsx
+++ b/web/src/pages/recommendations.tsx
@@ -1,0 +1,16 @@
+export function RecommendationsPage() {
+  return (
+    <section className="page-frame">
+      <header className="page-header">
+        <h1>Recommendations</h1>
+        <p>Turn detected gaps into concrete actions your marketing and content teams can take.</p>
+      </header>
+      <article className="placeholder-panel">
+        <h2>Fix-it recommendations will live here</h2>
+        <p>
+          This page is ready for prioritized actions, expected impact, owners, and before-and-after tracking.
+        </p>
+      </article>
+    </section>
+  );
+}

--- a/web/src/pages/sources.tsx
+++ b/web/src/pages/sources.tsx
@@ -1,0 +1,14 @@
+export function SourcesPage() {
+  return (
+    <section className="page-frame">
+      <header className="page-header">
+        <h1>Sources</h1>
+        <p>See which pages, reviews, communities, and publications influence AI answers about your market.</p>
+      </header>
+      <article className="placeholder-panel">
+        <h2>Source tracking will live here</h2>
+        <p>This page is ready for cited sources, competitor source wins, and earned-media opportunities.</p>
+      </article>
+    </section>
+  );
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(({ mode }) => {
       // and the tab keeps loading. Disabling HMR fixes that (refresh the page after edits).
       hmr: false,
       warmup: {
-        clientFiles: ["./index.html", "./src/main.tsx", "./src/pages/competitive.tsx"],
+        clientFiles: ["./index.html", "./src/main.tsx", "./src/App.tsx", "./src/pages/competitive.tsx"],
       },
       proxy: {
         "/api": {


### PR DESCRIPTION
## Summary
- add a real Perception app shell with sidebar navigation
- split Monitoring, Benchmarking, Recommendations, and Sources into page modules
- mount the existing competitive benchmark inside the dashboard workspace
- add shell render tests

## Test plan
- bun run test
- bun run build:web

Note: Vite prints a local Node version warning, but the build completes successfully.