### PR TITLE
Redesign competitive page (editorial system + LLM key wiring)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,15 @@
+# Copy to server/.env and fill in your key.
+# Without a key, the server falls back to a deterministic mock LLM (good for
+# UI demos, but no real AI answers).
+
+# Required for live LLM mode:
+OPENAI_API_KEY=
+
+# Optional: pin a different provider (currently only "openai" is supported).
+# LLM_PROVIDER=openai
+
+# Optional: turn the demo seed off if you want a fresh empty store.
+# PERCEPTION_DEMO_SEED=0
+
+# Optional: change the API port (default 3000).
+# PORT=3000

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,13 +2,21 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { businessRoutes } from "./routes/business";
 import { competitiveRoutes } from "./routes/competitive";
+import { llmStatusRoutes } from "./routes/llm-status";
 
 const app = new Hono();
 
 app.use(
   "*",
   cors({
-    origin: ["http://localhost:5173", "http://127.0.0.1:5173"],
+    origin: [
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+      "http://localhost:5174",
+      "http://127.0.0.1:5174",
+      "http://localhost:5175",
+      "http://127.0.0.1:5175",
+    ],
     allowMethods: ["GET", "POST", "OPTIONS"],
   }),
 );
@@ -16,6 +24,7 @@ app.use(
 app.get("/health", (c) => c.json({ ok: true }));
 app.route("/", businessRoutes);
 app.route("/", competitiveRoutes);
+app.route("/", llmStatusRoutes);
 
 export default {
   port: Number(process.env.PORT ?? 3000),

--- a/server/src/routes/llm-status.ts
+++ b/server/src/routes/llm-status.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+
+/**
+ * Reports whether the server is wired to a real LLM provider so the UI can
+ * show "Live" vs "Demo (mock)" without leaking the key.
+ */
+export const llmStatusRoutes = new Hono();
+
+llmStatusRoutes.get("/llm/status", (c) => {
+  const provider = process.env.LLM_PROVIDER ?? "openai";
+  const hasKey = provider === "openai" ? Boolean(process.env.OPENAI_API_KEY) : false;
+  return c.json({
+    provider,
+    mode: hasKey ? "live" : "mock",
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -3,13 +3,21 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Perception Competitive Benchmarking</title>
+    <meta name="theme-color" content="#faf6ec" />
+    <title>Perception · Competitive Intelligence</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Manrope:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+    />
   </head>
   <body>
     <div id="root">
-      <p style="margin: 24px; font-family: system-ui, sans-serif; color: #444">
-        Loading…
-      </p>
+      <div class="app-loading">
+        <span class="app-loading__mark">P</span>
+        <span class="app-loading__label">Perception</span>
+      </div>
     </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -5,7 +5,6 @@ interface Props {
   busy?: boolean;
 }
 
-/** Demo cohort: Sephora vs five beauty retail competitors */
 const DEFAULT_ACCOUNT = "Sephora";
 const DEFAULT_COMPETITORS = ["Ulta", "Bluemercury", "SpaceNK", "SallyBeauty", "Olive Young"];
 
@@ -18,43 +17,58 @@ export function CompetitiveSetPicker({ onCreate, busy }: Props) {
   }, [accountBrandName, competitorNames]);
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16, marginBottom: 20 }}>
-      <h3 style={{ marginTop: 0 }}>Competitive Set — Demo (5 competitors)</h3>
-      <label style={{ display: "block", marginBottom: 8 }}>
-        Your brand
+    <div className="panel panel--paper" aria-busy={busy}>
+      <p className="panel__title">Configure your benchmark</p>
+      <p className="panel__hint" style={{ marginBottom: 18 }}>
+        Pick your brand and five competitors. We&rsquo;ll fan twenty perception prompts across every brand and
+        compare the answers.
+      </p>
+
+      <label className="field">
+        <span className="field__label">Your brand</span>
         <input
+          className="field__input"
           value={accountBrandName}
           onChange={(e) => setAccountBrandName(e.target.value)}
-          style={{ width: "100%", marginTop: 4 }}
+          placeholder="e.g. Sephora"
+          spellCheck={false}
         />
       </label>
-      {competitorNames.map((name, idx) => (
-        <label key={idx} style={{ display: "block", marginBottom: 8 }}>
-          Competitor {idx + 1}
-          <input
-            value={name}
-            onChange={(e) => {
-              const next = [...competitorNames];
-              next[idx] = e.target.value;
-              setCompetitorNames(next);
-            }}
-            style={{ width: "100%", marginTop: 4 }}
-          />
-        </label>
-      ))}
-      <button
-        type="button"
-        onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
-        disabled={!canSubmit || busy}
-      >
-        {busy ? "Running 20-question benchmark..." : "Run benchmark"}
-      </button>
-      {busy && (
-        <p style={{ marginBottom: 0, color: "#555" }}>
-          Generating brand-perception summaries and comparisons. This can take a bit while the server fans out the LLM
-          calls.
-        </p>
-      )}
-    </section>
+
+      <div className="subhead" style={{ marginTop: 18 }}>Competitive set · 5 brands</div>
+      <div className="fieldset-grid">
+        {competitorNames.map((name, idx) => (
+          <label className="field" key={idx} style={{ marginBottom: 0 }}>
+            <span className="field__label">Competitor {idx + 1}</span>
+            <input
+              className="field__input"
+              value={name}
+              onChange={(e) => {
+                const next = [...competitorNames];
+                next[idx] = e.target.value;
+                setCompetitorNames(next);
+              }}
+              spellCheck={false}
+            />
+          </label>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 22 }}>
+        <button
+          type="button"
+          className="btn"
+          onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
+          disabled={!canSubmit || busy}
+        >
+          {busy ? "Running 20-prompt benchmark…" : "Run benchmark"}
+        </button>
+        {busy && (
+          <span style={{ fontFamily: "var(--pp-font-mono)", fontSize: 12, color: "var(--pp-ink-3)" }}>
+            Streaming brand summaries and judge comparisons in parallel.
+          </span>
+        )}
+      </div>
+    </div>
   );
 }

--- a/web/src/components/competitive/FeatureGapTable.tsx
+++ b/web/src/components/competitive/FeatureGapTable.tsx
@@ -12,33 +12,49 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
   const label = (id: string) => brandLabels?.[id] ?? id;
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Feature Strengths & Weaknesses</h3>
-      <table width="100%" style={{ marginBottom: 16 }}>
+    <section className="panel">
+      <h3 className="panel__title">Feature strengths</h3>
+      <p className="panel__hint" style={{ marginBottom: 16 }}>
+        The themes the judge LLM repeatedly attached to each brand across the 20 perception prompts.
+      </p>
+      <table className="data-table">
         <thead>
           <tr>
-            <th align="left">Brand</th>
-            <th align="left">Top Features</th>
+            <th style={{ width: "30%" }}>Brand</th>
+            <th>Top features</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => (
             <tr key={row.brandId}>
               <td>{label(row.brandId)}</td>
-              <td>{row.topFeatures.join(", ") || "No feature signal yet"}</td>
+              <td>
+                {row.topFeatures.length === 0 ? (
+                  <span style={{ color: "var(--pp-ink-4)", fontStyle: "italic" }}>No feature signal yet</span>
+                ) : (
+                  <span className="tag-row">
+                    {row.topFeatures.map((feature) => (
+                      <span className="tag" key={feature}>{feature}</span>
+                    ))}
+                  </span>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
-      <h4>Feature Praise Gaps</h4>
+
+      <div className="subhead">Feature praise gaps</div>
       {praiseGaps.length === 0 ? (
-        <p>No feature praise gaps detected.</p>
+        <p style={{ color: "var(--pp-ink-3)", margin: 0, fontSize: 14 }}>
+          No feature praise gaps detected in this window.
+        </p>
       ) : (
-        <ul>
+        <ul className="bullets">
           {praiseGaps.map((gap) => (
             <li key={gap.id}>
-              {gap.competitorBrandId ? label(gap.competitorBrandId) : "Competitor"} praised on &quot;
-              {gap.featureKey}&quot; while {accountBrandName}&apos;s equivalent is unmentioned in the judge output.
+              <strong>{gap.competitorBrandId ? label(gap.competitorBrandId) : "Competitor"}</strong> is praised on{" "}
+              <em>{gap.featureKey}</em>; {accountBrandName}&rsquo;s equivalent is unmentioned.
             </li>
           ))}
         </ul>

--- a/web/src/components/competitive/LiveRunTheater.tsx
+++ b/web/src/components/competitive/LiveRunTheater.tsx
@@ -1,0 +1,209 @@
+import { useMemo } from "react";
+
+const TOTAL_PROMPTS_PER_BRAND = 20;
+
+const BRAND_ACCENTS = ["#b3251f", "#1f5fa8", "#2f8a4d", "#a76b1f", "#5d3a8b", "#1f7a83"];
+
+export interface BrandProgressBox {
+  brandName: string;
+  status: string;
+  activePrompt: string;
+  lines: string[];
+  completedPrompts: number;
+}
+
+interface LiveRunTheaterProps {
+  busy: boolean;
+  progressStatus: string;
+  judgeLines: string[];
+  progressByBrand: Record<string, BrandProgressBox>;
+}
+
+function isStreaming(box: BrandProgressBox) {
+  return box.completedPrompts < TOTAL_PROMPTS_PER_BRAND && box.lines.length > 0;
+}
+
+function progressPct(box: BrandProgressBox) {
+  return Math.min(100, Math.round((box.completedPrompts / TOTAL_PROMPTS_PER_BRAND) * 100));
+}
+
+export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBrand }: LiveRunTheaterProps) {
+  const brandEntries = useMemo(() => Object.entries(progressByBrand), [progressByBrand]);
+  const visible = brandEntries.length > 0 || judgeLines.length > 0 || busy;
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <section className="theater">
+      <style>{theaterStyles}</style>
+      <header className="theater__header">
+        <h3 className="theater__title">Live Run Theater</h3>
+        <p className="theater__status">{progressStatus}</p>
+      </header>
+
+      {judgeLines.length > 0 && (
+        <aside className="theater__judge">
+          <span className="theater__judge-label">Judge</span>
+          <pre className="theater__judge-text">{judgeLines.join("\n")}</pre>
+        </aside>
+      )}
+
+      <div className="theater__columns">
+        {brandEntries.map(([brandId, box], index) => {
+          const accent = BRAND_ACCENTS[index % BRAND_ACCENTS.length];
+          const streaming = isStreaming(box);
+          const pct = progressPct(box);
+          return (
+            <article key={brandId} className="theater__column" style={{ borderTopColor: accent }}>
+              <div className="theater__column-head">
+                <h4 className="theater__column-title">{box.brandName}</h4>
+                <span className="theater__column-count">
+                  {box.completedPrompts}/{TOTAL_PROMPTS_PER_BRAND}
+                </span>
+              </div>
+              <div className="theater__progress">
+                <div className="theater__progress-bar" style={{ width: `${pct}%`, background: accent }} />
+              </div>
+              <p className="theater__column-status">{box.status}</p>
+              <pre className="theater__stream" data-empty={box.lines.length === 0}>
+                {box.lines.length === 0 ? "Waiting for streamed output…" : box.lines.join("\n")}
+                {streaming && <span className="theater__cursor" style={{ background: accent }} />}
+              </pre>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+const theaterStyles = `
+.theater {
+  margin-bottom: 16px;
+  border: 1px solid #e6e0d4;
+  border-radius: 10px;
+  padding: 18px 20px 22px;
+  background:
+    radial-gradient(circle at 12% -10%, rgba(179, 37, 31, 0.06), transparent 55%),
+    radial-gradient(circle at 110% 110%, rgba(31, 95, 168, 0.05), transparent 60%),
+    #fbf8f1;
+  font-family: "Iowan Old Style", "Hoefler Text", "Source Serif Pro", Georgia, serif;
+  color: #1f1b16;
+}
+.theater__header { margin-bottom: 14px; }
+.theater__title {
+  margin: 0 0 4px;
+  font-size: 22px;
+  letter-spacing: 0.01em;
+  font-weight: 600;
+}
+.theater__status {
+  margin: 0;
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 12px;
+  color: #5b5347;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.theater__judge {
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(31, 27, 22, 0.04);
+  border: 1px dashed rgba(31, 27, 22, 0.18);
+}
+.theater__judge-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #5b5347;
+  margin-bottom: 4px;
+}
+.theater__judge-text {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #2c261d;
+}
+.theater__columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.theater__column {
+  border: 1px solid #ece4d3;
+  border-top: 3px solid currentColor;
+  border-radius: 8px;
+  padding: 12px 14px 14px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+  box-shadow: 0 1px 0 rgba(31, 27, 22, 0.04);
+}
+.theater__column-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.theater__column-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+.theater__column-count {
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 11px;
+  color: #5b5347;
+  letter-spacing: 0.06em;
+}
+.theater__progress {
+  margin: 8px 0 6px;
+  height: 3px;
+  background: rgba(31, 27, 22, 0.08);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.theater__progress-bar {
+  height: 100%;
+  transition: width 240ms ease-out;
+}
+.theater__column-status {
+  margin: 0 0 8px;
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 11px;
+  color: #5b5347;
+  letter-spacing: 0.04em;
+  min-height: 1.4em;
+}
+.theater__stream {
+  margin: 0;
+  flex-grow: 1;
+  white-space: pre-wrap;
+  font-family: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #1f1b16;
+}
+.theater__stream[data-empty="true"] {
+  color: #a39a87;
+  font-style: italic;
+}
+.theater__cursor {
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: -2px;
+  animation: theaterBlink 1s steps(2, end) infinite;
+}
+@keyframes theaterBlink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+`;

--- a/web/src/components/competitive/SentimentComparison.tsx
+++ b/web/src/components/competitive/SentimentComparison.tsx
@@ -8,23 +8,36 @@ export function SentimentComparison({
   brandLabels?: Record<string, string>;
 }) {
   const label = (id: string) => brandLabels?.[id] ?? id;
+  const sorted = [...rows].sort((a, b) => b.sentiment - a.sentiment);
+
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Sentiment Comparison</h3>
-      <table width="100%">
-        <thead>
-          <tr>
-            <th align="left">Brand</th>
-            <th align="right">Sentiment</th>
-          </tr>
-        </thead>
+    <section className="panel">
+      <h3 className="panel__title">Sentiment</h3>
+      <p className="panel__hint" style={{ marginBottom: 16 }}>
+        Where each brand sits on a -1 to +1 valence axis (averaged across all prompts).
+      </p>
+      <table className="data-table">
         <tbody>
-          {rows.map((row) => (
-            <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td align="right">{row.sentiment.toFixed(2)}</td>
-            </tr>
-          ))}
+          {sorted.map((row) => {
+            const pct = ((row.sentiment + 1) / 2) * 100;
+            const tone =
+              row.sentiment >= 0.25 ? "var(--pp-success)" : row.sentiment <= -0.25 ? "var(--pp-accent)" : "var(--pp-ink)";
+            return (
+              <tr key={row.brandId}>
+                <td>
+                  <div className="bar-row">
+                    <span className="bar-row__label">{label(row.brandId)}</span>
+                    <span className="gauge" style={{ flexGrow: 1 }}>
+                      <span className="gauge__pin" style={{ left: `${pct}%`, background: tone }} />
+                    </span>
+                    <span className="bar-row__num" style={{ color: tone }}>
+                      {row.sentiment.toFixed(2)}
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </section>

--- a/web/src/components/competitive/ShareOfVoiceChart.tsx
+++ b/web/src/components/competitive/ShareOfVoiceChart.tsx
@@ -1,5 +1,14 @@
 import type { OverviewRow } from "../../types";
 
+const BRAND_VARS = [
+  "var(--pp-brand-1)",
+  "var(--pp-brand-2)",
+  "var(--pp-brand-3)",
+  "var(--pp-brand-4)",
+  "var(--pp-brand-5)",
+  "var(--pp-brand-6)",
+];
+
 export function ShareOfVoiceChart({
   rows,
   brandLabels,
@@ -8,21 +17,34 @@ export function ShareOfVoiceChart({
   brandLabels?: Record<string, string>;
 }) {
   const label = (id: string) => brandLabels?.[id] ?? id;
+  const sorted = [...rows].sort((a, b) => b.shareOfVoice - a.shareOfVoice);
+  const max = Math.max(0.001, ...sorted.map((row) => row.shareOfVoice));
+
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Share of Voice</h3>
-      <table width="100%">
-        <thead>
-          <tr>
-            <th align="left">Brand</th>
-            <th align="right">SOV</th>
-          </tr>
-        </thead>
+    <section className="panel">
+      <h3 className="panel__title">Share of voice</h3>
+      <p className="panel__hint" style={{ marginBottom: 16 }}>
+        Comparative narrative weight across all twenty prompts.
+      </p>
+      <table className="data-table">
         <tbody>
-          {rows.map((row) => (
+          {sorted.map((row, idx) => (
             <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td align="right">{(row.shareOfVoice * 100).toFixed(1)}%</td>
+              <td>
+                <div className="bar-row">
+                  <span className="bar-row__label">{label(row.brandId)}</span>
+                  <span className="bar-row__bar">
+                    <span
+                      className="bar-row__bar-fill"
+                      style={{
+                        width: `${(row.shareOfVoice / max) * 100}%`,
+                        background: BRAND_VARS[idx % BRAND_VARS.length],
+                      }}
+                    />
+                  </span>
+                  <span className="bar-row__num">{(row.shareOfVoice * 100).toFixed(1)}%</span>
+                </div>
+              </td>
             </tr>
           ))}
         </tbody>

--- a/web/src/components/competitive/WhitespacePanel.tsx
+++ b/web/src/components/competitive/WhitespacePanel.tsx
@@ -3,25 +3,76 @@ import type { GapEvent } from "../../types";
 export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
   const whitespace = gaps.filter((gap) => gap.gapType === "whitespace");
   const exclusion = gaps.filter((gap) => gap.gapType === "prompt_exclusion");
+  const praise = gaps.filter((gap) => gap.gapType === "feature_praise_gap");
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Gap Analysis Highlights</h3>
-      <p>
-        Prompt Exclusion Gaps: <strong>{exclusion.length}</strong>
+    <section className="panel">
+      <h3 className="panel__title">Whitespace Opportunities</h3>
+      <p className="panel__hint" style={{ marginBottom: 16 }}>
+        Categories and prompts where AI assistants don&rsquo;t firmly recommend any brand yet.
       </p>
-      <p>
-        Whitespace Opportunities: <strong>{whitespace.length}</strong>
-      </p>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, 1fr)",
+          gap: 12,
+          marginBottom: 16,
+        }}
+      >
+        <Stat label="Whitespace" value={whitespace.length} />
+        <Stat label="Exclusion gaps" value={exclusion.length} />
+        <Stat label="Praise gaps" value={praise.length} />
+      </div>
+
       {whitespace.length > 0 && (
-        <ul>
+        <ul className="bullets">
           {whitespace.map((gap) => (
             <li key={gap.id}>
-              Prompt run {gap.promptRunId} has no recommended brand; category {gap.categoryKey ?? "general"}.
+              Category <em>{gap.categoryKey ?? "general"}</em> — no brand owns the consensus answer.
+              {gap.evidence[0] && (
+                <span style={{ color: "var(--pp-ink-3)" }}> {gap.evidence[0]}</span>
+              )}
             </li>
           ))}
         </ul>
       )}
     </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--pp-rule)",
+        borderRadius: "var(--pp-radius)",
+        padding: "10px 12px",
+        background: "var(--pp-paper)",
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "var(--pp-font-mono)",
+          fontSize: 10,
+          letterSpacing: "0.18em",
+          textTransform: "uppercase",
+          color: "var(--pp-ink-3)",
+          marginBottom: 4,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--pp-font-display)",
+          fontSize: 28,
+          fontWeight: 600,
+          letterSpacing: "-0.01em",
+        }}
+      >
+        {value}
+      </div>
+    </div>
   );
 }

--- a/web/src/components/competitive/__tests__/components.test.tsx
+++ b/web/src/components/competitive/__tests__/components.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { CompetitiveSetPicker } from "../CompetitiveSetPicker";
+import { LiveRunTheater } from "../LiveRunTheater";
 import { WhitespacePanel } from "../WhitespacePanel";
 
 describe("competitive components", () => {
@@ -10,6 +11,36 @@ describe("competitive components", () => {
     expect(html.includes("Sephora")).toBeTrue();
     expect(html.includes("Ulta")).toBeTrue();
     expect(html.includes("Olive Young")).toBeTrue();
+  });
+
+  test("LiveRunTheater renders nothing when idle", () => {
+    const html = renderToStaticMarkup(
+      <LiveRunTheater busy={false} progressStatus="" judgeLines={[]} progressByBrand={{}} />,
+    );
+    expect(html).toBe("");
+  });
+
+  test("LiveRunTheater shows columns and progress while running", () => {
+    const html = renderToStaticMarkup(
+      <LiveRunTheater
+        busy
+        progressStatus="Streaming brand summaries..."
+        judgeLines={["who leads"]}
+        progressByBrand={{
+          b1: {
+            brandName: "Sephora",
+            status: "Streaming brand_specific summary…",
+            activePrompt: "How is Sephora perceived?",
+            lines: ["Sephora is widely regarded as a leader"],
+            completedPrompts: 7,
+          },
+        }}
+      />,
+    );
+    expect(html.includes("Live Run Theater")).toBeTrue();
+    expect(html.includes("Sephora")).toBeTrue();
+    expect(html.includes("7/20")).toBeTrue();
+    expect(html.includes("theater__cursor")).toBeTrue();
   });
 
   test("renders whitespace counts", () => {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { CompetitivePage } from "./pages/competitive";
+import "./styles/design.css";
 
 const root = document.getElementById("root");
 if (!root) {

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { CompetitiveSetPicker } from "../components/competitive/CompetitiveSetPicker";
 import { FeatureGapTable } from "../components/competitive/FeatureGapTable";
+import { LiveRunTheater } from "../components/competitive/LiveRunTheater";
 import { SentimentComparison } from "../components/competitive/SentimentComparison";
 import { ShareOfVoiceChart } from "../components/competitive/ShareOfVoiceChart";
 import { WhitespacePanel } from "../components/competitive/WhitespacePanel";
@@ -257,34 +258,13 @@ export function CompetitivePage() {
       <CompetitiveSetPicker onCreate={createSet} busy={busy} />
       {error && <p style={{ color: "crimson" }}>{error}</p>}
 
-      {(Object.keys(progressByBrand).length > 0 || judgeLines.length > 0 || busy) && (
-        <section style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-          <h3 style={{ marginTop: 0 }}>Live Run Stream</h3>
-          <p style={{ marginTop: 0 }}>{progressStatus}</p>
-          {judgeLines.length > 0 && (
-            <div style={{ marginBottom: 12, padding: 12, borderRadius: 6, background: "#fafafa" }}>
-              <strong>Judge</strong>
-              <pre style={{ margin: "8px 0 0", whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                {judgeLines.join("\n")}
-              </pre>
-            </div>
-          )}
-          <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 12 }}>
-            {Object.entries(progressByBrand).map(([brandId, box]) => (
-              <article
-                key={brandId}
-                style={{ border: "1px solid #ddd", borderRadius: 8, padding: 12, background: "#fff" }}
-              >
-                <h4 style={{ margin: "0 0 8px" }}>{box.brandName}</h4>
-                <p style={{ margin: "0 0 8px", color: "#555" }}>{box.status}</p>
-                <pre style={{ margin: 0, whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                  {box.lines.length ? box.lines.join("\n") : "Waiting for streamed output..."}
-                </pre>
-              </article>
-            ))}
-          </section>
-        </section>
-      )}
+      <LiveRunTheater
+        busy={busy}
+        progressStatus={progressStatus}
+        judgeLines={judgeLines}
+        progressByBrand={progressByBrand}
+      />
+
 
       {overview && (
         <>

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -19,6 +19,11 @@ interface BrandProgressBox {
   completedPrompts: number;
 }
 
+interface LlmStatus {
+  provider: string;
+  mode: "live" | "mock";
+}
+
 function appendLine(lines: string[], line: string) {
   return [...lines, line].slice(-MAX_PROGRESS_LINES);
 }
@@ -48,14 +53,21 @@ export function CompetitivePage() {
   const [trends, setTrends] = useState<TrendsResponse | null>(null);
   const [gaps, setGaps] = useState<GapEvent[]>([]);
   const [error, setError] = useState<string>("");
-  const [progressStatus, setProgressStatus] = useState<string>("No run in progress.");
+  const [progressStatus, setProgressStatus] = useState<string>("Idle.");
   const [judgeLines, setJudgeLines] = useState<string[]>([]);
   const [progressByBrand, setProgressByBrand] = useState<Record<string, BrandProgressBox>>({});
-
+  const [llmStatus, setLlmStatus] = useState<LlmStatus | null>(null);
   const [lastWindow, setLastWindow] = useState<{ windowStart: string; windowEnd: string } | null>(null);
   const progressSourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
+    fetch(`${API_BASE}/llm/status`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body) => body && setLlmStatus(body))
+      .catch(() => {
+        /* leave null; pill hides */
+      });
+
     return () => {
       progressSourceRef.current?.close();
       progressSourceRef.current = null;
@@ -86,17 +98,15 @@ export function CompetitivePage() {
         return;
       }
       case "judge_delta": {
-        setProgressStatus(`Judging ${event.promptKind} prompt...`);
+        setProgressStatus(`Judging ${event.promptKind} prompt…`);
         setJudgeLines((current) => appendLine(current, event.text));
         return;
       }
       case "answer_started": {
-        setProgressStatus(`Generating ${event.promptKind} summaries...`);
+        setProgressStatus(`Generating ${event.promptKind} summaries…`);
         setProgressByBrand((current) => {
           const existing = current[event.brandId];
-          if (!existing) {
-            return current;
-          }
+          if (!existing) return current;
           return {
             ...current,
             [event.brandId]: {
@@ -112,14 +122,12 @@ export function CompetitivePage() {
       case "answer_delta": {
         setProgressByBrand((current) => {
           const existing = current[event.brandId];
-          if (!existing) {
-            return current;
-          }
+          if (!existing) return current;
           return {
             ...current,
             [event.brandId]: {
               ...existing,
-              status: `Streaming ${event.promptKind} summary...`,
+              status: `Streaming ${event.promptKind} summary…`,
               activePrompt: event.prompt,
               lines: appendLine(existing.lines, event.text),
             },
@@ -130,9 +138,7 @@ export function CompetitivePage() {
       case "answer_completed": {
         setProgressByBrand((current) => {
           const existing = current[event.brandId];
-          if (!existing) {
-            return current;
-          }
+          if (!existing) return current;
           const completedPrompts = existing.completedPrompts + 1;
           return {
             ...current,
@@ -181,7 +187,7 @@ export function CompetitivePage() {
       const sessionId = crypto.randomUUID();
       const stream = new EventSource(`${API_BASE}/competitive/stream/${sessionId}`);
       progressSourceRef.current = stream;
-      setProgressStatus("Connecting progress stream...");
+      setProgressStatus("Connecting progress stream…");
       stream.onmessage = (message) => {
         handleProgressEvent(JSON.parse(message.data) as CompetitiveProgressEvent);
       };
@@ -244,81 +250,182 @@ export function CompetitivePage() {
     }
   }
 
+  const totalCompetitors = competitorBrandIds.length || 5;
+  const labelsForBrands = brandLabels;
+
   return (
-    <main style={{ maxWidth: 1100, margin: "0 auto", padding: 24, fontFamily: "Inter, Arial, sans-serif" }}>
-      <h1>Competitive Benchmarking — Demo</h1>
-      <p style={{ marginTop: 0 }}>
-        Each run uses <strong>10 brand-specific prompts</strong> (with each retailer’s name) plus{" "}
-        <strong>10 category-wide prompts</strong> (leader, best, most reliable, etc.), all answered per retailer;
-        outputs are compared and rolled into share of voice and sentiment. Default slate:{" "}
-        <strong>Sephora</strong> vs <strong>Ulta</strong>, <strong>Bluemercury</strong>, <strong>SpaceNK</strong>,{" "}
-        <strong>SallyBeauty</strong>, and <strong>Olive Young</strong>.
-      </p>
+    <main className="app-shell">
+      <header className="app-header fade-in">
+        <div className="app-brand">
+          <span className="app-brand__mark">P</span>
+          <span className="app-brand__name">Perception</span>
+          <span className="app-brand__sub">Competitive Intelligence · v0.1</span>
+        </div>
+        {llmStatus && (
+          <span className={`pill pill--${llmStatus.mode}`}>
+            <span className="pill__dot" />
+            {llmStatus.mode === "live" ? `Live · ${llmStatus.provider}` : "Demo · mock LLM"}
+          </span>
+        )}
+      </header>
 
-      <CompetitiveSetPicker onCreate={createSet} busy={busy} />
-      {error && <p style={{ color: "crimson" }}>{error}</p>}
+      <section className="hero fade-in fade-in--d1">
+        <div>
+          <p className="hero__eyebrow">Competitive benchmarking</p>
+          <h1 className="hero__title">
+            How AI <em>actually</em> talks about your brand.
+          </h1>
+          <p className="hero__lede">
+            Perception fans twenty perception prompts across your brand and five competitors, asks ChatGPT,
+            Claude, and Gemini-class models to answer each, and rolls the results into share of voice,
+            sentiment, and feature gaps you can screenshot and bring to your CMO.
+          </p>
+        </div>
+        <div className="hero__meta">
+          <div className="hero__meta-row">
+            <span><strong>{totalCompetitors}</strong> competitors</span>
+            <span><strong>20</strong> prompts / brand</span>
+            <span><strong>7d</strong> trailing window</span>
+          </div>
+          <div className="hero__meta-row">
+            <span>Account · <strong>{accountBrandName}</strong></span>
+          </div>
+        </div>
+      </section>
 
-      <LiveRunTheater
-        busy={busy}
-        progressStatus={progressStatus}
-        judgeLines={judgeLines}
-        progressByBrand={progressByBrand}
-      />
-
-
-      {overview && (
-        <>
-          <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginBottom: 16 }}>
-            <ShareOfVoiceChart rows={overview.rows} brandLabels={brandLabels} />
-            <SentimentComparison rows={overview.rows} brandLabels={brandLabels} />
-          </section>
-          <FeatureGapTable
-            rows={overview.rows}
-            gaps={gaps}
-            brandLabels={brandLabels}
-            accountBrandName={accountBrandName}
-          />
-          <section style={{ marginTop: 16 }}>
-            <WhitespacePanel gaps={gaps} />
-          </section>
-        </>
+      {llmStatus?.mode === "mock" && (
+        <p className="banner fade-in fade-in--d2">
+          Running in demo mode — answers are deterministic mock text. Add{" "}
+          <code style={{ fontFamily: "var(--pp-font-mono)" }}>OPENAI_API_KEY</code> to <code>server/.env</code>{" "}
+          and restart for live LLM output.
+        </p>
       )}
 
-      <section style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Trend Snapshot (7 days)</h3>
-        {!trends ? (
-          <p>No trend data yet.</p>
-        ) : (
-          <pre style={{ overflowX: "auto", margin: 0 }}>
-            {JSON.stringify(
-              Object.fromEntries(
-                Object.entries(trends.seriesByBrand).map(([id, pts]) => [brandLabels[id] ?? id, pts]),
-              ),
-              null,
-              2,
-            )}
-          </pre>
-        )}
-      </section>
+      <div className="grid-side fade-in fade-in--d2">
+        <aside>
+          <CompetitiveSetPicker onCreate={createSet} busy={busy} />
+        </aside>
 
-      <section style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Run Configuration</h3>
-        <p>
-          Account: {accountBrandName} ({accountBrandId || "run to assign IDs"})
-        </p>
-        <p>
-          Competitors:{" "}
-          {competitorBrandIds.length
-            ? competitorBrandIds.map((id) => brandLabels[id] ?? id).join(", ")
-            : "Ulta, Bluemercury, SpaceNK, SallyBeauty, Olive Young (defaults)"}
-        </p>
-        <p>
-          Window:{" "}
-          {lastWindow
-            ? `${lastWindow.windowStart} – ${lastWindow.windowEnd}`
-            : "Run the benchmark to set the query window"}
-        </p>
-      </section>
+        <div>
+          <LiveRunTheater
+            busy={busy}
+            progressStatus={progressStatus}
+            judgeLines={judgeLines}
+            progressByBrand={progressByBrand}
+          />
+
+          {error && (
+            <div
+              className="banner"
+              style={{ background: "rgba(179, 37, 31, 0.08)", borderColor: "rgba(179, 37, 31, 0.3)", color: "var(--pp-accent)" }}
+            >
+              {error}
+            </div>
+          )}
+
+          {!overview && !busy && (
+            <div className="empty">
+              <p className="empty__title">No benchmark yet</p>
+              <p>Hit “Run benchmark” to fan twenty prompts across all six brands.</p>
+            </div>
+          )}
+
+          {overview && (
+            <>
+              <section className="section fade-in fade-in--d3">
+                <header className="section__head">
+                  <h2 className="section__title">At a glance</h2>
+                  <span className="section__kicker">7-day rolling window</span>
+                </header>
+                <div className="grid-2">
+                  <ShareOfVoiceChart rows={overview.rows} brandLabels={labelsForBrands} />
+                  <SentimentComparison rows={overview.rows} brandLabels={labelsForBrands} />
+                </div>
+              </section>
+
+              <section className="section fade-in fade-in--d3">
+                <header className="section__head">
+                  <h2 className="section__title">Feature signal &amp; gaps</h2>
+                  <span className="section__kicker">Judge LLM · top 3 themes / brand</span>
+                </header>
+                <FeatureGapTable
+                  rows={overview.rows}
+                  gaps={gaps}
+                  brandLabels={labelsForBrands}
+                  accountBrandName={accountBrandName}
+                />
+              </section>
+
+              <section className="section">
+                <WhitespacePanel gaps={gaps} />
+              </section>
+            </>
+          )}
+
+          <section className="section">
+            <header className="section__head">
+              <h2 className="section__title">Trend snapshot</h2>
+              <span className="section__kicker">Last 7 days</span>
+            </header>
+            {!trends || Object.keys(trends.seriesByBrand).length === 0 ? (
+              <p className="panel__hint">Run a benchmark to populate trend lines.</p>
+            ) : (
+              <pre className="trend-list">
+                {Object.entries(trends.seriesByBrand)
+                  .map(([id, pts]) => {
+                    const name = labelsForBrands[id] ?? id;
+                    const summary = pts
+                      .map(
+                        (p) =>
+                          `  ${p.t.slice(0, 10)}  sov=${(p.sov * 100).toFixed(1).padStart(5, " ")}%  sent=${p.sentiment.toFixed(2)}`,
+                      )
+                      .join("\n");
+                    return `${name}\n${summary}`;
+                  })
+                  .join("\n\n")}
+              </pre>
+            )}
+          </section>
+
+          <section className="section">
+            <header className="section__head">
+              <h2 className="section__title">Run configuration</h2>
+              <span className="section__kicker">Last execution</span>
+            </header>
+            <div
+              className="panel--paper panel"
+              style={{
+                borderTop: "none",
+                display: "grid",
+                gap: 6,
+                fontFamily: "var(--pp-font-mono)",
+                fontSize: 12,
+                color: "var(--pp-ink-2)",
+              }}
+            >
+              <div>
+                <span style={{ color: "var(--pp-ink-3)" }}>account</span> · {accountBrandName}{" "}
+                <span style={{ color: "var(--pp-ink-4)" }}>({accountBrandId || "—"})</span>
+              </div>
+              <div>
+                <span style={{ color: "var(--pp-ink-3)" }}>competitors</span> ·{" "}
+                {competitorBrandIds.length
+                  ? competitorBrandIds.map((id) => labelsForBrands[id] ?? id).join(", ")
+                  : "Ulta, Bluemercury, SpaceNK, SallyBeauty, Olive Young (defaults)"}
+              </div>
+              <div>
+                <span style={{ color: "var(--pp-ink-3)" }}>window</span> ·{" "}
+                {lastWindow ? `${lastWindow.windowStart} → ${lastWindow.windowEnd}` : "—"}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <footer className="app-footer">
+        <span>Perception · brand intelligence for the AI layer</span>
+        <span>{new Date().getFullYear()}</span>
+      </footer>
     </main>
   );
 }

--- a/web/src/styles/design.css
+++ b/web/src/styles/design.css
@@ -1,0 +1,528 @@
+/*
+ * Perception design system
+ *
+ * Aesthetic: editorial / data publication. Cream paper background, deep ink
+ * text, single terracotta accent, hairline rules. Display serif (Fraunces)
+ * for headings, sans (Manrope) for body, mono (JetBrains Mono) for data and
+ * codes. Generous whitespace, no boxy cards.
+ */
+
+:root {
+  /* paper + ink */
+  --pp-bg: #faf6ec;
+  --pp-bg-warm: #f4eddc;
+  --pp-paper: #ffffff;
+  --pp-ink: #1a1814;
+  --pp-ink-2: #3b352c;
+  --pp-ink-3: #6b6356;
+  --pp-ink-4: #a39a87;
+
+  /* hairlines + dividers */
+  --pp-rule: #e8e0cc;
+  --pp-rule-strong: #d6cdb4;
+
+  /* accent */
+  --pp-accent: #b3251f;
+  --pp-accent-soft: #f0d4d2;
+  --pp-success: #2f6f4f;
+  --pp-warning: #b07a1f;
+
+  /* brand-column accents (kept in sync with LiveRunTheater) */
+  --pp-brand-1: #b3251f;
+  --pp-brand-2: #1f5fa8;
+  --pp-brand-3: #2f8a4d;
+  --pp-brand-4: #a76b1f;
+  --pp-brand-5: #5d3a8b;
+  --pp-brand-6: #1f7a83;
+
+  /* type */
+  --pp-font-display: "Fraunces", "Iowan Old Style", "Hoefler Text", Georgia, serif;
+  --pp-font-body: "Manrope", "Söhne", "Inter", system-ui, sans-serif;
+  --pp-font-mono: "JetBrains Mono", "Menlo", "SFMono-Regular", monospace;
+
+  /* spacing */
+  --pp-s-1: 4px;
+  --pp-s-2: 8px;
+  --pp-s-3: 12px;
+  --pp-s-4: 16px;
+  --pp-s-5: 24px;
+  --pp-s-6: 32px;
+  --pp-s-7: 48px;
+  --pp-s-8: 64px;
+
+  --pp-radius: 6px;
+  --pp-radius-lg: 10px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--pp-bg);
+  color: var(--pp-ink);
+  font-family: var(--pp-font-body);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01" on, "cv11" on;
+}
+
+body {
+  background:
+    radial-gradient(circle at 8% -8%, rgba(179, 37, 31, 0.04), transparent 55%),
+    radial-gradient(circle at 100% 110%, rgba(31, 95, 168, 0.035), transparent 55%),
+    var(--pp-bg);
+}
+
+a { color: var(--pp-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ---------- Loading splash ---------- */
+.app-loading {
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  font-family: var(--pp-font-display);
+  color: var(--pp-ink-3);
+  font-size: 22px;
+  letter-spacing: 0.02em;
+  font-style: italic;
+}
+.app-loading__mark {
+  width: 36px; height: 36px; display: inline-flex;
+  align-items: center; justify-content: center;
+  background: var(--pp-accent); color: #fff;
+  border-radius: 999px;
+  font-style: normal; font-weight: 600;
+  font-size: 18px;
+}
+
+/* ---------- App shell ---------- */
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--pp-s-7) var(--pp-s-6) var(--pp-s-8);
+}
+
+.app-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--pp-s-5);
+  padding-bottom: var(--pp-s-5);
+  border-bottom: 1px solid var(--pp-rule-strong);
+  margin-bottom: var(--pp-s-7);
+}
+.app-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--pp-s-3);
+}
+.app-brand__mark {
+  width: 36px; height: 36px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--pp-accent);
+  color: #fff;
+  border-radius: 999px;
+  font-family: var(--pp-font-display);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.app-brand__name {
+  font-family: var(--pp-font-display);
+  font-weight: 600;
+  font-size: 22px;
+  letter-spacing: 0.005em;
+}
+.app-brand__sub {
+  font-family: var(--pp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pp-ink-3);
+  border-left: 1px solid var(--pp-rule-strong);
+  padding-left: var(--pp-s-3);
+  margin-left: var(--pp-s-1);
+}
+
+/* ---------- Hero ---------- */
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 4fr);
+  gap: var(--pp-s-7);
+  margin-bottom: var(--pp-s-7);
+  align-items: end;
+}
+.hero__eyebrow {
+  font-family: var(--pp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pp-accent);
+  margin: 0 0 var(--pp-s-3);
+}
+.hero__title {
+  font-family: var(--pp-font-display);
+  font-variation-settings: "opsz" 144;
+  font-weight: 500;
+  font-size: clamp(40px, 5vw, 64px);
+  line-height: 1.05;
+  letter-spacing: -0.012em;
+  margin: 0 0 var(--pp-s-4);
+  color: var(--pp-ink);
+}
+.hero__title em {
+  font-style: italic;
+  font-weight: 400;
+  color: var(--pp-accent);
+}
+.hero__lede {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--pp-ink-2);
+  max-width: 56ch;
+}
+.hero__meta {
+  font-family: var(--pp-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--pp-ink-3);
+  text-transform: uppercase;
+}
+.hero__meta-row { display: flex; gap: var(--pp-s-5); flex-wrap: wrap; margin-bottom: var(--pp-s-2); }
+.hero__meta-row strong { font-weight: 600; color: var(--pp-ink); }
+
+/* ---------- Section + headings ---------- */
+.section {
+  margin-bottom: var(--pp-s-7);
+}
+.section__head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--pp-s-4);
+  margin-bottom: var(--pp-s-4);
+  padding-bottom: var(--pp-s-3);
+  border-bottom: 1px solid var(--pp-rule);
+}
+.section__title {
+  margin: 0;
+  font-family: var(--pp-font-display);
+  font-weight: 600;
+  font-size: 22px;
+  letter-spacing: -0.005em;
+}
+.section__kicker {
+  font-family: var(--pp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pp-ink-3);
+}
+
+.subhead {
+  margin: var(--pp-s-5) 0 var(--pp-s-3);
+  font-family: var(--pp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pp-ink-3);
+}
+
+/* ---------- Grids ---------- */
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--pp-s-5);
+}
+.grid-side {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: var(--pp-s-7);
+  align-items: start;
+}
+@media (max-width: 920px) {
+  .grid-side { grid-template-columns: 1fr; }
+  .hero { grid-template-columns: 1fr; }
+}
+
+/* ---------- Panel (replaces boxy cards) ---------- */
+.panel {
+  background: transparent;
+  border-top: 1px solid var(--pp-rule-strong);
+  padding-top: var(--pp-s-5);
+}
+.panel--paper {
+  background: var(--pp-paper);
+  border: 1px solid var(--pp-rule);
+  border-radius: var(--pp-radius-lg);
+  padding: var(--pp-s-5);
+}
+.panel__title {
+  margin: 0 0 var(--pp-s-3);
+  font-family: var(--pp-font-display);
+  font-weight: 600;
+  font-size: 18px;
+  letter-spacing: -0.005em;
+}
+.panel__hint {
+  margin: 0;
+  font-size: 13px;
+  color: var(--pp-ink-3);
+  line-height: 1.5;
+}
+
+/* ---------- Form ---------- */
+.field { display: block; margin-bottom: var(--pp-s-3); }
+.field__label {
+  display: block;
+  font-family: var(--pp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--pp-ink-3);
+  margin-bottom: 4px;
+}
+.field__input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--pp-rule-strong);
+  border-radius: var(--pp-radius);
+  background: #fff;
+  font-family: var(--pp-font-body);
+  font-size: 14px;
+  color: var(--pp-ink);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+.field__input:focus {
+  outline: none;
+  border-color: var(--pp-accent);
+  box-shadow: 0 0 0 3px rgba(179, 37, 31, 0.12);
+}
+.field__input::placeholder { color: var(--pp-ink-4); }
+
+.fieldset-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--pp-s-3);
+}
+@media (max-width: 480px) {
+  .fieldset-grid { grid-template-columns: 1fr; }
+}
+
+/* ---------- Button ---------- */
+.btn {
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--pp-font-body);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.005em;
+  padding: 11px 18px;
+  border-radius: var(--pp-radius);
+  background: var(--pp-ink);
+  color: #fff;
+  display: inline-flex; align-items: center; gap: 8px;
+  transition: transform 80ms ease, background 140ms ease, opacity 140ms ease;
+}
+.btn:hover { background: var(--pp-accent); }
+.btn:active { transform: translateY(1px); }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn--ghost {
+  background: transparent;
+  color: var(--pp-ink);
+  border: 1px solid var(--pp-rule-strong);
+}
+.btn--ghost:hover { background: var(--pp-ink); color: #fff; border-color: var(--pp-ink); }
+
+/* ---------- Pills + status ---------- */
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--pp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--pp-rule-strong);
+  color: var(--pp-ink-2);
+  background: #fff;
+}
+.pill--live { color: var(--pp-success); border-color: rgba(47, 111, 79, 0.4); }
+.pill--mock { color: var(--pp-ink-3); }
+.pill__dot {
+  width: 7px; height: 7px; border-radius: 999px;
+  background: currentColor;
+}
+.pill--live .pill__dot { animation: pulseDot 1.6s ease-in-out infinite; }
+@keyframes pulseDot {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
+.banner {
+  font-family: var(--pp-font-mono);
+  font-size: 12px;
+  color: var(--pp-ink-3);
+  background: rgba(176, 122, 31, 0.08);
+  border: 1px solid rgba(176, 122, 31, 0.25);
+  padding: 8px 12px;
+  border-radius: var(--pp-radius);
+  margin-bottom: var(--pp-s-4);
+  letter-spacing: 0.02em;
+}
+
+/* ---------- Data tables (used by chart components) ---------- */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.data-table th {
+  text-align: left;
+  font-family: var(--pp-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pp-ink-3);
+  font-weight: 600;
+  padding: 0 0 8px;
+  border-bottom: 1px solid var(--pp-rule);
+}
+.data-table td {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--pp-rule);
+  vertical-align: middle;
+}
+.data-table tr:last-child td { border-bottom: none; }
+.data-table .num {
+  font-family: var(--pp-font-mono);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--pp-ink);
+}
+
+/* Bar inside row, used by ShareOfVoice */
+.bar-row { display: flex; align-items: center; gap: 12px; }
+.bar-row__label { flex-grow: 1; }
+.bar-row__bar {
+  position: relative;
+  width: 40%;
+  height: 4px;
+  background: var(--pp-rule);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.bar-row__bar-fill {
+  height: 100%;
+  border-radius: 2px;
+}
+.bar-row__num {
+  font-family: var(--pp-font-mono);
+  font-variant-numeric: tabular-nums;
+  width: 56px;
+  text-align: right;
+  color: var(--pp-ink);
+  font-size: 13px;
+}
+
+/* Sentiment slider gauge */
+.gauge { position: relative; height: 6px; background: linear-gradient(90deg, #d6cdb4 0%, #f0d4d2 50%, #cfe1d4 100%); border-radius: 999px; }
+.gauge__pin {
+  position: absolute;
+  top: 50%;
+  width: 10px; height: 10px;
+  background: var(--pp-ink);
+  border: 2px solid #fff;
+  border-radius: 999px;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 1px var(--pp-rule-strong);
+}
+
+/* ---------- Tag chip (top features etc.) ---------- */
+.tag {
+  display: inline-block;
+  font-family: var(--pp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 3px 8px;
+  margin: 2px 4px 2px 0;
+  border-radius: 999px;
+  background: var(--pp-bg-warm);
+  color: var(--pp-ink-2);
+  border: 1px solid var(--pp-rule);
+}
+
+.tag-row { display: flex; flex-wrap: wrap; gap: 4px; }
+
+/* ---------- Empty state ---------- */
+.empty {
+  border: 1px dashed var(--pp-rule-strong);
+  border-radius: var(--pp-radius-lg);
+  padding: var(--pp-s-6);
+  text-align: center;
+  color: var(--pp-ink-3);
+  background: rgba(255, 255, 255, 0.6);
+}
+.empty__title {
+  font-family: var(--pp-font-display);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 18px;
+  color: var(--pp-ink-2);
+  margin: 0 0 var(--pp-s-2);
+}
+.empty p { margin: 0; font-size: 14px; }
+
+/* ---------- Trend snapshot list ---------- */
+.trend-list {
+  font-family: var(--pp-font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--pp-ink-2);
+  white-space: pre-wrap;
+  background: var(--pp-paper);
+  border: 1px solid var(--pp-rule);
+  border-radius: var(--pp-radius-lg);
+  padding: var(--pp-s-4);
+  max-height: 240px;
+  overflow: auto;
+}
+
+/* ---------- Footer ---------- */
+.app-footer {
+  margin-top: var(--pp-s-8);
+  padding-top: var(--pp-s-4);
+  border-top: 1px solid var(--pp-rule);
+  font-family: var(--pp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pp-ink-4);
+  display: flex;
+  justify-content: space-between;
+}
+
+/* ---------- Bullet list ---------- */
+.bullets {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 14px;
+  color: var(--pp-ink-2);
+  line-height: 1.6;
+}
+.bullets li { margin-bottom: 4px; }
+
+/* ---------- Page-load fade ---------- */
+.fade-in { animation: fadeIn 360ms ease-out both; }
+.fade-in--d1 { animation-delay: 60ms; }
+.fade-in--d2 { animation-delay: 140ms; }
+.fade-in--d3 { animation-delay: 220ms; }
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- new design system in `web/src/styles/design.css` — cream paper, deep ink, terracotta accent, Fraunces display + Manrope body + JetBrains Mono data, hairline rules instead of boxy cards
- Google Fonts wired in `web/index.html`
- rewrote layout in `web/src/pages/competitive.tsx` — header w/ brand mark, hero with display-serif headline, left-rail picker + right column results, three data sections, trend snapshot, run config, footer
- restyled every chart component to consume design tokens (ShareOfVoiceChart bars, SentimentComparison gauge, FeatureGapTable chips, WhitespacePanel big-number stats)
- new `LiveLLMStatus` pill in header reads from `GET /llm/status` (no key leak — returns provider + mode only)
- added `server/.env.example` + amber demo banner under hero when key is missing
- widened CORS to local Vite preview ports

## Why
The dashboard looked like a college project — system fonts, gray borders, forms with no labels, raw JSON for trends. This pass makes the surface match the PRD's "screenshot and bring to your CMO" promise. Editorial typography + restrained palette gives executive-ready feel without sacrificing the data density we need for the demo.

The LLM-key wiring is the second half: the team now knows at a glance whether the running server is on a real LLM or the deterministic mock, and where to put the key.

## Stacked on
`feat/live-run-theater` (#29) — Theater is the Live Run module of this layout. Both should land together; merge order: #29 → this PR.

## Test plan
- [x] `bun test` (11/11 pass — same suite as #29)
- [x] `bun run dev` → home page renders with Fraunces + Manrope, status pill shows mode, banner shows when key missing
- [x] Add `OPENAI_API_KEY` to `server/.env`, restart server → pill flips to "Live · openai", banner disappears
- [x] Click Run benchmark → Theater plays, charts populate with redesigned bars/gauge/chips

## Out of scope
- Further responsive-design polish on narrow widths (still works, but not optimized)
- Replacing the trend snapshot `<pre>` with a real chart (next pass)
- Dark mode