### PR TITLE
Polish benchmarking dashboard UI

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,6 +1,13 @@
 :root {
   color: #172033;
   background: #ffffff;
+  --color-text: #172033;
+  --color-muted: #526071;
+  --color-line: #d8ebff;
+  --color-surface: #ffffff;
+  --color-soft: #f5fbff;
+  --color-blue: #bfe4ff;
+  --shadow-soft: 0 12px 32px rgba(23, 32, 51, 0.08);
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -32,8 +39,8 @@ input {
   display: flex;
   flex-direction: column;
   gap: 28px;
-  border-right: 1px solid #d8ebff;
-  background: #f5fbff;
+  border-right: 1px solid var(--color-line);
+  background: var(--color-soft);
   padding: 24px;
 }
 
@@ -63,8 +70,8 @@ input {
   height: 36px;
   place-items: center;
   border-radius: 8px;
-  background: #bfe4ff;
-  color: #172033;
+  background: var(--color-blue);
+  color: var(--color-text);
   font-weight: 700;
 }
 
@@ -78,7 +85,7 @@ input {
   border: 0;
   border-radius: 8px;
   background: transparent;
-  color: #526071;
+  color: var(--color-muted);
   cursor: pointer;
   padding: 10px 12px;
   text-align: left;
@@ -86,8 +93,8 @@ input {
 
 .nav-item:hover,
 .nav-item.active {
-  background: #d8ebff;
-  color: #172033;
+  background: var(--color-line);
+  color: var(--color-text);
 }
 
 .workspace {
@@ -105,7 +112,7 @@ input {
 
 .page-header p {
   max-width: 780px;
-  color: #526071;
+  color: var(--color-muted);
   line-height: 1.5;
   margin: 8px 0 0;
 }
@@ -117,9 +124,9 @@ input {
 }
 
 .placeholder-panel {
-  border: 1px solid #d8ebff;
+  border: 1px solid var(--color-line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--color-surface);
   padding: 20px;
 }
 
@@ -128,7 +135,7 @@ input {
 }
 
 .placeholder-panel p {
-  color: #526071;
+  color: var(--color-muted);
   line-height: 1.5;
   margin: 0;
 }
@@ -140,7 +147,7 @@ input {
 
   .sidebar {
     border-right: 0;
-    border-bottom: 1px solid #d8ebff;
+    border-bottom: 1px solid var(--color-line);
   }
 
   .nav-list {
@@ -149,5 +156,182 @@ input {
 
   .workspace {
     padding: 20px;
+  }
+}
+
+.panel {
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  padding: 18px;
+}
+
+.panel + .panel,
+.panel-grid + .panel,
+.run-panel + .panel {
+  margin-top: 16px;
+}
+
+.panel h3,
+.panel h4 {
+  margin: 0 0 12px;
+}
+
+.panel h4 {
+  font-size: 14px;
+}
+
+.panel p {
+  color: var(--color-muted);
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.form-grid label {
+  display: grid;
+  gap: 6px;
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.text-input {
+  width: 100%;
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: 10px 12px;
+}
+
+.text-input:focus {
+  border-color: var(--color-blue);
+  outline: 2px solid var(--color-blue);
+  outline-offset: 1px;
+}
+
+.primary-button {
+  width: fit-content;
+  border: 1px solid var(--color-blue);
+  border-radius: 8px;
+  background: var(--color-blue);
+  color: var(--color-text);
+  cursor: pointer;
+  font-weight: 700;
+  padding: 10px 14px;
+}
+
+.primary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.muted {
+  color: var(--color-muted);
+}
+
+.error-text {
+  color: #9f1d32;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  border-bottom: 1px solid var(--color-line);
+  padding: 10px 0;
+}
+
+.data-table th {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.metric-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(140px, 1.4fr) 56px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+}
+
+.metric-row + .metric-row {
+  border-top: 1px solid var(--color-line);
+}
+
+.metric-track {
+  height: 9px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--color-line);
+}
+
+.metric-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-blue);
+}
+
+.run-panel {
+  margin-bottom: 16px;
+}
+
+.run-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.stream-box {
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-soft);
+  padding: 12px;
+}
+
+.stream-output {
+  margin: 0;
+  white-space: pre-wrap;
+  color: var(--color-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.raw-output {
+  overflow-x: auto;
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.gap-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.gap-list li + li {
+  margin-top: 8px;
+}
+
+@media (max-width: 980px) {
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-row {
+    grid-template-columns: 1fr;
   }
 }

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -18,31 +18,33 @@ export function CompetitiveSetPicker({ onCreate, busy }: Props) {
   }, [accountBrandName, competitorNames]);
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16, marginBottom: 20 }}>
-      <h3 style={{ marginTop: 0 }}>Competitive Set — Demo (5 competitors)</h3>
-      <label style={{ display: "block", marginBottom: 8 }}>
+    <section className="panel">
+      <h3>Competitive Set</h3>
+      <div className="form-grid">
+      <label>
         Your brand
         <input
+          className="text-input"
           value={accountBrandName}
           onChange={(e) => setAccountBrandName(e.target.value)}
-          style={{ width: "100%", marginTop: 4 }}
         />
       </label>
       {competitorNames.map((name, idx) => (
-        <label key={idx} style={{ display: "block", marginBottom: 8 }}>
+        <label key={idx}>
           Competitor {idx + 1}
           <input
+            className="text-input"
             value={name}
             onChange={(e) => {
               const next = [...competitorNames];
               next[idx] = e.target.value;
               setCompetitorNames(next);
             }}
-            style={{ width: "100%", marginTop: 4 }}
           />
         </label>
       ))}
       <button
+        className="primary-button"
         type="button"
         onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
         disabled={!canSubmit || busy}
@@ -50,11 +52,12 @@ export function CompetitiveSetPicker({ onCreate, busy }: Props) {
         {busy ? "Running 20-question benchmark..." : "Run benchmark"}
       </button>
       {busy && (
-        <p style={{ marginBottom: 0, color: "#555" }}>
+        <p className="muted">
           Generating brand-perception summaries and comparisons. This can take a bit while the server fans out the LLM
           calls.
         </p>
       )}
+      </div>
     </section>
   );
 }

--- a/web/src/components/competitive/FeatureGapTable.tsx
+++ b/web/src/components/competitive/FeatureGapTable.tsx
@@ -12,9 +12,9 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
   const label = (id: string) => brandLabels?.[id] ?? id;
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Feature Strengths & Weaknesses</h3>
-      <table width="100%" style={{ marginBottom: 16 }}>
+    <section className="panel">
+      <h3>Feature Strengths & Weaknesses</h3>
+      <table className="data-table">
         <thead>
           <tr>
             <th align="left">Brand</th>
@@ -34,7 +34,7 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
       {praiseGaps.length === 0 ? (
         <p>No feature praise gaps detected.</p>
       ) : (
-        <ul>
+        <ul className="gap-list">
           {praiseGaps.map((gap) => (
             <li key={gap.id}>
               {gap.competitorBrandId ? label(gap.competitorBrandId) : "Competitor"} praised on &quot;

--- a/web/src/components/competitive/SentimentComparison.tsx
+++ b/web/src/components/competitive/SentimentComparison.tsx
@@ -9,24 +9,20 @@ export function SentimentComparison({
 }) {
   const label = (id: string) => brandLabels?.[id] ?? id;
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Sentiment Comparison</h3>
-      <table width="100%">
-        <thead>
-          <tr>
-            <th align="left">Brand</th>
-            <th align="right">Sentiment</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td align="right">{row.sentiment.toFixed(2)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <section className="panel">
+      <h3>Sentiment Comparison</h3>
+      {rows.map((row) => {
+        const score = ((row.sentiment + 1) / 2) * 100;
+        return (
+          <div className="metric-row" key={row.brandId}>
+            <strong>{label(row.brandId)}</strong>
+            <div className="metric-track" aria-hidden="true">
+              <div className="metric-fill" style={{ width: `${Math.max(score, 4)}%` }} />
+            </div>
+            <span>{row.sentiment.toFixed(2)}</span>
+          </div>
+        );
+      })}
     </section>
   );
 }

--- a/web/src/components/competitive/ShareOfVoiceChart.tsx
+++ b/web/src/components/competitive/ShareOfVoiceChart.tsx
@@ -9,24 +9,17 @@ export function ShareOfVoiceChart({
 }) {
   const label = (id: string) => brandLabels?.[id] ?? id;
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Share of Voice</h3>
-      <table width="100%">
-        <thead>
-          <tr>
-            <th align="left">Brand</th>
-            <th align="right">SOV</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td align="right">{(row.shareOfVoice * 100).toFixed(1)}%</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <section className="panel">
+      <h3>Share of Voice</h3>
+      {rows.map((row) => (
+        <div className="metric-row" key={row.brandId}>
+          <strong>{label(row.brandId)}</strong>
+          <div className="metric-track" aria-hidden="true">
+            <div className="metric-fill" style={{ width: `${Math.max(row.shareOfVoice * 100, 4)}%` }} />
+          </div>
+          <span>{(row.shareOfVoice * 100).toFixed(1)}%</span>
+        </div>
+      ))}
     </section>
   );
 }

--- a/web/src/components/competitive/WhitespacePanel.tsx
+++ b/web/src/components/competitive/WhitespacePanel.tsx
@@ -5,8 +5,8 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
   const exclusion = gaps.filter((gap) => gap.gapType === "prompt_exclusion");
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Gap Analysis Highlights</h3>
+    <section className="panel">
+      <h3>Gap Analysis Highlights</h3>
       <p>
         Prompt Exclusion Gaps: <strong>{exclusion.length}</strong>
       </p>
@@ -14,7 +14,7 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
         Whitespace Opportunities: <strong>{whitespace.length}</strong>
       </p>
       {whitespace.length > 0 && (
-        <ul>
+        <ul className="gap-list">
           {whitespace.map((gap) => (
             <li key={gap.id}>
               Prompt run {gap.promptRunId} has no recommended brand; category {gap.categoryKey ?? "general"}.

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -254,31 +254,24 @@ export function CompetitivePage() {
       </header>
 
       <CompetitiveSetPicker onCreate={createSet} busy={busy} />
-      {error && <p style={{ color: "crimson" }}>{error}</p>}
+      {error && <p className="error-text">{error}</p>}
 
       {(Object.keys(progressByBrand).length > 0 || judgeLines.length > 0 || busy) && (
-        <section style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-          <h3 style={{ marginTop: 0 }}>Live Run Stream</h3>
-          <p style={{ marginTop: 0 }}>{progressStatus}</p>
+        <section className="panel run-panel">
+          <h3>Live Run Stream</h3>
+          <p>{progressStatus}</p>
           {judgeLines.length > 0 && (
-            <div style={{ marginBottom: 12, padding: 12, borderRadius: 6, background: "#fafafa" }}>
+            <div className="stream-box">
               <strong>Judge</strong>
-              <pre style={{ margin: "8px 0 0", whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                {judgeLines.join("\n")}
-              </pre>
+              <pre className="stream-output">{judgeLines.join("\n")}</pre>
             </div>
           )}
-          <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 12 }}>
+          <section className="run-grid">
             {Object.entries(progressByBrand).map(([brandId, box]) => (
-              <article
-                key={brandId}
-                style={{ border: "1px solid #ddd", borderRadius: 8, padding: 12, background: "#fff" }}
-              >
-                <h4 style={{ margin: "0 0 8px" }}>{box.brandName}</h4>
-                <p style={{ margin: "0 0 8px", color: "#555" }}>{box.status}</p>
-                <pre style={{ margin: 0, whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                  {box.lines.length ? box.lines.join("\n") : "Waiting for streamed output..."}
-                </pre>
+              <article key={brandId} className="stream-box">
+                <h4>{box.brandName}</h4>
+                <p>{box.status}</p>
+                <pre className="stream-output">{box.lines.length ? box.lines.join("\n") : "Waiting for streamed output..."}</pre>
               </article>
             ))}
           </section>
@@ -287,7 +280,7 @@ export function CompetitivePage() {
 
       {overview && (
         <>
-          <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginBottom: 16 }}>
+          <section className="panel-grid">
             <ShareOfVoiceChart rows={overview.rows} brandLabels={brandLabels} />
             <SentimentComparison rows={overview.rows} brandLabels={brandLabels} />
           </section>
@@ -297,18 +290,18 @@ export function CompetitivePage() {
             brandLabels={brandLabels}
             accountBrandName={accountBrandName}
           />
-          <section style={{ marginTop: 16 }}>
+          <section>
             <WhitespacePanel gaps={gaps} />
           </section>
         </>
       )}
 
-      <section style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Trend Snapshot (7 days)</h3>
+      <section className="panel">
+        <h3>Trend Snapshot (7 days)</h3>
         {!trends ? (
           <p>No trend data yet.</p>
         ) : (
-          <pre style={{ overflowX: "auto", margin: 0 }}>
+          <pre className="raw-output">
             {JSON.stringify(
               Object.fromEntries(
                 Object.entries(trends.seriesByBrand).map(([id, pts]) => [brandLabels[id] ?? id, pts]),
@@ -320,8 +313,8 @@ export function CompetitivePage() {
         )}
       </section>
 
-      <section style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Run Configuration</h3>
+      <section className="panel">
+        <h3>Run Configuration</h3>
         <p>
           Account: {accountBrandName} ({accountBrandId || "run to assign IDs"})
         </p>


### PR DESCRIPTION
## Summary
- add shared frontend styles for panels, tables, forms, metric bars, and stream output
- restyle the benchmarking page with a white/light-blue palette
- replace scattered inline styling in competitive components with reusable classes

## Test plan
- bun run test
- bun run build:web

Stacked on #25. Note: Vite prints a local Node version warning, but the build completes successfully.