### PR TITLE
Polish dashboard section pages

### DIFF
--- a/web/src/__tests__/app.test.tsx
+++ b/web/src/__tests__/app.test.tsx
@@ -16,8 +16,8 @@ describe("dashboard shell", () => {
   });
 
   test("renders placeholder pages", () => {
-    expect(renderToStaticMarkup(<MonitoringPage />).includes("Prompt monitoring")).toBeTrue();
-    expect(renderToStaticMarkup(<RecommendationsPage />).includes("Fix-it recommendations")).toBeTrue();
-    expect(renderToStaticMarkup(<SourcesPage />).includes("Source tracking")).toBeTrue();
+    expect(renderToStaticMarkup(<MonitoringPage />).includes("Prompt Queue")).toBeTrue();
+    expect(renderToStaticMarkup(<RecommendationsPage />).includes("Recommended Actions")).toBeTrue();
+    expect(renderToStaticMarkup(<SourcesPage />).includes("Influential Sources")).toBeTrue();
   });
 });

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -326,12 +326,105 @@ input {
   margin-top: 8px;
 }
 
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.summary-card {
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  padding: 18px;
+}
+
+.summary-card h3 {
+  margin: 8px 0;
+}
+
+.summary-card p {
+  color: var(--color-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.eyebrow {
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.task-list {
+  display: grid;
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.task-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-soft);
+  padding: 12px;
+}
+
+.task-list strong {
+  border-radius: 999px;
+  background: var(--color-blue);
+  color: var(--color-text);
+  font-size: 12px;
+  padding: 5px 9px;
+  white-space: nowrap;
+}
+
+.two-column {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  gap: 16px;
+}
+
+.source-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) 120px 120px;
+  gap: 12px;
+  border-bottom: 1px solid var(--color-line);
+  padding: 12px 0;
+}
+
+.source-row:first-child {
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.source-row:last-child {
+  border-bottom: 0;
+}
+
 @media (max-width: 980px) {
   .panel-grid {
     grid-template-columns: 1fr;
   }
 
   .metric-row {
+    grid-template-columns: 1fr;
+  }
+
+  .card-grid,
+  .two-column {
+    grid-template-columns: 1fr;
+  }
+
+  .source-row {
     grid-template-columns: 1fr;
   }
 }

--- a/web/src/components/dashboard/SummaryCard.tsx
+++ b/web/src/components/dashboard/SummaryCard.tsx
@@ -1,0 +1,15 @@
+interface SummaryCardProps {
+  eyebrow: string;
+  title: string;
+  description: string;
+}
+
+export function SummaryCard({ eyebrow, title, description }: SummaryCardProps) {
+  return (
+    <article className="summary-card">
+      <span className="eyebrow">{eyebrow}</span>
+      <h3>{title}</h3>
+      <p>{description}</p>
+    </article>
+  );
+}

--- a/web/src/components/dashboard/TaskList.tsx
+++ b/web/src/components/dashboard/TaskList.tsx
@@ -1,0 +1,19 @@
+interface TaskListProps {
+  items: Array<{
+    label: string;
+    status: string;
+  }>;
+}
+
+export function TaskList({ items }: TaskListProps) {
+  return (
+    <ul className="task-list">
+      {items.map((item) => (
+        <li key={item.label}>
+          <span>{item.label}</span>
+          <strong>{item.status}</strong>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -1,3 +1,6 @@
+import { SummaryCard } from "../components/dashboard/SummaryCard";
+import { TaskList } from "../components/dashboard/TaskList";
+
 export function MonitoringPage() {
   return (
     <section className="page-frame">
@@ -5,13 +8,30 @@ export function MonitoringPage() {
         <h1>Monitoring</h1>
         <p>Track the prompts where your brand should appear across AI-generated answers.</p>
       </header>
-      <article className="placeholder-panel">
-        <h2>Prompt monitoring will live here</h2>
-        <p>
-          This page is ready for the MVP monitoring flow: saved prompts, latest answer status, sentiment, and mention
-          history.
-        </p>
-      </article>
+      <section className="card-grid">
+        <SummaryCard eyebrow="Prompts" title="24 tracked" description="Recommendation, comparison, and pricing prompts." />
+        <SummaryCard eyebrow="Mentions" title="68%" description="Share of monitored answers where the brand appears." />
+        <SummaryCard eyebrow="Sentiment" title="+0.22" description="Current average sentiment across monitored prompts." />
+      </section>
+      <section className="two-column">
+        <article className="panel">
+          <h3>Prompt Queue</h3>
+          <TaskList
+            items={[
+              { label: "Best AI visibility tools for B2B SaaS", status: "Ready" },
+              { label: "Compare Perception with GEO monitoring alternatives", status: "Daily" },
+              { label: "What tools help marketers track AI mentions?", status: "Weekly" },
+            ]}
+          />
+        </article>
+        <article className="panel">
+          <h3>Next MVP Step</h3>
+          <p>
+            Connect this screen to saved prompts and answer history so teams can see mention frequency, sentiment, and
+            changes over time.
+          </p>
+        </article>
+      </section>
     </section>
   );
 }

--- a/web/src/pages/recommendations.tsx
+++ b/web/src/pages/recommendations.tsx
@@ -1,3 +1,6 @@
+import { SummaryCard } from "../components/dashboard/SummaryCard";
+import { TaskList } from "../components/dashboard/TaskList";
+
 export function RecommendationsPage() {
   return (
     <section className="page-frame">
@@ -5,12 +8,29 @@ export function RecommendationsPage() {
         <h1>Recommendations</h1>
         <p>Turn detected gaps into concrete actions your marketing and content teams can take.</p>
       </header>
-      <article className="placeholder-panel">
-        <h2>Fix-it recommendations will live here</h2>
-        <p>
-          This page is ready for prioritized actions, expected impact, owners, and before-and-after tracking.
-        </p>
-      </article>
+      <section className="card-grid">
+        <SummaryCard eyebrow="Open" title="7 actions" description="Prioritized opportunities from monitoring gaps." />
+        <SummaryCard eyebrow="Impact" title="3 high" description="Likely to improve share of voice or answer quality." />
+        <SummaryCard eyebrow="Proof" title="2 tests" description="Before-and-after checks ready for rerun." />
+      </section>
+      <section className="two-column">
+        <article className="panel">
+          <h3>Recommended Actions</h3>
+          <TaskList
+            items={[
+              { label: "Publish a comparison page for missing competitor prompts", status: "High" },
+              { label: "Add clearer pricing language to the product page", status: "Medium" },
+              { label: "Create an FAQ for AI visibility measurement", status: "High" },
+            ]}
+          />
+        </article>
+        <article className="panel">
+          <h3>Before and After</h3>
+          <p>
+            The MVP should let teams mark an action complete, rerun the same prompts, and compare visibility lift.
+          </p>
+        </article>
+      </section>
     </section>
   );
 }

--- a/web/src/pages/sources.tsx
+++ b/web/src/pages/sources.tsx
@@ -1,3 +1,5 @@
+import { SummaryCard } from "../components/dashboard/SummaryCard";
+
 export function SourcesPage() {
   return (
     <section className="page-frame">
@@ -5,9 +7,33 @@ export function SourcesPage() {
         <h1>Sources</h1>
         <p>See which pages, reviews, communities, and publications influence AI answers about your market.</p>
       </header>
-      <article className="placeholder-panel">
-        <h2>Source tracking will live here</h2>
-        <p>This page is ready for cited sources, competitor source wins, and earned-media opportunities.</p>
+      <section className="card-grid">
+        <SummaryCard eyebrow="Citations" title="18 found" description="Sources appearing in AI answers this week." />
+        <SummaryCard eyebrow="Competitors" title="5 wins" description="Third-party pages lifting competitor visibility." />
+        <SummaryCard eyebrow="Owned" title="4 pages" description="Brand pages that appear in monitored answers." />
+      </section>
+      <article className="panel">
+        <h3>Influential Sources</h3>
+        <div className="source-row">
+          <span>Source</span>
+          <span>Type</span>
+          <span>Signal</span>
+        </div>
+        <div className="source-row">
+          <span>Industry comparison article</span>
+          <span>Publication</span>
+          <span>Competitor</span>
+        </div>
+        <div className="source-row">
+          <span>Customer discussion thread</span>
+          <span>Community</span>
+          <span>Gap</span>
+        </div>
+        <div className="source-row">
+          <span>Product documentation page</span>
+          <span>Owned</span>
+          <span>Positive</span>
+        </div>
       </article>
     </section>
   );


### PR DESCRIPTION
## Summary
- add reusable dashboard summary card and task list components
- turn Monitoring, Recommendations, and Sources into polished MVP-ready page layouts
- keep the palette limited to white, light blue, and dark slate text

## Test plan
- bun run test
- bun run build:web

Stacked on #26. Note: Vite prints a local Node version warning, but the build completes successfully.