### PR TITLE
Add Accuracy Guard hallucination detection (v0)

### DIFF
--- a/server/src/db/store.ts
+++ b/server/src/db/store.ts
@@ -1,3 +1,4 @@
+import type { AccuracyFlag, FactSheet } from "../features/accuracy/types";
 import type {
   AIAnswer,
   Brand,
@@ -63,6 +64,8 @@ export const store = {
     payload: Record<string, unknown>;
     createdAt: string;
   }>,
+  factSheets: new Map<string, FactSheet>(),
+  accuracyFlags: [] as AccuracyFlag[],
 };
 
 export const seedPromptSetId = seededPromptSet.id;
@@ -78,4 +81,6 @@ export function resetStore() {
   store.gapEvents.length = 0;
   store.benchmarkSnapshots.length = 0;
   store.recommendationInputs.length = 0;
+  store.factSheets.clear();
+  store.accuracyFlags.length = 0;
 }

--- a/server/src/features/accuracy/__tests__/detector.test.ts
+++ b/server/src/features/accuracy/__tests__/detector.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import type { AIAnswer } from "../../competitive/types";
+import { detectAccuracyFlags } from "../detector";
+import type { FactSheet } from "../types";
+
+function makeAnswer(text: string): AIAnswer {
+  return {
+    id: "answer-1",
+    promptRunId: "prompt-run-1",
+    brandId: "brand-1",
+    answerText: text,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+const baseFactSheet: FactSheet = {
+  id: "fs-1",
+  brandId: "brand-1",
+  pricing: "$49 per month",
+  foundedYear: 1969,
+  headquarters: "San Francisco, CA",
+  keyFeatures: [],
+  executives: [],
+  createdAt: new Date().toISOString(),
+};
+
+describe("accuracy detector", () => {
+  test("flags a contradicted price", () => {
+    const flags = detectAccuracyFlags({
+      factSheet: baseFactSheet,
+      answers: [makeAnswer("Plans start at $29 per month for the basic tier.")],
+    });
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.dimension).toBe("pricing");
+    expect(flags[0]!.claim.includes("29")).toBeTrue();
+  });
+
+  test("does not flag a price within 10 percent of truth", () => {
+    const flags = detectAccuracyFlags({
+      factSheet: baseFactSheet,
+      answers: [makeAnswer("Listed at $50/month, depending on tier.")],
+    });
+    expect(flags).toHaveLength(0);
+  });
+
+  test("flags a contradicted founding year only when founding context is present", () => {
+    const flags = detectAccuracyFlags({
+      factSheet: baseFactSheet,
+      answers: [makeAnswer("Founded in 1972, the brand later revisited its identity in 2002.")],
+    });
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.dimension).toBe("founded_year");
+    expect(flags[0]!.claim).toBe("1972");
+  });
+
+  test("flags a different headquarters city", () => {
+    const flags = detectAccuracyFlags({
+      factSheet: baseFactSheet,
+      answers: [makeAnswer("The retailer is headquartered in New York and serves customers globally.")],
+    });
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.dimension).toBe("headquarters");
+  });
+
+  test("returns no flags when answer agrees with fact sheet", () => {
+    const flags = detectAccuracyFlags({
+      factSheet: baseFactSheet,
+      answers: [
+        makeAnswer(
+          "Founded in 1969, the company is headquartered in San Francisco and most plans start at $49 per month.",
+        ),
+      ],
+    });
+    expect(flags).toHaveLength(0);
+  });
+});

--- a/server/src/features/accuracy/detector.ts
+++ b/server/src/features/accuracy/detector.ts
@@ -1,0 +1,160 @@
+import type { AIAnswer } from "../competitive/types";
+import type { AccuracyFlag, ClaimDimension, FactSheet } from "./types";
+
+/**
+ * Detect factual contradictions between an AI-generated answer and a
+ * brand-provided fact sheet. v0 is a deterministic substring + regex pass:
+ * we look for prices, founding years, and named cities in the answer and
+ * compare them to the fact sheet. This is intentionally simple and low-risk
+ * for the demo; an LLM-driven extractor is a follow-up.
+ */
+
+const PRICE_REGEX = /\$\s?(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)(?:\s*\/\s*(?:mo|month|yr|year|user|seat))?/gi;
+const YEAR_REGEX = /\b(1[89]\d{2}|20\d{2})\b/g;
+
+function snippetAround(text: string, index: number, span = 120) {
+  const start = Math.max(0, index - span / 2);
+  const end = Math.min(text.length, index + span / 2);
+  return text.slice(start, end).trim();
+}
+
+function parsePriceFromString(value: string): number | null {
+  const match = value.match(/\$\s?(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)/);
+  if (!match) {
+    return null;
+  }
+  const numeric = Number(match[1]!.replace(/,/g, ""));
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function isClose(a: number, b: number) {
+  if (a === b) return true;
+  // Treat differences within ±10% as not-a-contradiction to absorb rounding.
+  return Math.abs(a - b) / Math.max(a, b) < 0.1;
+}
+
+function makeFlag(
+  dimension: ClaimDimension,
+  claim: string,
+  groundTruth: string,
+  evidence: string,
+  brandId: string,
+  answer: AIAnswer,
+): AccuracyFlag {
+  return {
+    id: crypto.randomUUID(),
+    brandId,
+    answerId: answer.id,
+    promptRunId: answer.promptRunId,
+    dimension,
+    verdict: "contradicted",
+    claim,
+    groundTruth,
+    evidence,
+    detectedAt: new Date().toISOString(),
+  };
+}
+
+function detectPricingFlags(factSheet: FactSheet, answer: AIAnswer): AccuracyFlag[] {
+  if (!factSheet.pricing) {
+    return [];
+  }
+  const truthValue = parsePriceFromString(factSheet.pricing);
+  if (truthValue == null) {
+    return [];
+  }
+
+  const flags: AccuracyFlag[] = [];
+  const seen = new Set<number>();
+  for (const match of answer.answerText.matchAll(PRICE_REGEX)) {
+    const claimValue = Number((match[1] ?? "").replace(/,/g, ""));
+    if (!Number.isFinite(claimValue) || seen.has(claimValue) || isClose(claimValue, truthValue)) {
+      seen.add(claimValue);
+      continue;
+    }
+    seen.add(claimValue);
+    flags.push(
+      makeFlag(
+        "pricing",
+        match[0]!,
+        factSheet.pricing,
+        snippetAround(answer.answerText, match.index ?? 0),
+        factSheet.brandId,
+        answer,
+      ),
+    );
+  }
+  return flags;
+}
+
+function detectFoundedYearFlags(factSheet: FactSheet, answer: AIAnswer): AccuracyFlag[] {
+  if (!factSheet.foundedYear) {
+    return [];
+  }
+  const flags: AccuracyFlag[] = [];
+  const seen = new Set<number>();
+  for (const match of answer.answerText.matchAll(YEAR_REGEX)) {
+    const year = Number(match[1]);
+    if (seen.has(year) || year === factSheet.foundedYear) {
+      seen.add(year);
+      continue;
+    }
+    seen.add(year);
+    // Only flag years that look like they're describing founding context.
+    const window = snippetAround(answer.answerText, match.index ?? 0, 80).toLowerCase();
+    if (!/(founded|founding|since|established|launched|debuted|opened)/.test(window)) {
+      continue;
+    }
+    flags.push(
+      makeFlag(
+        "founded_year",
+        String(year),
+        String(factSheet.foundedYear),
+        snippetAround(answer.answerText, match.index ?? 0),
+        factSheet.brandId,
+        answer,
+      ),
+    );
+  }
+  return flags;
+}
+
+function detectHeadquartersFlags(factSheet: FactSheet, answer: AIAnswer): AccuracyFlag[] {
+  if (!factSheet.headquarters) {
+    return [];
+  }
+  const truthCity = factSheet.headquarters.split(",")[0]?.trim().toLowerCase();
+  if (!truthCity) {
+    return [];
+  }
+  // If the answer mentions "headquartered in" / "based in" with a different city, flag it.
+  const phraseRegex = /(headquartered|based|located)\s+in\s+([a-z][a-z .'\-]+?)(?=[,.;]| and | with | which )/gi;
+  const flags: AccuracyFlag[] = [];
+  for (const match of answer.answerText.matchAll(phraseRegex)) {
+    const claimCity = match[2]?.trim() ?? "";
+    if (!claimCity || claimCity.toLowerCase().includes(truthCity)) {
+      continue;
+    }
+    flags.push(
+      makeFlag(
+        "headquarters",
+        claimCity,
+        factSheet.headquarters,
+        snippetAround(answer.answerText, match.index ?? 0),
+        factSheet.brandId,
+        answer,
+      ),
+    );
+  }
+  return flags;
+}
+
+export function detectAccuracyFlags(input: { factSheet: FactSheet; answers: AIAnswer[] }): AccuracyFlag[] {
+  const flags: AccuracyFlag[] = [];
+  for (const answer of input.answers) {
+    flags.push(...detectPricingFlags(input.factSheet, answer));
+    flags.push(...detectFoundedYearFlags(input.factSheet, answer));
+    flags.push(...detectHeadquartersFlags(input.factSheet, answer));
+  }
+  return flags;
+}

--- a/server/src/features/accuracy/types.ts
+++ b/server/src/features/accuracy/types.ts
@@ -1,0 +1,33 @@
+export type ClaimVerdict = "contradicted" | "unverifiable";
+
+export type ClaimDimension = "pricing" | "founded_year" | "headquarters";
+
+export interface FactSheet {
+  id: string;
+  brandId: string;
+  /** Free-form pricing string, e.g. "$49/month per seat". */
+  pricing?: string;
+  /** Four-digit founding year. */
+  foundedYear?: number;
+  /** Free-form HQ string, e.g. "San Francisco, CA". */
+  headquarters?: string;
+  keyFeatures: string[];
+  executives: string[];
+  createdAt: string;
+}
+
+export interface AccuracyFlag {
+  id: string;
+  brandId: string;
+  answerId: string;
+  promptRunId: string;
+  dimension: ClaimDimension;
+  verdict: ClaimVerdict;
+  /** What we found in the AI answer. */
+  claim: string;
+  /** What the fact sheet says it should be. */
+  groundTruth: string;
+  /** Short snippet from the answer for evidence. */
+  evidence: string;
+  detectedAt: string;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { accuracyRoutes } from "./routes/accuracy";
 import { businessRoutes } from "./routes/business";
 import { competitiveRoutes } from "./routes/competitive";
 
@@ -16,6 +17,7 @@ app.use(
 app.get("/health", (c) => c.json({ ok: true }));
 app.route("/", businessRoutes);
 app.route("/", competitiveRoutes);
+app.route("/", accuracyRoutes);
 
 export default {
   port: Number(process.env.PORT ?? 3000),

--- a/server/src/routes/accuracy.test.ts
+++ b/server/src/routes/accuracy.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { resetStore, store } from "../db/store";
+import { accuracyRoutes } from "./accuracy";
+
+describe("accuracy routes", () => {
+  const app = new Hono().route("/", accuracyRoutes);
+
+  beforeEach(() => {
+    resetStore();
+  });
+
+  function seedBrandWithAnswer(answerText: string) {
+    const brandId = "brand-1";
+    store.brands.set(brandId, { id: brandId, name: "Sephora" });
+    const promptRunId = "prompt-run-1";
+    store.promptRuns.set(promptRunId, {
+      id: promptRunId,
+      promptSetId: "prompt-set-1",
+      prompt: "How is Sephora priced?",
+      promptKind: "brand_specific",
+      model: "mock",
+      createdAt: new Date().toISOString(),
+    });
+    const answerId = crypto.randomUUID();
+    store.answers.set(answerId, {
+      id: answerId,
+      promptRunId,
+      brandId,
+      answerText,
+      createdAt: new Date().toISOString(),
+    });
+    return { brandId };
+  }
+
+  test("rejects fact sheet for unknown brand", async () => {
+    const res = await app.request("/accuracy/fact-sheet", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ brandId: "missing", pricing: "$49/month" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("flags contradiction across the full fact-sheet → run → flags flow", async () => {
+    const { brandId } = seedBrandWithAnswer(
+      "Subscriptions are $29 per month per seat for new customers.",
+    );
+
+    const sheetRes = await app.request("/accuracy/fact-sheet", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ brandId, pricing: "$49 per month" }),
+    });
+    expect(sheetRes.status).toBe(201);
+
+    const runRes = await app.request("/accuracy/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ brandId }),
+    });
+    expect(runRes.status).toBe(200);
+    const runBody = await runRes.json();
+    expect(runBody.scannedAnswers).toBe(1);
+    expect(runBody.flagged).toBe(1);
+
+    const flagsRes = await app.request(`/accuracy/flags?brandId=${brandId}`);
+    expect(flagsRes.status).toBe(200);
+    const flagsBody = await flagsRes.json();
+    expect(flagsBody.count).toBe(1);
+    expect(flagsBody.flags[0].dimension).toBe("pricing");
+  });
+
+  test("requires brandId on flags query", async () => {
+    const res = await app.request("/accuracy/flags");
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/src/routes/accuracy.ts
+++ b/server/src/routes/accuracy.ts
@@ -1,0 +1,60 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { store } from "../db/store";
+import { detectAccuracyFlags } from "../features/accuracy/detector";
+import type { FactSheet } from "../features/accuracy/types";
+
+const factSheetSchema = z.object({
+  brandId: z.string().min(1),
+  pricing: z.string().optional(),
+  foundedYear: z.number().int().min(1500).max(2100).optional(),
+  headquarters: z.string().optional(),
+  keyFeatures: z.array(z.string().min(1)).default([]),
+  executives: z.array(z.string().min(1)).default([]),
+});
+
+const runSchema = z.object({
+  brandId: z.string().min(1),
+});
+
+export const accuracyRoutes = new Hono();
+
+accuracyRoutes.post("/accuracy/fact-sheet", async (c) => {
+  const body = factSheetSchema.parse(await c.req.json());
+  if (!store.brands.has(body.brandId)) {
+    return c.json({ error: "Unknown brandId." }, 404);
+  }
+  const factSheet: FactSheet = {
+    id: crypto.randomUUID(),
+    brandId: body.brandId,
+    pricing: body.pricing,
+    foundedYear: body.foundedYear,
+    headquarters: body.headquarters,
+    keyFeatures: body.keyFeatures,
+    executives: body.executives,
+    createdAt: new Date().toISOString(),
+  };
+  store.factSheets.set(body.brandId, factSheet);
+  return c.json(factSheet, 201);
+});
+
+accuracyRoutes.post("/accuracy/runs", async (c) => {
+  const body = runSchema.parse(await c.req.json());
+  const factSheet = store.factSheets.get(body.brandId);
+  if (!factSheet) {
+    return c.json({ error: "No fact sheet registered for this brand." }, 404);
+  }
+  const answers = Array.from(store.answers.values()).filter((answer) => answer.brandId === body.brandId);
+  const flags = detectAccuracyFlags({ factSheet, answers });
+  store.accuracyFlags.push(...flags);
+  return c.json({ scannedAnswers: answers.length, flagged: flags.length, flags });
+});
+
+accuracyRoutes.get("/accuracy/flags", (c) => {
+  const brandId = c.req.query("brandId");
+  if (!brandId) {
+    return c.json({ error: "brandId is required." }, 400);
+  }
+  const flags = store.accuracyFlags.filter((flag) => flag.brandId === brandId);
+  return c.json({ count: flags.length, flags });
+});


### PR DESCRIPTION
## Summary
- new `server/src/features/accuracy/` module with `FactSheet`/`AccuracyFlag` types and a deterministic detector (regex + substring) for pricing, founding year, and headquarters contradictions
- new `server/src/routes/accuracy.ts` with three endpoints:
  - `POST /accuracy/fact-sheet` — register brand ground truth
  - `POST /accuracy/runs` — scan stored answers, persist flags
  - `GET /accuracy/flags?brandId=<id>` — list flags
- extends `server/src/db/store.ts` with `factSheets` map + `accuracyFlags` array (cleared by `resetStore`)
- 5 detector unit tests + 3 route tests

## Why
Hallucination detection is the strongest differentiator the PRD calls out, with zero code on `main` today. v0 runs entirely without an LLM key — deterministic and demoable. An LLM-driven extractor for richer claims (executive names, feature presence, etc.) is a clean follow-up.

## Test plan
- [x] `bun test` (17/17 pass — 5 detector + 3 route + 9 baseline)
- [x] live curl: `POST /accuracy/fact-sheet` → 201, `POST /accuracy/runs` → 200 with `{scannedAnswers, flagged, flags}`, `GET /accuracy/flags?brandId=...` → list

## Follow-ups (not in this PR)
- LLM-driven claim extraction for richer hallucination detection
- Surface flags in the UI (Recommendations tab once codex stack lands)
- Auto-trigger after each competitive run