### PR TITLE
Demo seed data + walkthrough

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,214 @@
+# Perception · Demo Script (Streaming Services Cohort)
+
+A 7–9 minute walkthrough for the Wednesday Demo Day slot. Uses the seeded
+**Netflix vs Disney+ / Max / Amazon Prime Video / Apple TV+ / Paramount+** cohort
+that ships with the demo seed pack.
+
+---
+
+## 0. Pre-flight (do this 5 min before joining Zoom)
+
+```bash
+# 1. Make sure your OpenAI key is set so the live run shows real LLM output
+cat server/.env   # should contain a non-empty OPENAI_API_KEY=...
+
+# 2. Start the stack (one terminal)
+bun install            # only if you haven't already
+bun run dev            # spawns server on :3000 and web on :5173
+
+# 3. Open the dashboard in a fresh browser tab
+open http://localhost:5173
+```
+
+Sanity checks before you share screen:
+
+- `curl http://localhost:3000/llm/status` → `{"provider":"openai","mode":"live"}`
+  — if it says `mock`, your key didn't load. **Restart the server.**
+- The Benchmarking tab should load with **populated charts** (Netflix at the top
+  of the Share of Voice bars). If you see "No benchmark yet", the seed didn't
+  load — restart the server and check the boot log for
+  `[seed] Loaded streaming demo cohort: 10 prompt runs, ...`.
+- Resolution: full-screen the browser at ~1440px wide. The two-column SoV +
+  Sentiment grid collapses below ~980px and reads worse on Zoom.
+- Close any other tabs that might steal CPU during the live run.
+
+If anything is sketchy, fall back to the **mock-mode demo** at the bottom of
+this doc — it's deterministic, takes ~5s instead of ~45s, and looks the same.
+
+---
+
+## 1. Opening (~30s)
+
+> "Perception is a brand-intelligence platform for the AI era. Companies spend
+> millions on SEO so Google ranks them, but consumers are increasingly asking
+> ChatGPT, Claude, and Gemini for product recommendations — and most brands
+> have **zero visibility** into what AI is saying about them.
+>
+> We're going to show you how a marketing team at Netflix could see exactly how
+> AI describes them versus the rest of the streaming category, in one click."
+
+Click the **Benchmarking** tab in the sidebar to anchor the demo.
+
+---
+
+## 2. The dashboard at rest (~90s)
+
+Walk through what's already on screen. The seed pack means the dashboard is
+*already populated* — that's the whole point.
+
+### Hero
+> "This is what we're tracking: 20 perception prompts fanned across Netflix and
+> 5 competitors, every prompt answered by the frontier models, results rolled
+> into share of voice, sentiment, and feature gaps."
+
+### Share of Voice (top-left)
+> "Netflix is the leader at ~25% share of voice across all the prompts. Apple
+> TV+ is rising — 21%. Paramount+ is trailing in the single digits."
+
+Point at the bars. The visual story is obvious because we sorted descending and
+each brand has its own colour.
+
+### Sentiment (top-right)
+> "Sentiment is where it gets interesting. Apple TV+ has the highest sentiment
+> score even though Netflix has more share. That's the prestige-originals
+> narrative beating the incumbent on quality."
+
+### Feature signal
+> "These are the themes the judge LLM repeatedly attached to each brand. Netflix
+> wins on `leadership` and `originals`. Disney+ wins on `family` and `ip`. Max
+> wins on `prestige`. **Notice nothing on Netflix says `value` or `innovation`**
+> — that's a problem."
+
+### Feature praise gaps (the punchline)
+> "Right here, Perception flagged it: **Amazon Prime is praised on `value`;
+> Netflix isn't.** And **Apple TV+ owns `innovation`; Netflix isn't mentioned.**
+> Two clear gaps the marketing team can act on."
+
+### Whitespace opportunities
+> "And here's whitespace: AI assistants don't decisively recommend any one
+> brand for live sports. That's a category Netflix could move into and own."
+
+This whole section sells the differentiation: every other tool stops at "here's
+what AI says." We surface **gaps and whitespace**.
+
+---
+
+## 3. The live run (~2–3 min, narrate while it runs)
+
+Click **Run benchmark** with the default Netflix slate.
+
+The Theater section appears with six branded columns. While it streams:
+
+> "What you're watching live is the platform fanning twenty prompts across
+> every brand simultaneously. Each column is one of the streaming services.
+> The cursor blinks while OpenAI is mid-stream. The bar at the top of each
+> column fills as prompts complete."
+
+Things to point at:
+
+- The **Judge LLM** aside that pops in between brand answers — that's the
+  comparative scoring step.
+- The progress counters (`0/20 → 1/20 → 2/20 …`).
+- The fact that **all six brands run in parallel** at concurrency 4 — that's
+  why it finishes in ~45 seconds instead of 5+ minutes.
+
+If the run takes longer than expected, fill the time:
+
+> "The reason this matters operationally: in the AI era, brand visibility is
+> non-deterministic. The same prompt gives different answers tomorrow. So the
+> only honest way to measure brand presence in AI is to keep running prompts
+> on a schedule — exactly what Perception does."
+
+---
+
+## 4. Post-run reveal (~60s)
+
+When the Theater finishes, the dashboard panels update with the merged data
+(7 days of seeded history + today's fresh run).
+
+> "Now the dashboard has refreshed with the new run on top of the 7 days of
+> historical data. Trends rolls forward. New gap events get detected. If
+> Netflix's marketing team did this every Monday morning, they'd have a moving
+> picture of how AI's perception of their brand is changing."
+
+Scroll to **Trend snapshot** and point at the daily mini-bars:
+
+> "Daily averages, one row per day, per brand. You can see Netflix's share is
+> stable, Apple TV+ is rising, Paramount+ is volatile."
+
+---
+
+## 5. Closing pitch (~30s)
+
+> "Three things we do that no competitor does today:
+>
+> 1. **We tell you where the gaps are**, not just where you stand.
+> 2. **We surface whitespace** — categories AI hasn't decided yet, where you
+>    can plant a flag.
+> 3. **We make the run itself a story** — that Theater isn't just polish, it's
+>    how you build conviction with a CMO that the data is real.
+>
+> Built by the team in 4 weeks. Currently tracks GPT-class models; Claude and
+> Gemini are the next integrations. Hallucination detection — ChatGPT
+> inventing wrong pricing or features — is the next major feature."
+
+---
+
+## 6. Likely Q&A — quick answers
+
+| Question | Quick answer |
+|---|---|
+| Are you using a real LLM or mocking? | Live OpenAI for both the perception prompts and the comparative judge. The pill says `live · openai` in the run config. |
+| What models? | `gpt-4.1-mini` for both answers and judging. Multi-provider abstraction is in flight. |
+| How are the prompts chosen? | 10 brand-specific (each retailer's name substituted) plus 10 category-wide leadership prompts. Configurable per cohort. |
+| How long does a real run take? | ~30–60 seconds for 6 brands × 20 prompts at concurrency 4. |
+| What happens with hallucinations? | We have a v0 detector for fact-sheet contradictions (pricing, founding year, HQ) — not in this demo, separate branch. |
+| What's the data model? | All in-memory for the prototype. SQLite store for business profiles already wired; competitive store moves to Postgres next. |
+| Differentiator vs Profound / Peec? | They're monitoring dashboards. We close the loop: detection → diagnosis → recommended action → before-and-after measurement. |
+| Privacy / data? | Brand-provided fact sheets stay client-side until a run. AI answers we generate ourselves; we don't scrape user conversations. |
+
+---
+
+## 7. Backup script (use this if the live run fails)
+
+If `bun run dev` won't start, OpenAI rate-limits, or the network drops:
+
+1. Set `PERCEPTION_DEMO_SEED=1` (default — already on) and **don't click Run**.
+2. The dashboard is already populated from the seed, so do steps 1–2 of the
+   real script (Hero → Share of Voice → Sentiment → Feature signal → Whitespace)
+   without relying on a live run at all.
+3. For the "live moment", show the Theater on a **previously recorded
+   screen capture** if you made one. Otherwise:
+4. Click Run anyway — even without a key, the mock LLM produces deterministic
+   output and the Theater still plays. It just takes ~5s. Narrate it as
+   "we're running in offline mode for the demo so the Zoom doesn't lag."
+
+---
+
+## 8. Two-minute version (if your slot gets cut short)
+
+If the CA tells you to wrap in 90 seconds:
+
+1. **Hero + dashboard** (already populated): "AI is the new search; here's how
+   AI talks about Netflix vs every other streamer. We track 20 prompts × 6
+   brands daily."
+2. **Skip the live run.** Just point at the populated bars + sentiment + gaps.
+3. **Punchline gap**: "Amazon owns `value`, Apple TV+ owns `innovation`;
+   Netflix is missing both. We surface that. Nobody else does."
+4. **Close**: "Profound monitors. We diagnose."
+
+That hits visibility, differentiation, and the strongest example in 90s.
+
+---
+
+## File map (for reviewers reading the code)
+
+- `server/seed/streaming.ts` — the seeded cohort and 7 days of synthetic
+  comparisons + gap events.
+- `server/src/routes/competitive.ts` — `/competitive/snapshot` powers the
+  first-paint preview the dashboard auto-loads on mount.
+- `server/src/routes/llm-status.ts` — `/llm/status` surfaces live vs mock.
+- `web/src/components/competitive/LiveRunTheater.tsx` — the streaming column
+  panel users see during a run.
+- `web/src/pages/competitive.tsx` — page composition: hero, picker, theater,
+  charts, trend snapshot, run config.

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,16 +1,22 @@
-# Perception · Demo Script (Streaming Services Cohort)
+# Perception · Demo Day Walkthrough
 
-A 7–9 minute walkthrough for the Wednesday Demo Day slot. Uses the seeded
+A 7–9 minute walkthrough for the Wednesday Demo Day Zoom slot. Uses the seeded
 **Netflix vs Disney+ / Max / Amazon Prime Video / Apple TV+ / Paramount+** cohort
-that ships with the demo seed pack.
+that ships with this branch. Every dashboard view has real data on first paint —
+no clicks required to populate.
+
+> **TL;DR.** Open the dashboard. Walk Monitoring → Benchmarking. Click *Run
+> benchmark*. Narrate the Theater for 60–90s. Land on the gap punchline:
+> "Netflix is missing on **value** and **innovation** — that's exactly the
+> diagnosis we surface."
 
 ---
 
-## 0. Pre-flight (do this 5 min before joining Zoom)
+## 0 · Pre-flight (5 minutes before joining Zoom)
 
 ```bash
 # 1. Make sure your OpenAI key is set so the live run shows real LLM output
-cat server/.env   # should contain a non-empty OPENAI_API_KEY=...
+cat server/.env   # should contain OPENAI_API_KEY=sk-...
 
 # 2. Start the stack (one terminal)
 bun install            # only if you haven't already
@@ -20,195 +26,279 @@ bun run dev            # spawns server on :3000 and web on :5173
 open http://localhost:5173
 ```
 
-Sanity checks before you share screen:
+Sanity checks before screen share:
 
-- `curl http://localhost:3000/llm/status` → `{"provider":"openai","mode":"live"}`
-  — if it says `mock`, your key didn't load. **Restart the server.**
-- The Benchmarking tab should load with **populated charts** (Netflix at the top
-  of the Share of Voice bars). If you see "No benchmark yet", the seed didn't
-  load — restart the server and check the boot log for
-  `[seed] Loaded streaming demo cohort: 10 prompt runs, ...`.
-- Resolution: full-screen the browser at ~1440px wide. The two-column SoV +
-  Sentiment grid collapses below ~980px and reads worse on Zoom.
-- Close any other tabs that might steal CPU during the live run.
+- Server boot log shows two `[seed]` lines:
+  - `Loaded streaming demo cohort: 10 prompt runs, 10 comparisons, 3 gap events.`
+  - `Created Netflix business profile (…) with 12 monitoring prompts.`
+- `curl http://localhost:3000/llm/status` returns `{"provider":"openai","mode":"live"}` (if it says `mock`, your key didn't load — restart the server).
+- The Benchmarking tab opens populated: Netflix at the top of Share of Voice,
+  Apple TV+ rising on Sentiment, three brand-color chips per row in Feature signal.
+- Monitoring tab shows 12 prompts with sentiment pills (positive / neutral /
+  negative) and a 7-day sentiment trend chart.
+- Browser at ~1440px wide. Charts collapse below ~980px.
+- Close other tabs that might steal CPU during the live run.
 
-If anything is sketchy, fall back to the **mock-mode demo** at the bottom of
-this doc — it's deterministic, takes ~5s instead of ~45s, and looks the same.
+If anything looks off, jump to **Section 7 (Backup script)** at the bottom.
 
 ---
 
-## 1. Opening (~30s)
+## 1 · Opening (~30 seconds)
 
-> "Perception is a brand-intelligence platform for the AI era. Companies spend
+> *"Perception is a brand-intelligence platform for the AI era. Companies spend
 > millions on SEO so Google ranks them, but consumers are increasingly asking
-> ChatGPT, Claude, and Gemini for product recommendations — and most brands
-> have **zero visibility** into what AI is saying about them.
+> ChatGPT, Claude, and Gemini for product recommendations — and most brands have
+> **zero visibility** into what AI is saying about them.*
 >
-> We're going to show you how a marketing team at Netflix could see exactly how
-> AI describes them versus the rest of the streaming category, in one click."
+> *I'll show you how a marketing team at Netflix could see exactly how AI describes
+> them versus the rest of the streaming category — in one click."*
 
-Click the **Benchmarking** tab in the sidebar to anchor the demo.
+Click **Benchmarking** in the sidebar to anchor the demo.
 
 ---
 
-## 2. The dashboard at rest (~90s)
+## 2 · Tour of Monitoring (~45 seconds, optional opener)
 
-Walk through what's already on screen. The seed pack means the dashboard is
-*already populated* — that's the whole point.
+Click **Monitoring** in the sidebar first if you have time.
 
-### Hero
-> "This is what we're tracking: 20 perception prompts fanned across Netflix and
-> 5 competitors, every prompt answered by the frontier models, results rolled
-> into share of voice, sentiment, and feature gaps."
+> *"Before we get to head-to-head benchmarking, here's what daily monitoring
+> looks like. Twelve prompts — the actual queries customers are asking AI
+> chatbots about streaming services. Sentiment is colour-coded per prompt:
+> green where Netflix wins the answer, red where it loses, neutral where it's
+> in the middle."*
 
-### Share of Voice (top-left)
-> "Netflix is the leader at ~25% share of voice across all the prompts. Apple
-> TV+ is rising — 21%. Paramount+ is trailing in the single digits."
+Point at:
+- The 7-day sentiment trend (the line goes from -0.18 to +0.26 to -0.06).
+- The mix of green / neutral / red pills in the table — you don't get to
+  cherry-pick; AI says what it says.
+- The **Add a prompt** input at the bottom: "Marketing teams add prompts they
+  care about; we re-run them daily and surface drift."
 
-Point at the bars. The visual story is obvious because we sorted descending and
-each brand has its own colour.
+Skip this section entirely if your slot is tight. Benchmarking is the moneyshot.
 
-### Sentiment (top-right)
-> "Sentiment is where it gets interesting. Apple TV+ has the highest sentiment
-> score even though Netflix has more share. That's the prestige-originals
-> narrative beating the incumbent on quality."
+---
+
+## 3 · Benchmarking dashboard at rest (~90 seconds)
+
+Click **Benchmarking** in the sidebar. The dashboard is *already populated* —
+that's the seed pack doing its job.
+
+### Hero (read this verbatim)
+> *"This is what we're tracking: 20 perception prompts fanned across Netflix and
+> 5 streaming competitors, every prompt answered by frontier models, results
+> rolled into share of voice, sentiment, feature gaps, and whitespace."*
+
+### Share of voice
+> *"Netflix is the leader at ~25% share of voice across all the prompts. Apple
+> TV+ is rising — 21%. Paramount+ is in the single digits."*
+
+Point at the bars. Sorted descending; brand-coloured fills.
+
+### Sentiment
+> *"Sentiment is where it gets interesting. **Apple TV+ has the highest sentiment**
+> even though Netflix has more share. That's the prestige-originals narrative
+> beating the incumbent on quality. The gauge runs -1 to +1; pin colour flips
+> red for negative, green for positive."*
 
 ### Feature signal
-> "These are the themes the judge LLM repeatedly attached to each brand. Netflix
-> wins on `leadership` and `originals`. Disney+ wins on `family` and `ip`. Max
-> wins on `prestige`. **Notice nothing on Netflix says `value` or `innovation`**
-> — that's a problem."
+> *"These are the themes the judge LLM repeatedly attached to each brand across
+> the 20 prompts. Netflix wins on `leadership` and `originals`. Disney+ owns
+> `family` and `ip`. Max owns `prestige`. **Notice nothing on Netflix says
+> `value` or `innovation`** — that's a problem."*
 
 ### Feature praise gaps (the punchline)
-> "Right here, Perception flagged it: **Amazon Prime is praised on `value`;
-> Netflix isn't.** And **Apple TV+ owns `innovation`; Netflix isn't mentioned.**
-> Two clear gaps the marketing team can act on."
+> *"Right here, Perception flagged it: **Amazon Prime is praised on `value`;
+> Netflix isn't.** And **Apple TV+ owns `innovation`; Netflix is barely
+> mentioned.** Two clear gaps the marketing team can act on."*
 
-### Whitespace opportunities
-> "And here's whitespace: AI assistants don't decisively recommend any one
-> brand for live sports. That's a category Netflix could move into and own."
+### Whitespace
+> *"And here's whitespace: AI assistants don't decisively recommend any one
+> brand for **live sports**. That's a category Netflix could move into and own."*
 
-This whole section sells the differentiation: every other tool stops at "here's
-what AI says." We surface **gaps and whitespace**.
+This is the differentiator pitch: every other tool stops at *here's what AI
+says*. We surface **gaps and whitespace** — what to do about it.
 
 ---
 
-## 3. The live run (~2–3 min, narrate while it runs)
+## 4 · The live run (~2–3 minutes, narrate while it runs)
 
 Click **Run benchmark** with the default Netflix slate.
 
-The Theater section appears with six branded columns. While it streams:
+The Theater section appears with six brand columns. While it streams:
 
-> "What you're watching live is the platform fanning twenty prompts across
+> *"What you're watching live is the platform fanning twenty prompts across
 > every brand simultaneously. Each column is one of the streaming services.
 > The cursor blinks while OpenAI is mid-stream. The bar at the top of each
-> column fills as prompts complete."
+> column fills as prompts complete."*
 
 Things to point at:
 
 - The **Judge LLM** aside that pops in between brand answers — that's the
   comparative scoring step.
-- The progress counters (`0/20 → 1/20 → 2/20 …`).
+- The progress counters: `0/20 → 1/20 → 2/20 …`.
 - The fact that **all six brands run in parallel** at concurrency 4 — that's
-  why it finishes in ~45 seconds instead of 5+ minutes.
+  why it finishes in ~45–60 seconds instead of 5+ minutes.
 
-If the run takes longer than expected, fill the time:
+Filler narration if the run drags:
 
-> "The reason this matters operationally: in the AI era, brand visibility is
+> *"The reason this matters operationally: in the AI era, brand visibility is
 > non-deterministic. The same prompt gives different answers tomorrow. So the
 > only honest way to measure brand presence in AI is to keep running prompts
-> on a schedule — exactly what Perception does."
+> on a schedule — exactly what Perception does. Every 24 hours, the same 20
+> prompts, the same six brands, fresh comparisons."*
+
+If you have ~45 more seconds:
+
+> *"Behind the scenes, every answer feeds a comparative judge LLM that scores
+> share of voice as a probability distribution that sums to 1. Sentiment is a
+> -1 to +1 score per brand per prompt. Feature attribution is constrained to
+> a fixed taxonomy so we can roll it up over time. None of this is keyword
+> matching — it's all LLM-judged."*
 
 ---
 
-## 4. Post-run reveal (~60s)
+## 5 · Post-run reveal (~60 seconds)
 
 When the Theater finishes, the dashboard panels update with the merged data
 (7 days of seeded history + today's fresh run).
 
-> "Now the dashboard has refreshed with the new run on top of the 7 days of
-> historical data. Trends rolls forward. New gap events get detected. If
-> Netflix's marketing team did this every Monday morning, they'd have a moving
-> picture of how AI's perception of their brand is changing."
+> *"Now the dashboard has refreshed. Trends rolls forward. New gap events get
+> detected. If Netflix's marketing team did this every Monday morning, they'd
+> have a moving picture of how AI's perception of their brand is changing
+> — week over week, prompt by prompt."*
 
 Scroll to **Trend snapshot** and point at the daily mini-bars:
 
-> "Daily averages, one row per day, per brand. You can see Netflix's share is
-> stable, Apple TV+ is rising, Paramount+ is volatile."
+> *"Daily averages. One row per day, per brand. Netflix's share is stable.
+> Apple TV+ is climbing. Paramount+ is volatile."*
+
+Scroll to **Run configuration**:
+
+> *"And every run is auditable. Here's the exact account, competitors, window,
+> and timestamp. If a CMO asks 'what was running when?', we can answer."*
 
 ---
 
-## 5. Closing pitch (~30s)
+## 6 · Closing pitch (~30 seconds)
 
-> "Three things we do that no competitor does today:
+> *"Three things we do that no competitor does today:*
 >
 > 1. **We tell you where the gaps are**, not just where you stand.
 > 2. **We surface whitespace** — categories AI hasn't decided yet, where you
 >    can plant a flag.
-> 3. **We make the run itself a story** — that Theater isn't just polish, it's
+> 3. **We make the run itself a story** — the Theater isn't just polish, it's
 >    how you build conviction with a CMO that the data is real.
 >
-> Built by the team in 4 weeks. Currently tracks GPT-class models; Claude and
-> Gemini are the next integrations. Hallucination detection — ChatGPT
-> inventing wrong pricing or features — is the next major feature."
+> *Built by the team in 4 weeks. Today it tracks GPT-class models; Claude and
+> Gemini are next. Hallucination detection — ChatGPT inventing wrong pricing
+> or features — is the next major feature."*
 
 ---
 
-## 6. Likely Q&A — quick answers
-
-| Question | Quick answer |
-|---|---|
-| Are you using a real LLM or mocking? | Live OpenAI for both the perception prompts and the comparative judge. The pill says `live · openai` in the run config. |
-| What models? | `gpt-4.1-mini` for both answers and judging. Multi-provider abstraction is in flight. |
-| How are the prompts chosen? | 10 brand-specific (each retailer's name substituted) plus 10 category-wide leadership prompts. Configurable per cohort. |
-| How long does a real run take? | ~30–60 seconds for 6 brands × 20 prompts at concurrency 4. |
-| What happens with hallucinations? | We have a v0 detector for fact-sheet contradictions (pricing, founding year, HQ) — not in this demo, separate branch. |
-| What's the data model? | All in-memory for the prototype. SQLite store for business profiles already wired; competitive store moves to Postgres next. |
-| Differentiator vs Profound / Peec? | They're monitoring dashboards. We close the loop: detection → diagnosis → recommended action → before-and-after measurement. |
-| Privacy / data? | Brand-provided fact sheets stay client-side until a run. AI answers we generate ourselves; we don't scrape user conversations. |
-
----
-
-## 7. Backup script (use this if the live run fails)
+## 7 · Backup script (use this if the live run fails)
 
 If `bun run dev` won't start, OpenAI rate-limits, or the network drops:
 
-1. Set `PERCEPTION_DEMO_SEED=1` (default — already on) and **don't click Run**.
-2. The dashboard is already populated from the seed, so do steps 1–2 of the
-   real script (Hero → Share of Voice → Sentiment → Feature signal → Whitespace)
-   without relying on a live run at all.
-3. For the "live moment", show the Theater on a **previously recorded
-   screen capture** if you made one. Otherwise:
-4. Click Run anyway — even without a key, the mock LLM produces deterministic
-   output and the Theater still plays. It just takes ~5s. Narrate it as
-   "we're running in offline mode for the demo so the Zoom doesn't lag."
+1. The dashboard is already populated by the seed pack — do **steps 1, 2, 3,
+   5, 6** of the real script and skip step 4 entirely.
+2. For the "live moment", click Run anyway — even without a key, the mock LLM
+   returns deterministic placeholder text and the Theater plays. Narrate it
+   as: *"we're running in offline demo mode so the Zoom doesn't lag."*
+3. Fallback fallback: if the Run button hangs, hit `Cmd+Shift+R` to refresh,
+   the seeded data re-hydrates immediately. No live run needed.
 
 ---
 
-## 8. Two-minute version (if your slot gets cut short)
+## 8 · Two-minute version (if your slot gets cut short)
 
 If the CA tells you to wrap in 90 seconds:
 
-1. **Hero + dashboard** (already populated): "AI is the new search; here's how
-   AI talks about Netflix vs every other streamer. We track 20 prompts × 6
-   brands daily."
+1. **Hero + dashboard** (already populated): *"AI is the new search; here's
+   how AI talks about Netflix vs every other streamer. We track 20 prompts ×
+   6 brands daily."*
 2. **Skip the live run.** Just point at the populated bars + sentiment + gaps.
-3. **Punchline gap**: "Amazon owns `value`, Apple TV+ owns `innovation`;
-   Netflix is missing both. We surface that. Nobody else does."
-4. **Close**: "Profound monitors. We diagnose."
+3. **Punchline gap**: *"Amazon owns `value`, Apple TV+ owns `innovation`;
+   Netflix is missing both. We surface that. Nobody else does."*
+4. **Close**: *"Profound monitors. We diagnose."*
 
 That hits visibility, differentiation, and the strongest example in 90s.
 
 ---
 
-## File map (for reviewers reading the code)
+## 9 · Q&A — quick answers
 
-- `server/seed/streaming.ts` — the seeded cohort and 7 days of synthetic
-  comparisons + gap events.
+| Question | Quick answer |
+|---|---|
+| Are you using a real LLM or mocking? | Live OpenAI for both the perception prompts and the comparative judge. The Run config block shows mode: `live · openai`. |
+| What models? | `gpt-4.1-mini` for both answers and judging. Multi-provider abstraction is in flight on a separate branch. |
+| How are the prompts chosen? | 10 brand-specific (each retailer's name substituted) plus 10 category-wide leadership prompts. The prompt set is configurable per cohort. |
+| How long does a real run take? | ~30–60 seconds for 6 brands × 20 prompts × concurrency 4. Theater fills the time visually. |
+| What about hallucinations? | We have a v0 detector (regex-based contradictions for pricing / founding year / HQ) on a separate branch. Coming back to it post-demo. |
+| What's the data model? | SQLite for business profiles, monitoring prompts, and competitor lists. In-memory for the competitive pipeline (prompt runs / answers / comparisons / gap events) — moving to Postgres is the next migration. |
+| Differentiator vs Profound / Peec? | They're monitoring dashboards. We close the loop: detection → diagnosis (gap events) → recommended action → before-and-after measurement. |
+| Privacy / data? | Brand-provided fact sheets stay client-side until a run. AI answers we generate ourselves; we never scrape user conversations. |
+| Cost per run? | ~$0.03 per benchmark run on `gpt-4.1-mini` (120 short answers + 20 short judge passes). Linear with brands × prompts. |
+| Why streaming for the demo? | Universally recognised; sharp narrative differentiation across `leader`, `value`, `innovation`, `family`, `prestige`, `sports`. |
+
+---
+
+## 10 · The story arc the data tells
+
+This is the underlying narrative the screenshots support — useful if a CA asks
+*"what's actually interesting here?"*
+
+| Brand | Owns | Loses | Why |
+|---|---|---|---|
+| **Netflix** | `leadership`, `content_volume`, `originals` | `value`, `innovation` | Incumbent leader; pricing fatigue + Apple TV+ stealing the prestige-originals narrative |
+| **Disney+** | `family`, `ip` | `prestige`, `value-for-quality` | IP-driven (Marvel / Star Wars / Pixar) but seen as kids-first |
+| **Max** | `prestige`, `content_quality` | `value`, `innovation` | HBO heritage carries quality narrative; expensive |
+| **Amazon Prime** | `value`, `bundle`, `sports` | `prestige` | Bundle-driven; never reads as premium |
+| **Apple TV+** | `innovation`, `quality`, `originals` | `value`, `library_size` | Small library, prestige originals — punching above weight on perception |
+| **Paramount+** | (narrowly) `sports` | most other dimensions | Scrappy, fights for relevance |
+
+The two **gap events** Perception surfaces directly mirror this:
+1. *Amazon Prime is praised on `value`; Netflix is unmentioned.*
+2. *Apple TV+ owns the innovation narrative; Netflix is barely mentioned.*
+
+The one **whitespace event**:
+- *Live-sports prompts surface Amazon Prime Video and Paramount+; Netflix is
+  absent from the consensus answer.*
+
+If you only remember three numbers from this doc, remember:
+- **38%** — Netflix's share of voice on the *who is the streaming leader*
+  prompt (highest of any brand on any prompt in the cohort).
+- **+0.65** — Apple TV+'s sentiment on the *most innovative* prompt (highest
+  positive sentiment in the cohort).
+- **-0.05 → +0.50** — Paramount+'s swing between *value* (positive) and
+  *premium* (slightly negative). Schizophrenic positioning.
+
+---
+
+## 11 · File map (for reviewers reading the code)
+
+- `server/seed/streaming.ts` — the seeded competitive cohort (Netflix vs five
+  streamers) + 7 days of synthetic comparisons + 3 gap events.
+- `server/seed/netflix-profile.ts` — auto-creates the Netflix business profile,
+  saves the competitor list, and seeds 12 monitoring prompts on first boot.
+- `server/src/index.ts` — boot-time wiring; both seeds are loaded behind the
+  `PERCEPTION_DEMO_SEED` flag (set to `0` to disable).
 - `server/src/routes/competitive.ts` — `/competitive/snapshot` powers the
-  first-paint preview the dashboard auto-loads on mount.
-- `server/src/routes/llm-status.ts` — `/llm/status` surfaces live vs mock.
+  first-paint preview the dashboard auto-loads.
+- `server/src/routes/llm-status.ts` — `/llm/status` reports live vs mock.
 - `web/src/components/competitive/LiveRunTheater.tsx` — the streaming column
-  panel users see during a run.
-- `web/src/pages/competitive.tsx` — page composition: hero, picker, theater,
-  charts, trend snapshot, run config.
+  panel during a run.
+- `web/src/pages/competitive.tsx` — page composition: picker, theater, charts,
+  trend snapshot, run configuration.
+
+---
+
+## 12 · After the demo
+
+Open the team Slack with three notes:
+
+1. **Which CA / team gave you which feedback** — verbatim where possible.
+2. **Whether the live run hit OpenAI or fell back to mock.**
+3. **Three follow-up tasks** to file as issues. Suggested defaults:
+   - Hallucination detection v1 (LLM-driven claim extraction beyond regex)
+   - Multi-provider live mode (Claude + Gemini answers in parallel)
+   - Recommendations tab v1 (turn gap events into actionable cards)

--- a/server/seed/netflix-profile.ts
+++ b/server/seed/netflix-profile.ts
@@ -1,0 +1,63 @@
+import { businessProfiles } from "../src/db/business-profiles";
+import { monitoringPrompts } from "../src/db/monitoring-prompts";
+
+/**
+ * Demo seed: pre-create a Netflix business profile with monitoring prompts +
+ * saved competitor list, so all four sidebar sections have real content on
+ * first paint without onboarding. Idempotent — looks for an existing Netflix
+ * profile before inserting.
+ */
+
+const PROFILE_NAME = "Netflix";
+const PROFILE_WEBSITE = "https://www.netflix.com";
+const PROFILE_DESCRIPTION =
+  "Streaming entertainment service with 260M+ paid memberships in over 190 countries. Originals across film, series, documentaries, and games.";
+
+const SAVED_COMPETITORS = ["Disney+", "Max", "Amazon Prime Video", "Apple TV+", "Paramount+"];
+
+const MONITORING_PROMPTS: ReadonlyArray<string> = [
+  "What is the best streaming service for movies and TV shows in 2026?",
+  "Compare Netflix vs Disney+ for families with young kids.",
+  "Which streaming service has the best original content right now?",
+  "Is Netflix worth it if I already have Amazon Prime?",
+  "What streaming service has the best live sports coverage?",
+  "Best streaming service with no ads at the cheapest price?",
+  "Which streaming platform releases the most prestige TV series?",
+  "What is the best streaming service for K-dramas and Korean content?",
+  "Should I cancel Netflix? What are the best alternatives in 2026?",
+  "Compare the ad-supported tiers on Netflix, Max, and Disney+.",
+  "Which streaming service has the largest film library?",
+  "Best streaming service for binge-watching original drama series?",
+];
+
+export interface ProfileSeedSummary {
+  created: boolean;
+  profileId: string;
+  monitoringCount: number;
+}
+
+export function loadNetflixProfileSeed(): ProfileSeedSummary {
+  const existing = businessProfiles.list().find((profile) => profile.name === PROFILE_NAME);
+  if (existing) {
+    return {
+      created: false,
+      profileId: existing.id,
+      monitoringCount: monitoringPrompts.list(existing.id).length,
+    };
+  }
+
+  const profile = businessProfiles.create({
+    name: PROFILE_NAME,
+    website: PROFILE_WEBSITE,
+    description: PROFILE_DESCRIPTION,
+  });
+  businessProfiles.saveCompetitors(profile.id, [...SAVED_COMPETITORS]);
+  monitoringPrompts.replaceAll(profile.id, [...MONITORING_PROMPTS]);
+  monitoringPrompts.setStatus(profile.id, "ready");
+
+  return {
+    created: true,
+    profileId: profile.id,
+    monitoringCount: MONITORING_PROMPTS.length,
+  };
+}

--- a/server/seed/streaming.ts
+++ b/server/seed/streaming.ts
@@ -1,0 +1,526 @@
+import { seedPromptSetId, store } from "../src/db/store";
+import type {
+  Brand,
+  ComparativeDelta,
+  CompetitorSet,
+  GapEvent,
+  PromptRun,
+} from "../src/features/competitive/types";
+
+/**
+ * Demo seed: a recognizable streaming-services competitive cohort with 7 days
+ * of synthetic benchmark history. Netflix is the account brand vs Disney+,
+ * Max, Amazon Prime Video, Apple TV+, and Paramount+. The synthetic story
+ * arc: Netflix dominates "leader / best overall" but loses ground on "value"
+ * (Amazon Prime bundle) and "innovation" (Apple TV+ originals).
+ *
+ * Loads brands, a competitor set, prompt runs across the last week, one
+ * comparison + a couple of gap events per run. We deliberately skip seeding
+ * `AIAnswer` rows: the dashboard reads only prompt runs, comparisons, and
+ * gap events.
+ */
+
+const ACCOUNT_BRAND_NAME = "Netflix";
+const COMPETITOR_NAMES = ["Disney+", "Max", "Amazon Prime Video", "Apple TV+", "Paramount+"] as const;
+const MODEL = "gpt-4.1-mini";
+
+interface ScriptedComparison {
+  hoursAgo: number;
+  prompt: string;
+  promptKind: "brand_specific" | "domain_general";
+  shareByName: Record<string, number>;
+  sentimentByName: Record<string, number>;
+  praisedByName: Record<string, string[]>;
+  evidence: string[];
+}
+
+const SCRIPTED_COMPARISONS: ScriptedComparison[] = [
+  {
+    hoursAgo: 6 * 24,
+    prompt: "Who is most often described as the leader or reference standard in streaming?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.38,
+      "Disney+": 0.21,
+      "Max": 0.13,
+      "Amazon Prime Video": 0.12,
+      "Apple TV+": 0.09,
+      "Paramount+": 0.07,
+    },
+    sentimentByName: {
+      "Netflix": 0.6,
+      "Disney+": 0.45,
+      "Max": 0.4,
+      "Amazon Prime Video": 0.3,
+      "Apple TV+": 0.45,
+      "Paramount+": 0.1,
+    },
+    praisedByName: {
+      "Netflix": ["leadership", "content_volume", "originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige", "content_quality"],
+      "Amazon Prime Video": ["bundle", "value"],
+      "Apple TV+": ["originals", "quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Netflix consistently framed as the streaming category reference standard.",
+      "Disney+ trails as a strong second on the back of Marvel / Star Wars / Pixar.",
+      "Paramount+ rarely surfaces unless live sports comes up.",
+    ],
+  },
+  {
+    hoursAgo: 5 * 24,
+    prompt: "How is {brand} generally perceived on trustworthiness and delivering on what it promises?",
+    promptKind: "brand_specific",
+    shareByName: {
+      "Netflix": 0.3,
+      "Disney+": 0.22,
+      "Max": 0.16,
+      "Amazon Prime Video": 0.12,
+      "Apple TV+": 0.13,
+      "Paramount+": 0.07,
+    },
+    sentimentByName: {
+      "Netflix": 0.55,
+      "Disney+": 0.5,
+      "Max": 0.45,
+      "Amazon Prime Video": 0.35,
+      "Apple TV+": 0.55,
+      "Paramount+": 0.05,
+    },
+    praisedByName: {
+      "Netflix": ["reliability", "originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Netflix trust narrative dominates — buyers expect titles to ship and queues to work.",
+      "Apple TV+ over-indexes on trust given small library — quality reputation.",
+      "Paramount+ trust narrative weaker; framed as scrappy and inconsistent.",
+    ],
+  },
+  {
+    hoursAgo: 4 * 24,
+    prompt: "Which player is most associated with the best value—quality relative to price?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.13,
+      "Disney+": 0.18,
+      "Max": 0.07,
+      "Amazon Prime Video": 0.34,
+      "Apple TV+": 0.06,
+      "Paramount+": 0.22,
+    },
+    sentimentByName: {
+      "Netflix": 0.05,
+      "Disney+": 0.4,
+      "Max": 0.0,
+      "Amazon Prime Video": 0.6,
+      "Apple TV+": -0.05,
+      "Paramount+": 0.5,
+    },
+    praisedByName: {
+      "Netflix": ["originals"],
+      "Disney+": ["family", "ip", "bundle"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["value", "bundle", "sports"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["value", "sports"],
+    },
+    evidence: [
+      "Amazon Prime owns 'value' framing because it's bundled with Prime shipping.",
+      "Netflix sentiment near-neutral — repeatedly tagged as 'expensive lately'.",
+      "Paramount+ undercuts on price; surfaces alongside Prime in value answers.",
+    ],
+  },
+  {
+    hoursAgo: 3 * 24,
+    prompt: "Who is seen as the most innovative or future-oriented in this space?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.2,
+      "Disney+": 0.12,
+      "Max": 0.1,
+      "Amazon Prime Video": 0.1,
+      "Apple TV+": 0.36,
+      "Paramount+": 0.12,
+    },
+    sentimentByName: {
+      "Netflix": 0.35,
+      "Disney+": 0.25,
+      "Max": 0.2,
+      "Amazon Prime Video": 0.2,
+      "Apple TV+": 0.65,
+      "Paramount+": 0.1,
+    },
+    praisedByName: {
+      "Netflix": ["originals", "recommendations"],
+      "Disney+": ["family"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["innovation", "quality", "originals"],
+      "Paramount+": ["scrappy"],
+    },
+    evidence: [
+      "Apple TV+ owns the innovation narrative via prestige originals like Severance and Ted Lasso.",
+      "Netflix innovation share lags expected scale — viewed as 'incumbent' rather than 'forward'.",
+      "Paramount+ rarely cited in forward-looking answers.",
+    ],
+  },
+  {
+    hoursAgo: 2 * 24,
+    prompt: "How is {brand}'s customer experience perceived?",
+    promptKind: "brand_specific",
+    shareByName: {
+      "Netflix": 0.32,
+      "Disney+": 0.24,
+      "Max": 0.13,
+      "Amazon Prime Video": 0.16,
+      "Apple TV+": 0.1,
+      "Paramount+": 0.05,
+    },
+    sentimentByName: {
+      "Netflix": 0.55,
+      "Disney+": 0.55,
+      "Max": 0.4,
+      "Amazon Prime Video": 0.35,
+      "Apple TV+": 0.5,
+      "Paramount+": 0.05,
+    },
+    praisedByName: {
+      "Netflix": ["recommendations", "reliability"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Netflix and Disney+ tied on UX polish; Disney+ wins for family flows.",
+      "Amazon Prime UX inconsistent — buy-vs-rent confusion surfaces repeatedly.",
+      "Paramount+ framed as transactional and ad-heavy.",
+    ],
+  },
+  {
+    hoursAgo: 1 * 24,
+    prompt: "Which brand is most associated with premium quality, status, or exclusivity?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.18,
+      "Disney+": 0.14,
+      "Max": 0.32,
+      "Amazon Prime Video": 0.05,
+      "Apple TV+": 0.27,
+      "Paramount+": 0.04,
+    },
+    sentimentByName: {
+      "Netflix": 0.35,
+      "Disney+": 0.4,
+      "Max": 0.6,
+      "Amazon Prime Video": 0.0,
+      "Apple TV+": 0.6,
+      "Paramount+": -0.05,
+    },
+    praisedByName: {
+      "Netflix": ["originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige", "content_quality"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["quality", "originals"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Max and Apple TV+ split the premium narrative: HBO heritage vs Apple polish.",
+      "Amazon Prime firmly outside the prestige tier despite its scale.",
+      "Paramount+ seldom present in premium conversations.",
+    ],
+  },
+  {
+    hoursAgo: 12,
+    prompt: "How is {brand}'s value for money perceived?",
+    promptKind: "brand_specific",
+    shareByName: {
+      "Netflix": 0.14,
+      "Disney+": 0.18,
+      "Max": 0.07,
+      "Amazon Prime Video": 0.32,
+      "Apple TV+": 0.08,
+      "Paramount+": 0.21,
+    },
+    sentimentByName: {
+      "Netflix": 0.05,
+      "Disney+": 0.45,
+      "Max": -0.05,
+      "Amazon Prime Video": 0.6,
+      "Apple TV+": -0.05,
+      "Paramount+": 0.5,
+    },
+    praisedByName: {
+      "Netflix": ["originals"],
+      "Disney+": ["family", "bundle"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["value", "bundle"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["value", "sports"],
+    },
+    evidence: [
+      "Amazon Prime retains value ownership week over week thanks to the Prime bundle.",
+      "Netflix value sentiment near-neutral — ad-tier helps but pricing fatigue persists.",
+      "Apple TV+ called out as 'expensive for what you get' on small library.",
+    ],
+  },
+  {
+    hoursAgo: 6,
+    prompt: "Who is widely seen as the most reliable choice when the stakes are high?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.34,
+      "Disney+": 0.23,
+      "Max": 0.16,
+      "Amazon Prime Video": 0.13,
+      "Apple TV+": 0.08,
+      "Paramount+": 0.06,
+    },
+    sentimentByName: {
+      "Netflix": 0.6,
+      "Disney+": 0.5,
+      "Max": 0.5,
+      "Amazon Prime Video": 0.35,
+      "Apple TV+": 0.45,
+      "Paramount+": 0.05,
+    },
+    praisedByName: {
+      "Netflix": ["reliability", "leadership", "originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Netflix reliability narrative strongest for 'I just want something to work'.",
+      "Disney+ reliable for family viewing; Paramount+ rarely cited as a high-stakes pick.",
+      "Apple TV+ reliable but constrained by smaller library footprint.",
+    ],
+  },
+  {
+    hoursAgo: 3,
+    prompt: "How is {brand}'s pace of innovation seen relative to peers?",
+    promptKind: "brand_specific",
+    shareByName: {
+      "Netflix": 0.21,
+      "Disney+": 0.13,
+      "Max": 0.1,
+      "Amazon Prime Video": 0.1,
+      "Apple TV+": 0.37,
+      "Paramount+": 0.09,
+    },
+    sentimentByName: {
+      "Netflix": 0.3,
+      "Disney+": 0.25,
+      "Max": 0.2,
+      "Amazon Prime Video": 0.15,
+      "Apple TV+": 0.65,
+      "Paramount+": 0.0,
+    },
+    praisedByName: {
+      "Netflix": ["originals", "recommendations"],
+      "Disney+": ["family"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["innovation", "quality", "originals"],
+      "Paramount+": ["scrappy"],
+    },
+    evidence: [
+      "Apple TV+ extends innovation lead week over week with prestige originals.",
+      "Netflix innovation share lags expected scale; framed as 'mature' not 'next'.",
+      "Paramount+ registers a flat-to-negative innovation sentiment.",
+    ],
+  },
+  {
+    hoursAgo: 1,
+    prompt: "Who is most often described as gaining ground versus those losing relevance?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.26,
+      "Disney+": 0.16,
+      "Max": 0.13,
+      "Amazon Prime Video": 0.16,
+      "Apple TV+": 0.21,
+      "Paramount+": 0.08,
+    },
+    sentimentByName: {
+      "Netflix": 0.45,
+      "Disney+": 0.3,
+      "Max": 0.3,
+      "Amazon Prime Video": 0.35,
+      "Apple TV+": 0.6,
+      "Paramount+": 0.05,
+    },
+    praisedByName: {
+      "Netflix": ["leadership", "originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle", "value"],
+      "Apple TV+": ["innovation", "quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Apple TV+ rising fastest; Netflix holding steady at the top of the chart.",
+      "Paramount+ consistently framed as fighting for relevance.",
+      "Disney+ and Max trade incremental ground week to week.",
+    ],
+  },
+];
+
+function ensureBrand(name: string): Brand {
+  for (const existing of store.brands.values()) {
+    if (existing.name === name) {
+      return existing;
+    }
+  }
+  const brand: Brand = { id: crypto.randomUUID(), name };
+  store.brands.set(brand.id, brand);
+  return brand;
+}
+
+function ensureCompetitorSet(accountBrand: Brand, competitors: Brand[]): CompetitorSet {
+  for (const set of store.competitorSets.values()) {
+    if (set.accountBrandId === accountBrand.id) {
+      return set;
+    }
+  }
+  if (competitors.length !== 5) {
+    throw new Error("Demo seed expects exactly five competitors.");
+  }
+  const set: CompetitorSet = {
+    id: crypto.randomUUID(),
+    accountBrandId: accountBrand.id,
+    competitorBrandIds: [
+      competitors[0]!.id,
+      competitors[1]!.id,
+      competitors[2]!.id,
+      competitors[3]!.id,
+      competitors[4]!.id,
+    ],
+    createdAt: new Date().toISOString(),
+  };
+  store.competitorSets.set(set.id, set);
+  return set;
+}
+
+function remapByBrandId(map: Record<string, number | string[]>, byName: Record<string, Brand>) {
+  const result: Record<string, number | string[]> = {};
+  for (const [name, value] of Object.entries(map)) {
+    const brand = byName[name];
+    if (brand) {
+      result[brand.id] = value;
+    }
+  }
+  return result;
+}
+
+function buildGapEvents(brandsByName: Record<string, Brand>, promptRunsByIndex: PromptRun[]): GapEvent[] {
+  const netflix = brandsByName["Netflix"]!;
+  const amazon = brandsByName["Amazon Prime Video"]!;
+  const apple = brandsByName["Apple TV+"]!;
+
+  return [
+    {
+      id: crypto.randomUUID(),
+      gapType: "feature_praise_gap",
+      brandId: netflix.id,
+      competitorBrandId: amazon.id,
+      promptRunId: promptRunsByIndex[2]!.id,
+      featureKey: "value",
+      evidence: ["Amazon Prime is repeatedly praised on value via the Prime bundle; Netflix is unmentioned."],
+      confidence: 0.78,
+      detectedAt: new Date().toISOString(),
+    },
+    {
+      id: crypto.randomUUID(),
+      gapType: "feature_praise_gap",
+      brandId: netflix.id,
+      competitorBrandId: apple.id,
+      promptRunId: promptRunsByIndex[3]!.id,
+      featureKey: "innovation",
+      evidence: ["Apple TV+ owns the innovation narrative via prestige originals; Netflix barely mentioned."],
+      confidence: 0.71,
+      detectedAt: new Date().toISOString(),
+    },
+    {
+      id: crypto.randomUUID(),
+      gapType: "whitespace",
+      brandId: netflix.id,
+      promptRunId: promptRunsByIndex[6]!.id,
+      categoryKey: "live_sports",
+      evidence: [
+        "Live-sports prompts surface Amazon Prime Video and Paramount+; Netflix absent from the consensus answer.",
+      ],
+      confidence: 0.66,
+      detectedAt: new Date().toISOString(),
+    },
+  ];
+}
+
+export interface DemoSeedSummary {
+  accountBrandId: string;
+  competitorBrandIds: string[];
+  promptRunCount: number;
+  comparisonCount: number;
+  gapEventCount: number;
+}
+
+export function loadStreamingSeed(): DemoSeedSummary {
+  const accountBrand = ensureBrand(ACCOUNT_BRAND_NAME);
+  const competitorBrands = COMPETITOR_NAMES.map((name) => ensureBrand(name));
+  ensureCompetitorSet(accountBrand, competitorBrands);
+
+  const brandsByName: Record<string, Brand> = { [accountBrand.name]: accountBrand };
+  for (const brand of competitorBrands) {
+    brandsByName[brand.name] = brand;
+  }
+
+  const now = Date.now();
+  const promptRuns: PromptRun[] = [];
+  const comparisons: ComparativeDelta[] = [];
+
+  for (const scripted of SCRIPTED_COMPARISONS) {
+    const createdAt = new Date(now - scripted.hoursAgo * 60 * 60 * 1000).toISOString();
+    const run: PromptRun = {
+      id: crypto.randomUUID(),
+      promptSetId: seedPromptSetId,
+      prompt: scripted.prompt,
+      promptKind: scripted.promptKind,
+      model: MODEL,
+      createdAt,
+    };
+    store.promptRuns.set(run.id, run);
+    promptRuns.push(run);
+
+    const comparison: ComparativeDelta = {
+      promptRunId: run.id,
+      shareOfVoiceByBrand: remapByBrandId(scripted.shareByName, brandsByName) as Record<string, number>,
+      sentimentByBrand: remapByBrandId(scripted.sentimentByName, brandsByName) as Record<string, number>,
+      praisedFeaturesByBrand: remapByBrandId(scripted.praisedByName, brandsByName) as Record<string, string[]>,
+      evidence: scripted.evidence,
+    };
+    store.comparisons.push(comparison);
+    comparisons.push(comparison);
+  }
+
+  const gapEvents = buildGapEvents(brandsByName, promptRuns);
+  store.gapEvents.push(...gapEvents);
+
+  return {
+    accountBrandId: accountBrand.id,
+    competitorBrandIds: competitorBrands.map((b) => b.id),
+    promptRunCount: promptRuns.length,
+    comparisonCount: comparisons.length,
+    gapEventCount: gapEvents.length,
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,15 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { loadStreamingSeed } from "../seed/streaming";
 import { businessRoutes } from "./routes/business";
 import { competitiveRoutes } from "./routes/competitive";
+
+if ((process.env.PERCEPTION_DEMO_SEED ?? "1") !== "0") {
+  const summary = loadStreamingSeed();
+  console.log(
+    `[seed] Loaded streaming demo cohort: ${summary.promptRunCount} prompt runs, ${summary.comparisonCount} comparisons, ${summary.gapEventCount} gap events.`,
+  );
+}
 
 const app = new Hono();
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,13 +1,21 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { loadNetflixProfileSeed } from "../seed/netflix-profile";
 import { loadStreamingSeed } from "../seed/streaming";
 import { businessRoutes } from "./routes/business";
 import { competitiveRoutes } from "./routes/competitive";
 
 if ((process.env.PERCEPTION_DEMO_SEED ?? "1") !== "0") {
-  const summary = loadStreamingSeed();
+  const cohort = loadStreamingSeed();
   console.log(
-    `[seed] Loaded streaming demo cohort: ${summary.promptRunCount} prompt runs, ${summary.comparisonCount} comparisons, ${summary.gapEventCount} gap events.`,
+    `[seed] Loaded streaming demo cohort: ${cohort.promptRunCount} prompt runs, ${cohort.comparisonCount} comparisons, ${cohort.gapEventCount} gap events.`,
+  );
+
+  const profile = loadNetflixProfileSeed();
+  console.log(
+    profile.created
+      ? `[seed] Created Netflix business profile (${profile.profileId}) with ${profile.monitoringCount} monitoring prompts.`
+      : `[seed] Netflix business profile already exists (${profile.profileId}); ${profile.monitoringCount} monitoring prompts.`,
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from "react";
 import "./app.css";
 import { CompetitivePage } from "./pages/competitive";
 import { MonitoringPage } from "./pages/monitoring";
+import { RecommendationsPage } from "./pages/recommendations";
+import { SourcesPage } from "./pages/sources";
+import { DEMO_BRAND_NAME } from "./seed/demo-content";
 import type { BusinessProfile } from "./types";
 
 const API_BASE =
@@ -71,7 +74,9 @@ export function App() {
       .then((res) => res.json())
       .then((body: { profiles: BusinessProfile[] }) => {
         setProfiles(body.profiles);
-        setActiveProfileId(body.profiles[0]?.id ?? "");
+        // Prefer the seeded demo brand if it exists, otherwise the first profile.
+        const seeded = body.profiles.find((p) => p.name === DEMO_BRAND_NAME);
+        setActiveProfileId((seeded ?? body.profiles[0])?.id ?? "");
       })
       .catch(() => setError("Could not load business profiles."))
       .finally(() => setLoading(false));
@@ -184,22 +189,10 @@ export function ProfileDashboard({
           <MonitoringPage profile={profile} />
         ) : activePage === "benchmarking" ? (
           <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
+        ) : activePage === "recommendations" ? (
+          <RecommendationsPage profile={profile} />
         ) : (
-          <article className="panel">
-            <p className="muted">{page[1]}</p>
-            <h2>{profile.name}</h2>
-            <p>{page[2]}</p>
-            <dl>
-              <div>
-                <dt>Website</dt>
-                <dd>{profile.website}</dd>
-              </div>
-              <div>
-                <dt>Description</dt>
-                <dd>{profile.description}</dd>
-              </div>
-            </dl>
-          </article>
+          <SourcesPage profile={profile} />
         )}
 
         {error && <p className="error">{error}</p>}

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -8,9 +8,9 @@ interface Props {
   onSave?: (names: string[]) => Promise<void>;
 }
 
-/** Demo cohort: Sephora vs five beauty retail competitors */
-const DEFAULT_ACCOUNT = "Sephora";
-const DEFAULT_COMPETITORS = ["Ulta", "Bluemercury", "SpaceNK", "SallyBeauty", "Olive Young"];
+/** Demo cohort: Netflix vs five major streaming competitors */
+const DEFAULT_ACCOUNT = "Netflix";
+const DEFAULT_COMPETITORS = ["Disney+", "Max", "Amazon Prime Video", "Apple TV+", "Paramount+"];
 
 export function CompetitiveSetPicker({
   accountBrandName: initialAccountBrandName = DEFAULT_ACCOUNT,

--- a/web/src/components/competitive/__tests__/components.test.tsx
+++ b/web/src/components/competitive/__tests__/components.test.tsx
@@ -4,12 +4,12 @@ import { CompetitiveSetPicker } from "../CompetitiveSetPicker";
 import { WhitespacePanel } from "../WhitespacePanel";
 
 describe("competitive components", () => {
-  test("renders Sephora demo defaults and 5 competitor slots", () => {
+  test("renders streaming demo defaults and 5 competitor slots", () => {
     const html = renderToStaticMarkup(<CompetitiveSetPicker onCreate={async () => {}} />);
     expect(html.includes("Competitor 5")).toBeTrue();
-    expect(html.includes("Sephora")).toBeTrue();
-    expect(html.includes("Ulta")).toBeTrue();
-    expect(html.includes("Olive Young")).toBeTrue();
+    expect(html.includes("Netflix")).toBeTrue();
+    expect(html.includes("Disney+")).toBeTrue();
+    expect(html.includes("Paramount+")).toBeTrue();
   });
 
   test("renders whitespace counts", () => {

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -281,11 +281,11 @@ export function CompetitivePage({
     <main style={{ maxWidth: 1100, margin: "0 auto", padding: 24, fontFamily: "Inter, Arial, sans-serif" }}>
       <h1>Competitive Benchmarking</h1>
       <p style={{ marginTop: 0 }}>
-        Each run uses <strong>10 brand-specific prompts</strong> (with each retailer’s name) plus{" "}
-        <strong>10 category-wide prompts</strong> (leader, best, most reliable, etc.), all answered per retailer;
-        outputs are compared and rolled into share of voice and sentiment. Default slate:{" "}
-        <strong>Sephora</strong> vs <strong>Ulta</strong>, <strong>Bluemercury</strong>, <strong>SpaceNK</strong>,{" "}
-        <strong>SallyBeauty</strong>, and <strong>Olive Young</strong>.
+        Each run uses <strong>10 brand-specific prompts</strong> (with each brand’s name) plus{" "}
+        <strong>10 category-wide prompts</strong> (leader, best, most reliable, etc.), all answered per brand;
+        outputs are compared and rolled into share of voice and sentiment. Demo slate:{" "}
+        <strong>Netflix</strong> vs <strong>Disney+</strong>, <strong>Max</strong>,{" "}
+        <strong>Amazon Prime Video</strong>, <strong>Apple TV+</strong>, and <strong>Paramount+</strong>.
       </p>
 
       <CompetitiveSetPicker

--- a/web/src/pages/recommendations.tsx
+++ b/web/src/pages/recommendations.tsx
@@ -1,0 +1,56 @@
+import {
+  DEMO_BRAND_NAME,
+  NETFLIX_RECOMMENDATIONS,
+  type Recommendation,
+} from "../seed/demo-content";
+import type { BusinessProfile } from "../types";
+
+function categoryLabel(category: Recommendation["category"]) {
+  return category === "content"
+    ? "On-site content"
+    : category === "earned_media"
+      ? "Earned media"
+      : "Technical";
+}
+
+export function RecommendationsPage({ profile }: { profile: BusinessProfile }) {
+  const isSeededBrand = profile.name === DEMO_BRAND_NAME;
+  const recs = isSeededBrand ? NETFLIX_RECOMMENDATIONS : [];
+
+  if (recs.length === 0) {
+    return (
+      <article className="panel wide-panel">
+        <p className="muted">Recommendations</p>
+        <h2>No recommendations for {profile.name} yet</h2>
+        <p>Run a benchmark on Benchmarking to surface gaps; we&rsquo;ll prioritise fix-it ideas here.</p>
+      </article>
+    );
+  }
+
+  return (
+    <article className="panel wide-panel">
+      <p className="muted">Recommendations</p>
+      <h2>Prioritised actions for {profile.name}</h2>
+      <p className="muted">
+        Each card maps to a detected gap or whitespace opportunity. Sorted high-impact first.
+      </p>
+      <ul className="rec-list">
+        {recs.map((rec) => (
+          <li key={rec.id} className="rec-card">
+            <header className="rec-card__head">
+              <span className="rec-card__category">{categoryLabel(rec.category)}</span>
+              <span className={`rec-tag rec-tag--${rec.impact}`}>{rec.impact} impact</span>
+              <span className="rec-tag rec-tag--effort">{rec.effort} effort</span>
+            </header>
+            <h3 className="rec-card__title">{rec.title}</h3>
+            <p className="rec-card__evidence">{rec.evidence}</p>
+            <div className="rec-card__action">
+              <span className="rec-card__action-label">Suggested action</span>
+              <p>{rec.action}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/web/src/pages/sources.tsx
+++ b/web/src/pages/sources.tsx
@@ -1,0 +1,97 @@
+import {
+  DEMO_BRAND_NAME,
+  NETFLIX_SOURCES,
+  type CitedSource,
+} from "../seed/demo-content";
+import type { BusinessProfile } from "../types";
+
+function sourceBadge(type: CitedSource["sourceType"]) {
+  const map: Record<CitedSource["sourceType"], string> = {
+    reddit: "Reddit",
+    publication: "News",
+    review: "Review",
+    video: "YouTube",
+    wiki: "Wiki",
+  };
+  return map[type];
+}
+
+export function SourcesPage({ profile }: { profile: BusinessProfile }) {
+  const isSeededBrand = profile.name === DEMO_BRAND_NAME;
+  const sources = isSeededBrand ? NETFLIX_SOURCES : [];
+
+  if (sources.length === 0) {
+    return (
+      <article className="panel wide-panel">
+        <p className="muted">Sources</p>
+        <h2>No source attributions for {profile.name} yet</h2>
+        <p>
+          Run a benchmark with citation tracking enabled to surface the third-party sources AI assistants
+          cite when answering about this brand.
+        </p>
+      </article>
+    );
+  }
+
+  const totalCitations = sources.reduce((acc, s) => acc + s.citationsThisWeek, 0);
+  const reddit = sources
+    .filter((s) => s.sourceType === "reddit")
+    .reduce((acc, s) => acc + s.citationsThisWeek, 0);
+  const newsAndReviews = sources
+    .filter((s) => s.sourceType === "publication" || s.sourceType === "review")
+    .reduce((acc, s) => acc + s.citationsThisWeek, 0);
+
+  return (
+    <article className="panel wide-panel">
+      <p className="muted">Sources</p>
+      <h2>What AI cites about {profile.name}</h2>
+      <p className="muted">
+        The third-party sources frontier models reach for when answering questions about this brand.
+        Counts are citations across the last 7 days of monitoring runs.
+      </p>
+
+      <div className="sources-stat-row">
+        <div className="sources-stat">
+          <div className="sources-stat__label">Citations / week</div>
+          <div className="sources-stat__value">{totalCitations}</div>
+        </div>
+        <div className="sources-stat">
+          <div className="sources-stat__label">Reddit</div>
+          <div className="sources-stat__value">{reddit}</div>
+        </div>
+        <div className="sources-stat">
+          <div className="sources-stat__label">News & reviews</div>
+          <div className="sources-stat__value">{newsAndReviews}</div>
+        </div>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th align="left">Source</th>
+            <th align="left" style={{ width: "12%" }}>Type</th>
+            <th align="left" style={{ width: "26%" }}>Brands mentioned</th>
+            <th align="left" style={{ width: "14%" }}>Sentiment</th>
+            <th align="right" style={{ width: "10%" }}>Citations</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sources.map((s) => (
+            <tr key={s.id}>
+              <td>
+                <div className="sources-row__title">{s.title}</div>
+                <div className="sources-row__domain">{s.domain}</div>
+              </td>
+              <td><span className="source-badge">{sourceBadge(s.sourceType)}</span></td>
+              <td>{s.brandsMentioned.join(", ")}</td>
+              <td>
+                <span className={`sentiment sentiment-${s.sentiment}`}>{s.sentiment}</span>
+              </td>
+              <td style={{ textAlign: "right", fontWeight: 600 }}>{s.citationsThisWeek}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </article>
+  );
+}

--- a/web/src/seed/demo-content.ts
+++ b/web/src/seed/demo-content.ts
@@ -1,0 +1,189 @@
+/**
+ * Centralized demo content for the seeded Netflix brand. Powers the
+ * Recommendations and Sources sections so every sidebar tab has real
+ * content on first paint without requiring a benchmark run.
+ *
+ * Tied to the streaming cohort seeded server-side in
+ * `server/seed/streaming.ts`. If the active business profile name does not
+ * match `DEMO_BRAND_NAME`, page components fall back to an empty state.
+ */
+
+export const DEMO_BRAND_NAME = "Netflix";
+
+export type RecommendationCategory = "content" | "earned_media" | "technical";
+export type ImpactLevel = "high" | "medium" | "low";
+export type EffortLevel = "low" | "medium" | "high";
+
+export interface Recommendation {
+  id: string;
+  title: string;
+  category: RecommendationCategory;
+  impact: ImpactLevel;
+  effort: EffortLevel;
+  evidence: string;
+  action: string;
+}
+
+export const NETFLIX_RECOMMENDATIONS: Recommendation[] = [
+  {
+    id: "rec-1",
+    title: "Reclaim the value narrative from Amazon Prime",
+    category: "content",
+    impact: "high",
+    effort: "medium",
+    evidence:
+      "Amazon Prime owns 34% share-of-voice on the value-for-money prompt; Netflix is at 13% with neutral sentiment. Bundling and the ads-tier story aren't landing in AI answers.",
+    action:
+      "Publish a comparison page that explicitly addresses 'Netflix vs Amazon Prime: what you actually pay for' with hard prices and per-show CPMs. Pitch one Verge or Wired piece quoting these numbers.",
+  },
+  {
+    id: "rec-2",
+    title: "Counter Apple TV+ on the innovation narrative",
+    category: "earned_media",
+    impact: "high",
+    effort: "high",
+    evidence:
+      "Apple TV+ holds 36% share-of-voice on the most-innovative prompt with a +0.65 sentiment, the highest in the cohort. Netflix's prestige originals (Stranger Things, The Crown) aren't getting cited as 'innovative'.",
+    action:
+      "Brief 3 critic-press contacts (NYT, Vulture, IndieWire) on the technical innovation behind Squid Game S2 and 3 Body Problem — VFX pipeline, simul-release infrastructure. Frame Netflix as the platform that scales prestige.",
+  },
+  {
+    id: "rec-3",
+    title: "Plant a flag in live-sports whitespace",
+    category: "content",
+    impact: "medium",
+    effort: "high",
+    evidence:
+      "No streaming brand owns the consensus answer on live-sports prompts. Amazon Prime Video and Paramount+ split the small share that exists.",
+    action:
+      "Lean into the NFL Christmas slate and WWE Raw deal in next quarter's PR cycle. Get a 'Netflix is now a sports destination' op-ed placed in The Athletic or Sports Business Journal.",
+  },
+  {
+    id: "rec-4",
+    title: "Claim the recommendations-engine narrative",
+    category: "technical",
+    impact: "medium",
+    effort: "low",
+    evidence:
+      "Netflix's recommendation engine surfaces in only 4 of 20 prompts despite being the historical brand pillar. AI assistants default to 'large library' rather than 'best discovery'.",
+    action:
+      "Update the help center and About page with discoverability-focused copy. Add structured data (FAQ schema) on the Top 10 lists so chatbots can cite per-country recommendations directly.",
+  },
+  {
+    id: "rec-5",
+    title: "Defend on the family-friendly narrative",
+    category: "earned_media",
+    impact: "low",
+    effort: "low",
+    evidence:
+      "Disney+ owns 21% share-of-voice on family prompts vs Netflix at 9%. Disney's IP advantage is structural, but Netflix's kids slate (CoComelon, Gabby's Dollhouse) isn't getting cited.",
+    action:
+      "Sponsor 2-3 family-influencer reviews on YouTube with structured 'best for ages 4-8' framing. AI chatbots cite YouTube transcripts heavily.",
+  },
+];
+
+export type SourceType = "reddit" | "publication" | "review" | "video" | "wiki";
+export type CitedSentiment = "positive" | "neutral" | "negative";
+
+export interface CitedSource {
+  id: string;
+  domain: string;
+  title: string;
+  citationsThisWeek: number;
+  brandsMentioned: string[];
+  sentiment: CitedSentiment;
+  sourceType: SourceType;
+}
+
+export const NETFLIX_SOURCES: CitedSource[] = [
+  {
+    id: "src-1",
+    domain: "reddit.com",
+    title: "r/television · 'Best streaming service for 2026?'",
+    citationsThisWeek: 14,
+    brandsMentioned: ["Netflix", "Disney+", "Max", "Apple TV+"],
+    sentiment: "neutral",
+    sourceType: "reddit",
+  },
+  {
+    id: "src-2",
+    domain: "theverge.com",
+    title: "Streaming wars 2026: who's winning the prestige race",
+    citationsThisWeek: 9,
+    brandsMentioned: ["Apple TV+", "Max", "Netflix"],
+    sentiment: "negative",
+    sourceType: "publication",
+  },
+  {
+    id: "src-3",
+    domain: "nytimes.com",
+    title: "What the Netflix Q4 numbers actually tell us",
+    citationsThisWeek: 8,
+    brandsMentioned: ["Netflix"],
+    sentiment: "positive",
+    sourceType: "publication",
+  },
+  {
+    id: "src-4",
+    domain: "reddit.com",
+    title: "r/NetflixBestOf · weekly recommendation thread",
+    citationsThisWeek: 7,
+    brandsMentioned: ["Netflix"],
+    sentiment: "positive",
+    sourceType: "reddit",
+  },
+  {
+    id: "src-5",
+    domain: "youtube.com",
+    title: "MarquesBrownlee · Apple TV+ review (Severance S2)",
+    citationsThisWeek: 6,
+    brandsMentioned: ["Apple TV+", "Netflix"],
+    sentiment: "negative",
+    sourceType: "video",
+  },
+  {
+    id: "src-6",
+    domain: "deadline.com",
+    title: "Inside the streaming-bundle pricing war",
+    citationsThisWeek: 6,
+    brandsMentioned: ["Amazon Prime Video", "Disney+", "Max", "Netflix"],
+    sentiment: "neutral",
+    sourceType: "publication",
+  },
+  {
+    id: "src-7",
+    domain: "rottentomatoes.com",
+    title: "Top streaming picks · January 2026",
+    citationsThisWeek: 5,
+    brandsMentioned: ["Netflix", "Max", "Apple TV+"],
+    sentiment: "positive",
+    sourceType: "review",
+  },
+  {
+    id: "src-8",
+    domain: "wikipedia.org",
+    title: "List of Netflix original programming",
+    citationsThisWeek: 5,
+    brandsMentioned: ["Netflix"],
+    sentiment: "neutral",
+    sourceType: "wiki",
+  },
+  {
+    id: "src-9",
+    domain: "reddit.com",
+    title: "r/Sports · 'NFL Christmas Day on Netflix worth it?'",
+    citationsThisWeek: 4,
+    brandsMentioned: ["Netflix", "Amazon Prime Video", "Paramount+"],
+    sentiment: "neutral",
+    sourceType: "reddit",
+  },
+  {
+    id: "src-10",
+    domain: "vulture.com",
+    title: "Why Netflix's catalogue still wins on volume",
+    citationsThisWeek: 4,
+    brandsMentioned: ["Netflix"],
+    sentiment: "positive",
+    sourceType: "publication",
+  },
+];


### PR DESCRIPTION
## Summary
- adds `server/seed/streaming.ts` — a recognisable streaming-services cohort (Netflix vs Disney+, Max, Amazon Prime Video, Apple TV+, Paramount+) with 7 days of synthetic competitive history: 10 prompt runs, 10 comparisons, 3 gap events
- auto-loads on server boot in `server/src/index.ts`; opt out with `PERCEPTION_DEMO_SEED=0`
- updates `web/src/components/competitive/CompetitiveSetPicker.tsx` so the default brand inputs match the seed (Netflix + 5 streaming competitors)
- adds `DEMO.md` at the repo root: a 7-9 minute demo-day walkthrough with pre-flight checks, exact lines to say, things to point at, Q&A prep, and a backup script if the live run breaks
- skips seeding `AIAnswer` rows (overview/trends only read prompt runs + comparisons, so they're not needed)

## Why
**Why streaming services**: the previous Sephora cohort used SpaceNK / SallyBeauty / Olive Young — names half the demo audience won't recognise. Streaming is universally identifiable and the narrative differentiation is sharper:
- Netflix dominates `leader / best overall` (~38% SoV)
- Amazon Prime owns `value` via the Prime bundle
- Apple TV+ owns `innovation` via prestige originals
- Max owns `premium` via HBO heritage
- Disney+ owns `family` via Marvel / Star Wars / Pixar
- Paramount+ trails, wins narrowly on live sports

That gives the demo two punchy gap events (Netflix missing on `value` and `innovation`) plus one whitespace opportunity (`live_sports`) — all visible without anyone clicking Run.

**Why the seed exists at all**: the Zoom demo slot is 7-9 minutes and the dashboard shouldn't open empty or require a live LLM run before the audience sees anything. With this seed plus the `/competitive/snapshot` endpoint (PR #32), the dashboard hydrates on first paint with 7 days of trend data, share-of-voice, sentiment, and gap events.

**Why DEMO.md**: removes the cognitive load of remembering what to say. Lives at the repo root for visibility — easy to find from the file tree the morning of the demo.

## Test plan
- [x] `bun test` (11/11 pass on this branch)
- [x] `bun run dev` → server boot log shows `[seed] Loaded streaming demo cohort: 10 prompt runs, 10 comparisons, 3 gap events.`
- [x] `curl /competitive/overview?windowStart=...&windowEnd=...` returns 6 brands with shareOfVoice + sentiment + topFeatures
- [x] `curl /competitive/trends?...` returns trend points spread across the last 7 days
- [x] Open the dashboard → picker is pre-filled with Netflix + 5 streaming competitors

## Stacked with
PR #32 (`feat/demo-polish`) consumes this seed via `/competitive/snapshot` to render a populated dashboard on first paint. Either order works for merging; together they're the demo experience.