### PR TITLE
Replace live run stream with typewriter theater

### DIFF
--- a/web/src/components/competitive/LiveRunTheater.tsx
+++ b/web/src/components/competitive/LiveRunTheater.tsx
@@ -1,0 +1,209 @@
+import { useMemo } from "react";
+
+const TOTAL_PROMPTS_PER_BRAND = 20;
+
+const BRAND_ACCENTS = ["#b3251f", "#1f5fa8", "#2f8a4d", "#a76b1f", "#5d3a8b", "#1f7a83"];
+
+export interface BrandProgressBox {
+  brandName: string;
+  status: string;
+  activePrompt: string;
+  lines: string[];
+  completedPrompts: number;
+}
+
+interface LiveRunTheaterProps {
+  busy: boolean;
+  progressStatus: string;
+  judgeLines: string[];
+  progressByBrand: Record<string, BrandProgressBox>;
+}
+
+function isStreaming(box: BrandProgressBox) {
+  return box.completedPrompts < TOTAL_PROMPTS_PER_BRAND && box.lines.length > 0;
+}
+
+function progressPct(box: BrandProgressBox) {
+  return Math.min(100, Math.round((box.completedPrompts / TOTAL_PROMPTS_PER_BRAND) * 100));
+}
+
+export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBrand }: LiveRunTheaterProps) {
+  const brandEntries = useMemo(() => Object.entries(progressByBrand), [progressByBrand]);
+  const visible = brandEntries.length > 0 || judgeLines.length > 0 || busy;
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <section className="theater">
+      <style>{theaterStyles}</style>
+      <header className="theater__header">
+        <h3 className="theater__title">Live Run Theater</h3>
+        <p className="theater__status">{progressStatus}</p>
+      </header>
+
+      {judgeLines.length > 0 && (
+        <aside className="theater__judge">
+          <span className="theater__judge-label">Judge</span>
+          <pre className="theater__judge-text">{judgeLines.join("\n")}</pre>
+        </aside>
+      )}
+
+      <div className="theater__columns">
+        {brandEntries.map(([brandId, box], index) => {
+          const accent = BRAND_ACCENTS[index % BRAND_ACCENTS.length];
+          const streaming = isStreaming(box);
+          const pct = progressPct(box);
+          return (
+            <article key={brandId} className="theater__column" style={{ borderTopColor: accent }}>
+              <div className="theater__column-head">
+                <h4 className="theater__column-title">{box.brandName}</h4>
+                <span className="theater__column-count">
+                  {box.completedPrompts}/{TOTAL_PROMPTS_PER_BRAND}
+                </span>
+              </div>
+              <div className="theater__progress">
+                <div className="theater__progress-bar" style={{ width: `${pct}%`, background: accent }} />
+              </div>
+              <p className="theater__column-status">{box.status}</p>
+              <pre className="theater__stream" data-empty={box.lines.length === 0}>
+                {box.lines.length === 0 ? "Waiting for streamed output…" : box.lines.join("\n")}
+                {streaming && <span className="theater__cursor" style={{ background: accent }} />}
+              </pre>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+const theaterStyles = `
+.theater {
+  margin-bottom: 16px;
+  border: 1px solid #e6e0d4;
+  border-radius: 10px;
+  padding: 18px 20px 22px;
+  background:
+    radial-gradient(circle at 12% -10%, rgba(179, 37, 31, 0.06), transparent 55%),
+    radial-gradient(circle at 110% 110%, rgba(31, 95, 168, 0.05), transparent 60%),
+    #fbf8f1;
+  font-family: "Iowan Old Style", "Hoefler Text", "Source Serif Pro", Georgia, serif;
+  color: #1f1b16;
+}
+.theater__header { margin-bottom: 14px; }
+.theater__title {
+  margin: 0 0 4px;
+  font-size: 22px;
+  letter-spacing: 0.01em;
+  font-weight: 600;
+}
+.theater__status {
+  margin: 0;
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 12px;
+  color: #5b5347;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.theater__judge {
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(31, 27, 22, 0.04);
+  border: 1px dashed rgba(31, 27, 22, 0.18);
+}
+.theater__judge-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #5b5347;
+  margin-bottom: 4px;
+}
+.theater__judge-text {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #2c261d;
+}
+.theater__columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.theater__column {
+  border: 1px solid #ece4d3;
+  border-top: 3px solid currentColor;
+  border-radius: 8px;
+  padding: 12px 14px 14px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+  box-shadow: 0 1px 0 rgba(31, 27, 22, 0.04);
+}
+.theater__column-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.theater__column-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+.theater__column-count {
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 11px;
+  color: #5b5347;
+  letter-spacing: 0.06em;
+}
+.theater__progress {
+  margin: 8px 0 6px;
+  height: 3px;
+  background: rgba(31, 27, 22, 0.08);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.theater__progress-bar {
+  height: 100%;
+  transition: width 240ms ease-out;
+}
+.theater__column-status {
+  margin: 0 0 8px;
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 11px;
+  color: #5b5347;
+  letter-spacing: 0.04em;
+  min-height: 1.4em;
+}
+.theater__stream {
+  margin: 0;
+  flex-grow: 1;
+  white-space: pre-wrap;
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #1f1b16;
+}
+.theater__stream[data-empty="true"] {
+  color: #a39a87;
+  font-style: italic;
+}
+.theater__cursor {
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: -2px;
+  animation: theaterBlink 1s steps(2, end) infinite;
+}
+@keyframes theaterBlink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+`;

--- a/web/src/components/competitive/__tests__/components.test.tsx
+++ b/web/src/components/competitive/__tests__/components.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { CompetitiveSetPicker } from "../CompetitiveSetPicker";
+import { LiveRunTheater } from "../LiveRunTheater";
 import { WhitespacePanel } from "../WhitespacePanel";
 
 describe("competitive components", () => {
@@ -10,6 +11,36 @@ describe("competitive components", () => {
     expect(html.includes("Sephora")).toBeTrue();
     expect(html.includes("Ulta")).toBeTrue();
     expect(html.includes("Olive Young")).toBeTrue();
+  });
+
+  test("LiveRunTheater renders nothing when idle", () => {
+    const html = renderToStaticMarkup(
+      <LiveRunTheater busy={false} progressStatus="" judgeLines={[]} progressByBrand={{}} />,
+    );
+    expect(html).toBe("");
+  });
+
+  test("LiveRunTheater shows columns and progress while running", () => {
+    const html = renderToStaticMarkup(
+      <LiveRunTheater
+        busy
+        progressStatus="Streaming brand summaries..."
+        judgeLines={["who leads"]}
+        progressByBrand={{
+          b1: {
+            brandName: "Sephora",
+            status: "Streaming brand_specific summary…",
+            activePrompt: "How is Sephora perceived?",
+            lines: ["Sephora is widely regarded as a leader"],
+            completedPrompts: 7,
+          },
+        }}
+      />,
+    );
+    expect(html.includes("Live Run Theater")).toBeTrue();
+    expect(html.includes("Sephora")).toBeTrue();
+    expect(html.includes("7/20")).toBeTrue();
+    expect(html.includes("theater__cursor")).toBeTrue();
   });
 
   test("renders whitespace counts", () => {

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { CompetitiveSetPicker } from "../components/competitive/CompetitiveSetPicker";
 import { FeatureGapTable } from "../components/competitive/FeatureGapTable";
+import { LiveRunTheater } from "../components/competitive/LiveRunTheater";
 import { SentimentComparison } from "../components/competitive/SentimentComparison";
 import { ShareOfVoiceChart } from "../components/competitive/ShareOfVoiceChart";
 import { WhitespacePanel } from "../components/competitive/WhitespacePanel";
@@ -257,34 +258,13 @@ export function CompetitivePage() {
       <CompetitiveSetPicker onCreate={createSet} busy={busy} />
       {error && <p style={{ color: "crimson" }}>{error}</p>}
 
-      {(Object.keys(progressByBrand).length > 0 || judgeLines.length > 0 || busy) && (
-        <section style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-          <h3 style={{ marginTop: 0 }}>Live Run Stream</h3>
-          <p style={{ marginTop: 0 }}>{progressStatus}</p>
-          {judgeLines.length > 0 && (
-            <div style={{ marginBottom: 12, padding: 12, borderRadius: 6, background: "#fafafa" }}>
-              <strong>Judge</strong>
-              <pre style={{ margin: "8px 0 0", whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                {judgeLines.join("\n")}
-              </pre>
-            </div>
-          )}
-          <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 12 }}>
-            {Object.entries(progressByBrand).map(([brandId, box]) => (
-              <article
-                key={brandId}
-                style={{ border: "1px solid #ddd", borderRadius: 8, padding: 12, background: "#fff" }}
-              >
-                <h4 style={{ margin: "0 0 8px" }}>{box.brandName}</h4>
-                <p style={{ margin: "0 0 8px", color: "#555" }}>{box.status}</p>
-                <pre style={{ margin: 0, whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                  {box.lines.length ? box.lines.join("\n") : "Waiting for streamed output..."}
-                </pre>
-              </article>
-            ))}
-          </section>
-        </section>
-      )}
+      <LiveRunTheater
+        busy={busy}
+        progressStatus={progressStatus}
+        judgeLines={judgeLines}
+        progressByBrand={progressByBrand}
+      />
+
 
       {overview && (
         <>


### PR DESCRIPTION
## Summary
- new `web/src/components/competitive/LiveRunTheater.tsx` — one column per brand, progress bar, blinking cursor while streaming, brand-color accents
- replaces the plaintext Live Run Stream block in `web/src/pages/competitive.tsx`
- editorial paper-toned aesthetic (serif headings, mono streamed text) so it photographs better on Zoom than the prior `<pre>` block
- two new component tests: hidden when idle, visible with cursor while streaming

## Why
The existing live panel was functional but read like a log file. Theater gives the demo 60-90 seconds of automatic visual interest while the audience watches all five brands stream in parallel.

## Test plan
- [x] `bun test` (11/11 pass)
- [x] `bun run dev` → click Run benchmark → confirm five columns appear with cursors and the progress bar fills as prompts complete