### PR TITLE
UX refactor (sidebar, theater, dashboard polish)

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,214 @@
+# Perception · Demo Script (Streaming Services Cohort)
+
+A 7–9 minute walkthrough for the Wednesday Demo Day slot. Uses the seeded
+**Netflix vs Disney+ / Max / Amazon Prime Video / Apple TV+ / Paramount+** cohort
+that ships with the demo seed pack.
+
+---
+
+## 0. Pre-flight (do this 5 min before joining Zoom)
+
+```bash
+# 1. Make sure your OpenAI key is set so the live run shows real LLM output
+cat server/.env   # should contain a non-empty OPENAI_API_KEY=...
+
+# 2. Start the stack (one terminal)
+bun install            # only if you haven't already
+bun run dev            # spawns server on :3000 and web on :5173
+
+# 3. Open the dashboard in a fresh browser tab
+open http://localhost:5173
+```
+
+Sanity checks before you share screen:
+
+- `curl http://localhost:3000/llm/status` → `{"provider":"openai","mode":"live"}`
+  — if it says `mock`, your key didn't load. **Restart the server.**
+- The Benchmarking tab should load with **populated charts** (Netflix at the top
+  of the Share of Voice bars). If you see "No benchmark yet", the seed didn't
+  load — restart the server and check the boot log for
+  `[seed] Loaded streaming demo cohort: 10 prompt runs, ...`.
+- Resolution: full-screen the browser at ~1440px wide. The two-column SoV +
+  Sentiment grid collapses below ~980px and reads worse on Zoom.
+- Close any other tabs that might steal CPU during the live run.
+
+If anything is sketchy, fall back to the **mock-mode demo** at the bottom of
+this doc — it's deterministic, takes ~5s instead of ~45s, and looks the same.
+
+---
+
+## 1. Opening (~30s)
+
+> "Perception is a brand-intelligence platform for the AI era. Companies spend
+> millions on SEO so Google ranks them, but consumers are increasingly asking
+> ChatGPT, Claude, and Gemini for product recommendations — and most brands
+> have **zero visibility** into what AI is saying about them.
+>
+> We're going to show you how a marketing team at Netflix could see exactly how
+> AI describes them versus the rest of the streaming category, in one click."
+
+Click the **Benchmarking** tab in the sidebar to anchor the demo.
+
+---
+
+## 2. The dashboard at rest (~90s)
+
+Walk through what's already on screen. The seed pack means the dashboard is
+*already populated* — that's the whole point.
+
+### Hero
+> "This is what we're tracking: 20 perception prompts fanned across Netflix and
+> 5 competitors, every prompt answered by the frontier models, results rolled
+> into share of voice, sentiment, and feature gaps."
+
+### Share of Voice (top-left)
+> "Netflix is the leader at ~25% share of voice across all the prompts. Apple
+> TV+ is rising — 21%. Paramount+ is trailing in the single digits."
+
+Point at the bars. The visual story is obvious because we sorted descending and
+each brand has its own colour.
+
+### Sentiment (top-right)
+> "Sentiment is where it gets interesting. Apple TV+ has the highest sentiment
+> score even though Netflix has more share. That's the prestige-originals
+> narrative beating the incumbent on quality."
+
+### Feature signal
+> "These are the themes the judge LLM repeatedly attached to each brand. Netflix
+> wins on `leadership` and `originals`. Disney+ wins on `family` and `ip`. Max
+> wins on `prestige`. **Notice nothing on Netflix says `value` or `innovation`**
+> — that's a problem."
+
+### Feature praise gaps (the punchline)
+> "Right here, Perception flagged it: **Amazon Prime is praised on `value`;
+> Netflix isn't.** And **Apple TV+ owns `innovation`; Netflix isn't mentioned.**
+> Two clear gaps the marketing team can act on."
+
+### Whitespace opportunities
+> "And here's whitespace: AI assistants don't decisively recommend any one
+> brand for live sports. That's a category Netflix could move into and own."
+
+This whole section sells the differentiation: every other tool stops at "here's
+what AI says." We surface **gaps and whitespace**.
+
+---
+
+## 3. The live run (~2–3 min, narrate while it runs)
+
+Click **Run benchmark** with the default Netflix slate.
+
+The Theater section appears with six branded columns. While it streams:
+
+> "What you're watching live is the platform fanning twenty prompts across
+> every brand simultaneously. Each column is one of the streaming services.
+> The cursor blinks while OpenAI is mid-stream. The bar at the top of each
+> column fills as prompts complete."
+
+Things to point at:
+
+- The **Judge LLM** aside that pops in between brand answers — that's the
+  comparative scoring step.
+- The progress counters (`0/20 → 1/20 → 2/20 …`).
+- The fact that **all six brands run in parallel** at concurrency 4 — that's
+  why it finishes in ~45 seconds instead of 5+ minutes.
+
+If the run takes longer than expected, fill the time:
+
+> "The reason this matters operationally: in the AI era, brand visibility is
+> non-deterministic. The same prompt gives different answers tomorrow. So the
+> only honest way to measure brand presence in AI is to keep running prompts
+> on a schedule — exactly what Perception does."
+
+---
+
+## 4. Post-run reveal (~60s)
+
+When the Theater finishes, the dashboard panels update with the merged data
+(7 days of seeded history + today's fresh run).
+
+> "Now the dashboard has refreshed with the new run on top of the 7 days of
+> historical data. Trends rolls forward. New gap events get detected. If
+> Netflix's marketing team did this every Monday morning, they'd have a moving
+> picture of how AI's perception of their brand is changing."
+
+Scroll to **Trend snapshot** and point at the daily mini-bars:
+
+> "Daily averages, one row per day, per brand. You can see Netflix's share is
+> stable, Apple TV+ is rising, Paramount+ is volatile."
+
+---
+
+## 5. Closing pitch (~30s)
+
+> "Three things we do that no competitor does today:
+>
+> 1. **We tell you where the gaps are**, not just where you stand.
+> 2. **We surface whitespace** — categories AI hasn't decided yet, where you
+>    can plant a flag.
+> 3. **We make the run itself a story** — that Theater isn't just polish, it's
+>    how you build conviction with a CMO that the data is real.
+>
+> Built by the team in 4 weeks. Currently tracks GPT-class models; Claude and
+> Gemini are the next integrations. Hallucination detection — ChatGPT
+> inventing wrong pricing or features — is the next major feature."
+
+---
+
+## 6. Likely Q&A — quick answers
+
+| Question | Quick answer |
+|---|---|
+| Are you using a real LLM or mocking? | Live OpenAI for both the perception prompts and the comparative judge. The pill says `live · openai` in the run config. |
+| What models? | `gpt-4.1-mini` for both answers and judging. Multi-provider abstraction is in flight. |
+| How are the prompts chosen? | 10 brand-specific (each retailer's name substituted) plus 10 category-wide leadership prompts. Configurable per cohort. |
+| How long does a real run take? | ~30–60 seconds for 6 brands × 20 prompts at concurrency 4. |
+| What happens with hallucinations? | We have a v0 detector for fact-sheet contradictions (pricing, founding year, HQ) — not in this demo, separate branch. |
+| What's the data model? | All in-memory for the prototype. SQLite store for business profiles already wired; competitive store moves to Postgres next. |
+| Differentiator vs Profound / Peec? | They're monitoring dashboards. We close the loop: detection → diagnosis → recommended action → before-and-after measurement. |
+| Privacy / data? | Brand-provided fact sheets stay client-side until a run. AI answers we generate ourselves; we don't scrape user conversations. |
+
+---
+
+## 7. Backup script (use this if the live run fails)
+
+If `bun run dev` won't start, OpenAI rate-limits, or the network drops:
+
+1. Set `PERCEPTION_DEMO_SEED=1` (default — already on) and **don't click Run**.
+2. The dashboard is already populated from the seed, so do steps 1–2 of the
+   real script (Hero → Share of Voice → Sentiment → Feature signal → Whitespace)
+   without relying on a live run at all.
+3. For the "live moment", show the Theater on a **previously recorded
+   screen capture** if you made one. Otherwise:
+4. Click Run anyway — even without a key, the mock LLM produces deterministic
+   output and the Theater still plays. It just takes ~5s. Narrate it as
+   "we're running in offline mode for the demo so the Zoom doesn't lag."
+
+---
+
+## 8. Two-minute version (if your slot gets cut short)
+
+If the CA tells you to wrap in 90 seconds:
+
+1. **Hero + dashboard** (already populated): "AI is the new search; here's how
+   AI talks about Netflix vs every other streamer. We track 20 prompts × 6
+   brands daily."
+2. **Skip the live run.** Just point at the populated bars + sentiment + gaps.
+3. **Punchline gap**: "Amazon owns `value`, Apple TV+ owns `innovation`;
+   Netflix is missing both. We surface that. Nobody else does."
+4. **Close**: "Profound monitors. We diagnose."
+
+That hits visibility, differentiation, and the strongest example in 90s.
+
+---
+
+## File map (for reviewers reading the code)
+
+- `server/seed/streaming.ts` — the seeded cohort and 7 days of synthetic
+  comparisons + gap events.
+- `server/src/routes/competitive.ts` — `/competitive/snapshot` powers the
+  first-paint preview the dashboard auto-loads on mount.
+- `server/src/routes/llm-status.ts` — `/llm/status` surfaces live vs mock.
+- `web/src/components/competitive/LiveRunTheater.tsx` — the streaming column
+  panel users see during a run.
+- `web/src/pages/competitive.tsx` — page composition: hero, picker, theater,
+  charts, trend snapshot, run config.

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,16 +1,22 @@
-# Perception · Demo Script (Streaming Services Cohort)
+# Perception · Demo Day Walkthrough
 
-A 7–9 minute walkthrough for the Wednesday Demo Day slot. Uses the seeded
+A 7–9 minute walkthrough for the Wednesday Demo Day Zoom slot. Uses the seeded
 **Netflix vs Disney+ / Max / Amazon Prime Video / Apple TV+ / Paramount+** cohort
-that ships with the demo seed pack.
+that ships with this branch. Every dashboard view has real data on first paint —
+no clicks required to populate.
+
+> **TL;DR.** Open the dashboard. Walk Monitoring → Benchmarking. Click *Run
+> benchmark*. Narrate the Theater for 60–90s. Land on the gap punchline:
+> "Netflix is missing on **value** and **innovation** — that's exactly the
+> diagnosis we surface."
 
 ---
 
-## 0. Pre-flight (do this 5 min before joining Zoom)
+## 0 · Pre-flight (5 minutes before joining Zoom)
 
 ```bash
 # 1. Make sure your OpenAI key is set so the live run shows real LLM output
-cat server/.env   # should contain a non-empty OPENAI_API_KEY=...
+cat server/.env   # should contain OPENAI_API_KEY=sk-...
 
 # 2. Start the stack (one terminal)
 bun install            # only if you haven't already
@@ -20,195 +26,279 @@ bun run dev            # spawns server on :3000 and web on :5173
 open http://localhost:5173
 ```
 
-Sanity checks before you share screen:
+Sanity checks before screen share:
 
-- `curl http://localhost:3000/llm/status` → `{"provider":"openai","mode":"live"}`
-  — if it says `mock`, your key didn't load. **Restart the server.**
-- The Benchmarking tab should load with **populated charts** (Netflix at the top
-  of the Share of Voice bars). If you see "No benchmark yet", the seed didn't
-  load — restart the server and check the boot log for
-  `[seed] Loaded streaming demo cohort: 10 prompt runs, ...`.
-- Resolution: full-screen the browser at ~1440px wide. The two-column SoV +
-  Sentiment grid collapses below ~980px and reads worse on Zoom.
-- Close any other tabs that might steal CPU during the live run.
+- Server boot log shows two `[seed]` lines:
+  - `Loaded streaming demo cohort: 10 prompt runs, 10 comparisons, 3 gap events.`
+  - `Created Netflix business profile (…) with 12 monitoring prompts.`
+- `curl http://localhost:3000/llm/status` returns `{"provider":"openai","mode":"live"}` (if it says `mock`, your key didn't load — restart the server).
+- The Benchmarking tab opens populated: Netflix at the top of Share of Voice,
+  Apple TV+ rising on Sentiment, three brand-color chips per row in Feature signal.
+- Monitoring tab shows 12 prompts with sentiment pills (positive / neutral /
+  negative) and a 7-day sentiment trend chart.
+- Browser at ~1440px wide. Charts collapse below ~980px.
+- Close other tabs that might steal CPU during the live run.
 
-If anything is sketchy, fall back to the **mock-mode demo** at the bottom of
-this doc — it's deterministic, takes ~5s instead of ~45s, and looks the same.
+If anything looks off, jump to **Section 7 (Backup script)** at the bottom.
 
 ---
 
-## 1. Opening (~30s)
+## 1 · Opening (~30 seconds)
 
-> "Perception is a brand-intelligence platform for the AI era. Companies spend
+> *"Perception is a brand-intelligence platform for the AI era. Companies spend
 > millions on SEO so Google ranks them, but consumers are increasingly asking
-> ChatGPT, Claude, and Gemini for product recommendations — and most brands
-> have **zero visibility** into what AI is saying about them.
+> ChatGPT, Claude, and Gemini for product recommendations — and most brands have
+> **zero visibility** into what AI is saying about them.*
 >
-> We're going to show you how a marketing team at Netflix could see exactly how
-> AI describes them versus the rest of the streaming category, in one click."
+> *I'll show you how a marketing team at Netflix could see exactly how AI describes
+> them versus the rest of the streaming category — in one click."*
 
-Click the **Benchmarking** tab in the sidebar to anchor the demo.
+Click **Benchmarking** in the sidebar to anchor the demo.
 
 ---
 
-## 2. The dashboard at rest (~90s)
+## 2 · Tour of Monitoring (~45 seconds, optional opener)
 
-Walk through what's already on screen. The seed pack means the dashboard is
-*already populated* — that's the whole point.
+Click **Monitoring** in the sidebar first if you have time.
 
-### Hero
-> "This is what we're tracking: 20 perception prompts fanned across Netflix and
-> 5 competitors, every prompt answered by the frontier models, results rolled
-> into share of voice, sentiment, and feature gaps."
+> *"Before we get to head-to-head benchmarking, here's what daily monitoring
+> looks like. Twelve prompts — the actual queries customers are asking AI
+> chatbots about streaming services. Sentiment is colour-coded per prompt:
+> green where Netflix wins the answer, red where it loses, neutral where it's
+> in the middle."*
 
-### Share of Voice (top-left)
-> "Netflix is the leader at ~25% share of voice across all the prompts. Apple
-> TV+ is rising — 21%. Paramount+ is trailing in the single digits."
+Point at:
+- The 7-day sentiment trend (the line goes from -0.18 to +0.26 to -0.06).
+- The mix of green / neutral / red pills in the table — you don't get to
+  cherry-pick; AI says what it says.
+- The **Add a prompt** input at the bottom: "Marketing teams add prompts they
+  care about; we re-run them daily and surface drift."
 
-Point at the bars. The visual story is obvious because we sorted descending and
-each brand has its own colour.
+Skip this section entirely if your slot is tight. Benchmarking is the moneyshot.
 
-### Sentiment (top-right)
-> "Sentiment is where it gets interesting. Apple TV+ has the highest sentiment
-> score even though Netflix has more share. That's the prestige-originals
-> narrative beating the incumbent on quality."
+---
+
+## 3 · Benchmarking dashboard at rest (~90 seconds)
+
+Click **Benchmarking** in the sidebar. The dashboard is *already populated* —
+that's the seed pack doing its job.
+
+### Hero (read this verbatim)
+> *"This is what we're tracking: 20 perception prompts fanned across Netflix and
+> 5 streaming competitors, every prompt answered by frontier models, results
+> rolled into share of voice, sentiment, feature gaps, and whitespace."*
+
+### Share of voice
+> *"Netflix is the leader at ~25% share of voice across all the prompts. Apple
+> TV+ is rising — 21%. Paramount+ is in the single digits."*
+
+Point at the bars. Sorted descending; brand-coloured fills.
+
+### Sentiment
+> *"Sentiment is where it gets interesting. **Apple TV+ has the highest sentiment**
+> even though Netflix has more share. That's the prestige-originals narrative
+> beating the incumbent on quality. The gauge runs -1 to +1; pin colour flips
+> red for negative, green for positive."*
 
 ### Feature signal
-> "These are the themes the judge LLM repeatedly attached to each brand. Netflix
-> wins on `leadership` and `originals`. Disney+ wins on `family` and `ip`. Max
-> wins on `prestige`. **Notice nothing on Netflix says `value` or `innovation`**
-> — that's a problem."
+> *"These are the themes the judge LLM repeatedly attached to each brand across
+> the 20 prompts. Netflix wins on `leadership` and `originals`. Disney+ owns
+> `family` and `ip`. Max owns `prestige`. **Notice nothing on Netflix says
+> `value` or `innovation`** — that's a problem."*
 
 ### Feature praise gaps (the punchline)
-> "Right here, Perception flagged it: **Amazon Prime is praised on `value`;
-> Netflix isn't.** And **Apple TV+ owns `innovation`; Netflix isn't mentioned.**
-> Two clear gaps the marketing team can act on."
+> *"Right here, Perception flagged it: **Amazon Prime is praised on `value`;
+> Netflix isn't.** And **Apple TV+ owns `innovation`; Netflix is barely
+> mentioned.** Two clear gaps the marketing team can act on."*
 
-### Whitespace opportunities
-> "And here's whitespace: AI assistants don't decisively recommend any one
-> brand for live sports. That's a category Netflix could move into and own."
+### Whitespace
+> *"And here's whitespace: AI assistants don't decisively recommend any one
+> brand for **live sports**. That's a category Netflix could move into and own."*
 
-This whole section sells the differentiation: every other tool stops at "here's
-what AI says." We surface **gaps and whitespace**.
+This is the differentiator pitch: every other tool stops at *here's what AI
+says*. We surface **gaps and whitespace** — what to do about it.
 
 ---
 
-## 3. The live run (~2–3 min, narrate while it runs)
+## 4 · The live run (~2–3 minutes, narrate while it runs)
 
 Click **Run benchmark** with the default Netflix slate.
 
-The Theater section appears with six branded columns. While it streams:
+The Theater section appears with six brand columns. While it streams:
 
-> "What you're watching live is the platform fanning twenty prompts across
+> *"What you're watching live is the platform fanning twenty prompts across
 > every brand simultaneously. Each column is one of the streaming services.
 > The cursor blinks while OpenAI is mid-stream. The bar at the top of each
-> column fills as prompts complete."
+> column fills as prompts complete."*
 
 Things to point at:
 
 - The **Judge LLM** aside that pops in between brand answers — that's the
   comparative scoring step.
-- The progress counters (`0/20 → 1/20 → 2/20 …`).
+- The progress counters: `0/20 → 1/20 → 2/20 …`.
 - The fact that **all six brands run in parallel** at concurrency 4 — that's
-  why it finishes in ~45 seconds instead of 5+ minutes.
+  why it finishes in ~45–60 seconds instead of 5+ minutes.
 
-If the run takes longer than expected, fill the time:
+Filler narration if the run drags:
 
-> "The reason this matters operationally: in the AI era, brand visibility is
+> *"The reason this matters operationally: in the AI era, brand visibility is
 > non-deterministic. The same prompt gives different answers tomorrow. So the
 > only honest way to measure brand presence in AI is to keep running prompts
-> on a schedule — exactly what Perception does."
+> on a schedule — exactly what Perception does. Every 24 hours, the same 20
+> prompts, the same six brands, fresh comparisons."*
+
+If you have ~45 more seconds:
+
+> *"Behind the scenes, every answer feeds a comparative judge LLM that scores
+> share of voice as a probability distribution that sums to 1. Sentiment is a
+> -1 to +1 score per brand per prompt. Feature attribution is constrained to
+> a fixed taxonomy so we can roll it up over time. None of this is keyword
+> matching — it's all LLM-judged."*
 
 ---
 
-## 4. Post-run reveal (~60s)
+## 5 · Post-run reveal (~60 seconds)
 
 When the Theater finishes, the dashboard panels update with the merged data
 (7 days of seeded history + today's fresh run).
 
-> "Now the dashboard has refreshed with the new run on top of the 7 days of
-> historical data. Trends rolls forward. New gap events get detected. If
-> Netflix's marketing team did this every Monday morning, they'd have a moving
-> picture of how AI's perception of their brand is changing."
+> *"Now the dashboard has refreshed. Trends rolls forward. New gap events get
+> detected. If Netflix's marketing team did this every Monday morning, they'd
+> have a moving picture of how AI's perception of their brand is changing
+> — week over week, prompt by prompt."*
 
 Scroll to **Trend snapshot** and point at the daily mini-bars:
 
-> "Daily averages, one row per day, per brand. You can see Netflix's share is
-> stable, Apple TV+ is rising, Paramount+ is volatile."
+> *"Daily averages. One row per day, per brand. Netflix's share is stable.
+> Apple TV+ is climbing. Paramount+ is volatile."*
+
+Scroll to **Run configuration**:
+
+> *"And every run is auditable. Here's the exact account, competitors, window,
+> and timestamp. If a CMO asks 'what was running when?', we can answer."*
 
 ---
 
-## 5. Closing pitch (~30s)
+## 6 · Closing pitch (~30 seconds)
 
-> "Three things we do that no competitor does today:
+> *"Three things we do that no competitor does today:*
 >
 > 1. **We tell you where the gaps are**, not just where you stand.
 > 2. **We surface whitespace** — categories AI hasn't decided yet, where you
 >    can plant a flag.
-> 3. **We make the run itself a story** — that Theater isn't just polish, it's
+> 3. **We make the run itself a story** — the Theater isn't just polish, it's
 >    how you build conviction with a CMO that the data is real.
 >
-> Built by the team in 4 weeks. Currently tracks GPT-class models; Claude and
-> Gemini are the next integrations. Hallucination detection — ChatGPT
-> inventing wrong pricing or features — is the next major feature."
+> *Built by the team in 4 weeks. Today it tracks GPT-class models; Claude and
+> Gemini are next. Hallucination detection — ChatGPT inventing wrong pricing
+> or features — is the next major feature."*
 
 ---
 
-## 6. Likely Q&A — quick answers
-
-| Question | Quick answer |
-|---|---|
-| Are you using a real LLM or mocking? | Live OpenAI for both the perception prompts and the comparative judge. The pill says `live · openai` in the run config. |
-| What models? | `gpt-4.1-mini` for both answers and judging. Multi-provider abstraction is in flight. |
-| How are the prompts chosen? | 10 brand-specific (each retailer's name substituted) plus 10 category-wide leadership prompts. Configurable per cohort. |
-| How long does a real run take? | ~30–60 seconds for 6 brands × 20 prompts at concurrency 4. |
-| What happens with hallucinations? | We have a v0 detector for fact-sheet contradictions (pricing, founding year, HQ) — not in this demo, separate branch. |
-| What's the data model? | All in-memory for the prototype. SQLite store for business profiles already wired; competitive store moves to Postgres next. |
-| Differentiator vs Profound / Peec? | They're monitoring dashboards. We close the loop: detection → diagnosis → recommended action → before-and-after measurement. |
-| Privacy / data? | Brand-provided fact sheets stay client-side until a run. AI answers we generate ourselves; we don't scrape user conversations. |
-
----
-
-## 7. Backup script (use this if the live run fails)
+## 7 · Backup script (use this if the live run fails)
 
 If `bun run dev` won't start, OpenAI rate-limits, or the network drops:
 
-1. Set `PERCEPTION_DEMO_SEED=1` (default — already on) and **don't click Run**.
-2. The dashboard is already populated from the seed, so do steps 1–2 of the
-   real script (Hero → Share of Voice → Sentiment → Feature signal → Whitespace)
-   without relying on a live run at all.
-3. For the "live moment", show the Theater on a **previously recorded
-   screen capture** if you made one. Otherwise:
-4. Click Run anyway — even without a key, the mock LLM produces deterministic
-   output and the Theater still plays. It just takes ~5s. Narrate it as
-   "we're running in offline mode for the demo so the Zoom doesn't lag."
+1. The dashboard is already populated by the seed pack — do **steps 1, 2, 3,
+   5, 6** of the real script and skip step 4 entirely.
+2. For the "live moment", click Run anyway — even without a key, the mock LLM
+   returns deterministic placeholder text and the Theater plays. Narrate it
+   as: *"we're running in offline demo mode so the Zoom doesn't lag."*
+3. Fallback fallback: if the Run button hangs, hit `Cmd+Shift+R` to refresh,
+   the seeded data re-hydrates immediately. No live run needed.
 
 ---
 
-## 8. Two-minute version (if your slot gets cut short)
+## 8 · Two-minute version (if your slot gets cut short)
 
 If the CA tells you to wrap in 90 seconds:
 
-1. **Hero + dashboard** (already populated): "AI is the new search; here's how
-   AI talks about Netflix vs every other streamer. We track 20 prompts × 6
-   brands daily."
+1. **Hero + dashboard** (already populated): *"AI is the new search; here's
+   how AI talks about Netflix vs every other streamer. We track 20 prompts ×
+   6 brands daily."*
 2. **Skip the live run.** Just point at the populated bars + sentiment + gaps.
-3. **Punchline gap**: "Amazon owns `value`, Apple TV+ owns `innovation`;
-   Netflix is missing both. We surface that. Nobody else does."
-4. **Close**: "Profound monitors. We diagnose."
+3. **Punchline gap**: *"Amazon owns `value`, Apple TV+ owns `innovation`;
+   Netflix is missing both. We surface that. Nobody else does."*
+4. **Close**: *"Profound monitors. We diagnose."*
 
 That hits visibility, differentiation, and the strongest example in 90s.
 
 ---
 
-## File map (for reviewers reading the code)
+## 9 · Q&A — quick answers
 
-- `server/seed/streaming.ts` — the seeded cohort and 7 days of synthetic
-  comparisons + gap events.
+| Question | Quick answer |
+|---|---|
+| Are you using a real LLM or mocking? | Live OpenAI for both the perception prompts and the comparative judge. The Run config block shows mode: `live · openai`. |
+| What models? | `gpt-4.1-mini` for both answers and judging. Multi-provider abstraction is in flight on a separate branch. |
+| How are the prompts chosen? | 10 brand-specific (each retailer's name substituted) plus 10 category-wide leadership prompts. The prompt set is configurable per cohort. |
+| How long does a real run take? | ~30–60 seconds for 6 brands × 20 prompts × concurrency 4. Theater fills the time visually. |
+| What about hallucinations? | We have a v0 detector (regex-based contradictions for pricing / founding year / HQ) on a separate branch. Coming back to it post-demo. |
+| What's the data model? | SQLite for business profiles, monitoring prompts, and competitor lists. In-memory for the competitive pipeline (prompt runs / answers / comparisons / gap events) — moving to Postgres is the next migration. |
+| Differentiator vs Profound / Peec? | They're monitoring dashboards. We close the loop: detection → diagnosis (gap events) → recommended action → before-and-after measurement. |
+| Privacy / data? | Brand-provided fact sheets stay client-side until a run. AI answers we generate ourselves; we never scrape user conversations. |
+| Cost per run? | ~$0.03 per benchmark run on `gpt-4.1-mini` (120 short answers + 20 short judge passes). Linear with brands × prompts. |
+| Why streaming for the demo? | Universally recognised; sharp narrative differentiation across `leader`, `value`, `innovation`, `family`, `prestige`, `sports`. |
+
+---
+
+## 10 · The story arc the data tells
+
+This is the underlying narrative the screenshots support — useful if a CA asks
+*"what's actually interesting here?"*
+
+| Brand | Owns | Loses | Why |
+|---|---|---|---|
+| **Netflix** | `leadership`, `content_volume`, `originals` | `value`, `innovation` | Incumbent leader; pricing fatigue + Apple TV+ stealing the prestige-originals narrative |
+| **Disney+** | `family`, `ip` | `prestige`, `value-for-quality` | IP-driven (Marvel / Star Wars / Pixar) but seen as kids-first |
+| **Max** | `prestige`, `content_quality` | `value`, `innovation` | HBO heritage carries quality narrative; expensive |
+| **Amazon Prime** | `value`, `bundle`, `sports` | `prestige` | Bundle-driven; never reads as premium |
+| **Apple TV+** | `innovation`, `quality`, `originals` | `value`, `library_size` | Small library, prestige originals — punching above weight on perception |
+| **Paramount+** | (narrowly) `sports` | most other dimensions | Scrappy, fights for relevance |
+
+The two **gap events** Perception surfaces directly mirror this:
+1. *Amazon Prime is praised on `value`; Netflix is unmentioned.*
+2. *Apple TV+ owns the innovation narrative; Netflix is barely mentioned.*
+
+The one **whitespace event**:
+- *Live-sports prompts surface Amazon Prime Video and Paramount+; Netflix is
+  absent from the consensus answer.*
+
+If you only remember three numbers from this doc, remember:
+- **38%** — Netflix's share of voice on the *who is the streaming leader*
+  prompt (highest of any brand on any prompt in the cohort).
+- **+0.65** — Apple TV+'s sentiment on the *most innovative* prompt (highest
+  positive sentiment in the cohort).
+- **-0.05 → +0.50** — Paramount+'s swing between *value* (positive) and
+  *premium* (slightly negative). Schizophrenic positioning.
+
+---
+
+## 11 · File map (for reviewers reading the code)
+
+- `server/seed/streaming.ts` — the seeded competitive cohort (Netflix vs five
+  streamers) + 7 days of synthetic comparisons + 3 gap events.
+- `server/seed/netflix-profile.ts` — auto-creates the Netflix business profile,
+  saves the competitor list, and seeds 12 monitoring prompts on first boot.
+- `server/src/index.ts` — boot-time wiring; both seeds are loaded behind the
+  `PERCEPTION_DEMO_SEED` flag (set to `0` to disable).
 - `server/src/routes/competitive.ts` — `/competitive/snapshot` powers the
-  first-paint preview the dashboard auto-loads on mount.
-- `server/src/routes/llm-status.ts` — `/llm/status` surfaces live vs mock.
+  first-paint preview the dashboard auto-loads.
+- `server/src/routes/llm-status.ts` — `/llm/status` reports live vs mock.
 - `web/src/components/competitive/LiveRunTheater.tsx` — the streaming column
-  panel users see during a run.
-- `web/src/pages/competitive.tsx` — page composition: hero, picker, theater,
-  charts, trend snapshot, run config.
+  panel during a run.
+- `web/src/pages/competitive.tsx` — page composition: picker, theater, charts,
+  trend snapshot, run configuration.
+
+---
+
+## 12 · After the demo
+
+Open the team Slack with three notes:
+
+1. **Which CA / team gave you which feedback** — verbatim where possible.
+2. **Whether the live run hit OpenAI or fell back to mock.**
+3. **Three follow-up tasks** to file as issues. Suggested defaults:
+   - Hallucination detection v1 (LLM-driven claim extraction beyond regex)
+   - Multi-provider live mode (Claude + Gemini answers in parallel)
+   - Recommendations tab v1 (turn gap events into actionable cards)

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,15 @@
+# Copy to server/.env and fill in your key.
+# Without a key the server falls back to a deterministic mock LLM —
+# fine for UI demos, but no real AI answers.
+
+# Required for live LLM mode:
+OPENAI_API_KEY=
+
+# Optional: pin a different provider (currently only "openai" is supported).
+# LLM_PROVIDER=openai
+
+# Optional: turn the demo seed off if you want a fresh empty store.
+# PERCEPTION_DEMO_SEED=0
+
+# Optional: change the API port (default 3000).
+# PORT=3000

--- a/server/seed/netflix-profile.ts
+++ b/server/seed/netflix-profile.ts
@@ -1,0 +1,63 @@
+import { businessProfiles } from "../src/db/business-profiles";
+import { monitoringPrompts } from "../src/db/monitoring-prompts";
+
+/**
+ * Demo seed: pre-create a Netflix business profile with monitoring prompts +
+ * saved competitor list, so all four sidebar sections have real content on
+ * first paint without onboarding. Idempotent — looks for an existing Netflix
+ * profile before inserting.
+ */
+
+const PROFILE_NAME = "Netflix";
+const PROFILE_WEBSITE = "https://www.netflix.com";
+const PROFILE_DESCRIPTION =
+  "Streaming entertainment service with 260M+ paid memberships in over 190 countries. Originals across film, series, documentaries, and games.";
+
+const SAVED_COMPETITORS = ["Disney+", "Max", "Amazon Prime Video", "Apple TV+", "Paramount+"];
+
+const MONITORING_PROMPTS: ReadonlyArray<string> = [
+  "What is the best streaming service for movies and TV shows in 2026?",
+  "Compare Netflix vs Disney+ for families with young kids.",
+  "Which streaming service has the best original content right now?",
+  "Is Netflix worth it if I already have Amazon Prime?",
+  "What streaming service has the best live sports coverage?",
+  "Best streaming service with no ads at the cheapest price?",
+  "Which streaming platform releases the most prestige TV series?",
+  "What is the best streaming service for K-dramas and Korean content?",
+  "Should I cancel Netflix? What are the best alternatives in 2026?",
+  "Compare the ad-supported tiers on Netflix, Max, and Disney+.",
+  "Which streaming service has the largest film library?",
+  "Best streaming service for binge-watching original drama series?",
+];
+
+export interface ProfileSeedSummary {
+  created: boolean;
+  profileId: string;
+  monitoringCount: number;
+}
+
+export function loadNetflixProfileSeed(): ProfileSeedSummary {
+  const existing = businessProfiles.list().find((profile) => profile.name === PROFILE_NAME);
+  if (existing) {
+    return {
+      created: false,
+      profileId: existing.id,
+      monitoringCount: monitoringPrompts.list(existing.id).length,
+    };
+  }
+
+  const profile = businessProfiles.create({
+    name: PROFILE_NAME,
+    website: PROFILE_WEBSITE,
+    description: PROFILE_DESCRIPTION,
+  });
+  businessProfiles.saveCompetitors(profile.id, [...SAVED_COMPETITORS]);
+  monitoringPrompts.replaceAll(profile.id, [...MONITORING_PROMPTS]);
+  monitoringPrompts.setStatus(profile.id, "ready");
+
+  return {
+    created: true,
+    profileId: profile.id,
+    monitoringCount: MONITORING_PROMPTS.length,
+  };
+}

--- a/server/seed/streaming.ts
+++ b/server/seed/streaming.ts
@@ -1,0 +1,526 @@
+import { seedPromptSetId, store } from "../src/db/store";
+import type {
+  Brand,
+  ComparativeDelta,
+  CompetitorSet,
+  GapEvent,
+  PromptRun,
+} from "../src/features/competitive/types";
+
+/**
+ * Demo seed: a recognizable streaming-services competitive cohort with 7 days
+ * of synthetic benchmark history. Netflix is the account brand vs Disney+,
+ * Max, Amazon Prime Video, Apple TV+, and Paramount+. The synthetic story
+ * arc: Netflix dominates "leader / best overall" but loses ground on "value"
+ * (Amazon Prime bundle) and "innovation" (Apple TV+ originals).
+ *
+ * Loads brands, a competitor set, prompt runs across the last week, one
+ * comparison + a couple of gap events per run. We deliberately skip seeding
+ * `AIAnswer` rows: the dashboard reads only prompt runs, comparisons, and
+ * gap events.
+ */
+
+const ACCOUNT_BRAND_NAME = "Netflix";
+const COMPETITOR_NAMES = ["Disney+", "Max", "Amazon Prime Video", "Apple TV+", "Paramount+"] as const;
+const MODEL = "gpt-4.1-mini";
+
+interface ScriptedComparison {
+  hoursAgo: number;
+  prompt: string;
+  promptKind: "brand_specific" | "domain_general";
+  shareByName: Record<string, number>;
+  sentimentByName: Record<string, number>;
+  praisedByName: Record<string, string[]>;
+  evidence: string[];
+}
+
+const SCRIPTED_COMPARISONS: ScriptedComparison[] = [
+  {
+    hoursAgo: 6 * 24,
+    prompt: "Who is most often described as the leader or reference standard in streaming?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.38,
+      "Disney+": 0.21,
+      "Max": 0.13,
+      "Amazon Prime Video": 0.12,
+      "Apple TV+": 0.09,
+      "Paramount+": 0.07,
+    },
+    sentimentByName: {
+      "Netflix": 0.6,
+      "Disney+": 0.45,
+      "Max": 0.4,
+      "Amazon Prime Video": 0.3,
+      "Apple TV+": 0.45,
+      "Paramount+": 0.1,
+    },
+    praisedByName: {
+      "Netflix": ["leadership", "content_volume", "originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige", "content_quality"],
+      "Amazon Prime Video": ["bundle", "value"],
+      "Apple TV+": ["originals", "quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Netflix consistently framed as the streaming category reference standard.",
+      "Disney+ trails as a strong second on the back of Marvel / Star Wars / Pixar.",
+      "Paramount+ rarely surfaces unless live sports comes up.",
+    ],
+  },
+  {
+    hoursAgo: 5 * 24,
+    prompt: "How is {brand} generally perceived on trustworthiness and delivering on what it promises?",
+    promptKind: "brand_specific",
+    shareByName: {
+      "Netflix": 0.3,
+      "Disney+": 0.22,
+      "Max": 0.16,
+      "Amazon Prime Video": 0.12,
+      "Apple TV+": 0.13,
+      "Paramount+": 0.07,
+    },
+    sentimentByName: {
+      "Netflix": 0.55,
+      "Disney+": 0.5,
+      "Max": 0.45,
+      "Amazon Prime Video": 0.35,
+      "Apple TV+": 0.55,
+      "Paramount+": 0.05,
+    },
+    praisedByName: {
+      "Netflix": ["reliability", "originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Netflix trust narrative dominates — buyers expect titles to ship and queues to work.",
+      "Apple TV+ over-indexes on trust given small library — quality reputation.",
+      "Paramount+ trust narrative weaker; framed as scrappy and inconsistent.",
+    ],
+  },
+  {
+    hoursAgo: 4 * 24,
+    prompt: "Which player is most associated with the best value—quality relative to price?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.13,
+      "Disney+": 0.18,
+      "Max": 0.07,
+      "Amazon Prime Video": 0.34,
+      "Apple TV+": 0.06,
+      "Paramount+": 0.22,
+    },
+    sentimentByName: {
+      "Netflix": 0.05,
+      "Disney+": 0.4,
+      "Max": 0.0,
+      "Amazon Prime Video": 0.6,
+      "Apple TV+": -0.05,
+      "Paramount+": 0.5,
+    },
+    praisedByName: {
+      "Netflix": ["originals"],
+      "Disney+": ["family", "ip", "bundle"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["value", "bundle", "sports"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["value", "sports"],
+    },
+    evidence: [
+      "Amazon Prime owns 'value' framing because it's bundled with Prime shipping.",
+      "Netflix sentiment near-neutral — repeatedly tagged as 'expensive lately'.",
+      "Paramount+ undercuts on price; surfaces alongside Prime in value answers.",
+    ],
+  },
+  {
+    hoursAgo: 3 * 24,
+    prompt: "Who is seen as the most innovative or future-oriented in this space?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.2,
+      "Disney+": 0.12,
+      "Max": 0.1,
+      "Amazon Prime Video": 0.1,
+      "Apple TV+": 0.36,
+      "Paramount+": 0.12,
+    },
+    sentimentByName: {
+      "Netflix": 0.35,
+      "Disney+": 0.25,
+      "Max": 0.2,
+      "Amazon Prime Video": 0.2,
+      "Apple TV+": 0.65,
+      "Paramount+": 0.1,
+    },
+    praisedByName: {
+      "Netflix": ["originals", "recommendations"],
+      "Disney+": ["family"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["innovation", "quality", "originals"],
+      "Paramount+": ["scrappy"],
+    },
+    evidence: [
+      "Apple TV+ owns the innovation narrative via prestige originals like Severance and Ted Lasso.",
+      "Netflix innovation share lags expected scale — viewed as 'incumbent' rather than 'forward'.",
+      "Paramount+ rarely cited in forward-looking answers.",
+    ],
+  },
+  {
+    hoursAgo: 2 * 24,
+    prompt: "How is {brand}'s customer experience perceived?",
+    promptKind: "brand_specific",
+    shareByName: {
+      "Netflix": 0.32,
+      "Disney+": 0.24,
+      "Max": 0.13,
+      "Amazon Prime Video": 0.16,
+      "Apple TV+": 0.1,
+      "Paramount+": 0.05,
+    },
+    sentimentByName: {
+      "Netflix": 0.55,
+      "Disney+": 0.55,
+      "Max": 0.4,
+      "Amazon Prime Video": 0.35,
+      "Apple TV+": 0.5,
+      "Paramount+": 0.05,
+    },
+    praisedByName: {
+      "Netflix": ["recommendations", "reliability"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Netflix and Disney+ tied on UX polish; Disney+ wins for family flows.",
+      "Amazon Prime UX inconsistent — buy-vs-rent confusion surfaces repeatedly.",
+      "Paramount+ framed as transactional and ad-heavy.",
+    ],
+  },
+  {
+    hoursAgo: 1 * 24,
+    prompt: "Which brand is most associated with premium quality, status, or exclusivity?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.18,
+      "Disney+": 0.14,
+      "Max": 0.32,
+      "Amazon Prime Video": 0.05,
+      "Apple TV+": 0.27,
+      "Paramount+": 0.04,
+    },
+    sentimentByName: {
+      "Netflix": 0.35,
+      "Disney+": 0.4,
+      "Max": 0.6,
+      "Amazon Prime Video": 0.0,
+      "Apple TV+": 0.6,
+      "Paramount+": -0.05,
+    },
+    praisedByName: {
+      "Netflix": ["originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige", "content_quality"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["quality", "originals"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Max and Apple TV+ split the premium narrative: HBO heritage vs Apple polish.",
+      "Amazon Prime firmly outside the prestige tier despite its scale.",
+      "Paramount+ seldom present in premium conversations.",
+    ],
+  },
+  {
+    hoursAgo: 12,
+    prompt: "How is {brand}'s value for money perceived?",
+    promptKind: "brand_specific",
+    shareByName: {
+      "Netflix": 0.14,
+      "Disney+": 0.18,
+      "Max": 0.07,
+      "Amazon Prime Video": 0.32,
+      "Apple TV+": 0.08,
+      "Paramount+": 0.21,
+    },
+    sentimentByName: {
+      "Netflix": 0.05,
+      "Disney+": 0.45,
+      "Max": -0.05,
+      "Amazon Prime Video": 0.6,
+      "Apple TV+": -0.05,
+      "Paramount+": 0.5,
+    },
+    praisedByName: {
+      "Netflix": ["originals"],
+      "Disney+": ["family", "bundle"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["value", "bundle"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["value", "sports"],
+    },
+    evidence: [
+      "Amazon Prime retains value ownership week over week thanks to the Prime bundle.",
+      "Netflix value sentiment near-neutral — ad-tier helps but pricing fatigue persists.",
+      "Apple TV+ called out as 'expensive for what you get' on small library.",
+    ],
+  },
+  {
+    hoursAgo: 6,
+    prompt: "Who is widely seen as the most reliable choice when the stakes are high?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.34,
+      "Disney+": 0.23,
+      "Max": 0.16,
+      "Amazon Prime Video": 0.13,
+      "Apple TV+": 0.08,
+      "Paramount+": 0.06,
+    },
+    sentimentByName: {
+      "Netflix": 0.6,
+      "Disney+": 0.5,
+      "Max": 0.5,
+      "Amazon Prime Video": 0.35,
+      "Apple TV+": 0.45,
+      "Paramount+": 0.05,
+    },
+    praisedByName: {
+      "Netflix": ["reliability", "leadership", "originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Netflix reliability narrative strongest for 'I just want something to work'.",
+      "Disney+ reliable for family viewing; Paramount+ rarely cited as a high-stakes pick.",
+      "Apple TV+ reliable but constrained by smaller library footprint.",
+    ],
+  },
+  {
+    hoursAgo: 3,
+    prompt: "How is {brand}'s pace of innovation seen relative to peers?",
+    promptKind: "brand_specific",
+    shareByName: {
+      "Netflix": 0.21,
+      "Disney+": 0.13,
+      "Max": 0.1,
+      "Amazon Prime Video": 0.1,
+      "Apple TV+": 0.37,
+      "Paramount+": 0.09,
+    },
+    sentimentByName: {
+      "Netflix": 0.3,
+      "Disney+": 0.25,
+      "Max": 0.2,
+      "Amazon Prime Video": 0.15,
+      "Apple TV+": 0.65,
+      "Paramount+": 0.0,
+    },
+    praisedByName: {
+      "Netflix": ["originals", "recommendations"],
+      "Disney+": ["family"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle"],
+      "Apple TV+": ["innovation", "quality", "originals"],
+      "Paramount+": ["scrappy"],
+    },
+    evidence: [
+      "Apple TV+ extends innovation lead week over week with prestige originals.",
+      "Netflix innovation share lags expected scale; framed as 'mature' not 'next'.",
+      "Paramount+ registers a flat-to-negative innovation sentiment.",
+    ],
+  },
+  {
+    hoursAgo: 1,
+    prompt: "Who is most often described as gaining ground versus those losing relevance?",
+    promptKind: "domain_general",
+    shareByName: {
+      "Netflix": 0.26,
+      "Disney+": 0.16,
+      "Max": 0.13,
+      "Amazon Prime Video": 0.16,
+      "Apple TV+": 0.21,
+      "Paramount+": 0.08,
+    },
+    sentimentByName: {
+      "Netflix": 0.45,
+      "Disney+": 0.3,
+      "Max": 0.3,
+      "Amazon Prime Video": 0.35,
+      "Apple TV+": 0.6,
+      "Paramount+": 0.05,
+    },
+    praisedByName: {
+      "Netflix": ["leadership", "originals"],
+      "Disney+": ["family", "ip"],
+      "Max": ["prestige"],
+      "Amazon Prime Video": ["bundle", "value"],
+      "Apple TV+": ["innovation", "quality"],
+      "Paramount+": ["sports"],
+    },
+    evidence: [
+      "Apple TV+ rising fastest; Netflix holding steady at the top of the chart.",
+      "Paramount+ consistently framed as fighting for relevance.",
+      "Disney+ and Max trade incremental ground week to week.",
+    ],
+  },
+];
+
+function ensureBrand(name: string): Brand {
+  for (const existing of store.brands.values()) {
+    if (existing.name === name) {
+      return existing;
+    }
+  }
+  const brand: Brand = { id: crypto.randomUUID(), name };
+  store.brands.set(brand.id, brand);
+  return brand;
+}
+
+function ensureCompetitorSet(accountBrand: Brand, competitors: Brand[]): CompetitorSet {
+  for (const set of store.competitorSets.values()) {
+    if (set.accountBrandId === accountBrand.id) {
+      return set;
+    }
+  }
+  if (competitors.length !== 5) {
+    throw new Error("Demo seed expects exactly five competitors.");
+  }
+  const set: CompetitorSet = {
+    id: crypto.randomUUID(),
+    accountBrandId: accountBrand.id,
+    competitorBrandIds: [
+      competitors[0]!.id,
+      competitors[1]!.id,
+      competitors[2]!.id,
+      competitors[3]!.id,
+      competitors[4]!.id,
+    ],
+    createdAt: new Date().toISOString(),
+  };
+  store.competitorSets.set(set.id, set);
+  return set;
+}
+
+function remapByBrandId(map: Record<string, number | string[]>, byName: Record<string, Brand>) {
+  const result: Record<string, number | string[]> = {};
+  for (const [name, value] of Object.entries(map)) {
+    const brand = byName[name];
+    if (brand) {
+      result[brand.id] = value;
+    }
+  }
+  return result;
+}
+
+function buildGapEvents(brandsByName: Record<string, Brand>, promptRunsByIndex: PromptRun[]): GapEvent[] {
+  const netflix = brandsByName["Netflix"]!;
+  const amazon = brandsByName["Amazon Prime Video"]!;
+  const apple = brandsByName["Apple TV+"]!;
+
+  return [
+    {
+      id: crypto.randomUUID(),
+      gapType: "feature_praise_gap",
+      brandId: netflix.id,
+      competitorBrandId: amazon.id,
+      promptRunId: promptRunsByIndex[2]!.id,
+      featureKey: "value",
+      evidence: ["Amazon Prime is repeatedly praised on value via the Prime bundle; Netflix is unmentioned."],
+      confidence: 0.78,
+      detectedAt: new Date().toISOString(),
+    },
+    {
+      id: crypto.randomUUID(),
+      gapType: "feature_praise_gap",
+      brandId: netflix.id,
+      competitorBrandId: apple.id,
+      promptRunId: promptRunsByIndex[3]!.id,
+      featureKey: "innovation",
+      evidence: ["Apple TV+ owns the innovation narrative via prestige originals; Netflix barely mentioned."],
+      confidence: 0.71,
+      detectedAt: new Date().toISOString(),
+    },
+    {
+      id: crypto.randomUUID(),
+      gapType: "whitespace",
+      brandId: netflix.id,
+      promptRunId: promptRunsByIndex[6]!.id,
+      categoryKey: "live_sports",
+      evidence: [
+        "Live-sports prompts surface Amazon Prime Video and Paramount+; Netflix absent from the consensus answer.",
+      ],
+      confidence: 0.66,
+      detectedAt: new Date().toISOString(),
+    },
+  ];
+}
+
+export interface DemoSeedSummary {
+  accountBrandId: string;
+  competitorBrandIds: string[];
+  promptRunCount: number;
+  comparisonCount: number;
+  gapEventCount: number;
+}
+
+export function loadStreamingSeed(): DemoSeedSummary {
+  const accountBrand = ensureBrand(ACCOUNT_BRAND_NAME);
+  const competitorBrands = COMPETITOR_NAMES.map((name) => ensureBrand(name));
+  ensureCompetitorSet(accountBrand, competitorBrands);
+
+  const brandsByName: Record<string, Brand> = { [accountBrand.name]: accountBrand };
+  for (const brand of competitorBrands) {
+    brandsByName[brand.name] = brand;
+  }
+
+  const now = Date.now();
+  const promptRuns: PromptRun[] = [];
+  const comparisons: ComparativeDelta[] = [];
+
+  for (const scripted of SCRIPTED_COMPARISONS) {
+    const createdAt = new Date(now - scripted.hoursAgo * 60 * 60 * 1000).toISOString();
+    const run: PromptRun = {
+      id: crypto.randomUUID(),
+      promptSetId: seedPromptSetId,
+      prompt: scripted.prompt,
+      promptKind: scripted.promptKind,
+      model: MODEL,
+      createdAt,
+    };
+    store.promptRuns.set(run.id, run);
+    promptRuns.push(run);
+
+    const comparison: ComparativeDelta = {
+      promptRunId: run.id,
+      shareOfVoiceByBrand: remapByBrandId(scripted.shareByName, brandsByName) as Record<string, number>,
+      sentimentByBrand: remapByBrandId(scripted.sentimentByName, brandsByName) as Record<string, number>,
+      praisedFeaturesByBrand: remapByBrandId(scripted.praisedByName, brandsByName) as Record<string, string[]>,
+      evidence: scripted.evidence,
+    };
+    store.comparisons.push(comparison);
+    comparisons.push(comparison);
+  }
+
+  const gapEvents = buildGapEvents(brandsByName, promptRuns);
+  store.gapEvents.push(...gapEvents);
+
+  return {
+    accountBrandId: accountBrand.id,
+    competitorBrandIds: competitorBrands.map((b) => b.id),
+    promptRunCount: promptRuns.length,
+    comparisonCount: comparisons.length,
+    gapEventCount: gapEvents.length,
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,15 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { loadStreamingSeed } from "../seed/streaming";
 import { businessRoutes } from "./routes/business";
 import { competitiveRoutes } from "./routes/competitive";
+
+if ((process.env.PERCEPTION_DEMO_SEED ?? "1") !== "0") {
+  const summary = loadStreamingSeed();
+  console.log(
+    `[seed] Loaded streaming demo cohort: ${summary.promptRunCount} prompt runs, ${summary.comparisonCount} comparisons, ${summary.gapEventCount} gap events.`,
+  );
+}
 
 const app = new Hono();
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,13 +1,21 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { loadNetflixProfileSeed } from "../seed/netflix-profile";
 import { loadStreamingSeed } from "../seed/streaming";
 import { businessRoutes } from "./routes/business";
 import { competitiveRoutes } from "./routes/competitive";
 
 if ((process.env.PERCEPTION_DEMO_SEED ?? "1") !== "0") {
-  const summary = loadStreamingSeed();
+  const cohort = loadStreamingSeed();
   console.log(
-    `[seed] Loaded streaming demo cohort: ${summary.promptRunCount} prompt runs, ${summary.comparisonCount} comparisons, ${summary.gapEventCount} gap events.`,
+    `[seed] Loaded streaming demo cohort: ${cohort.promptRunCount} prompt runs, ${cohort.comparisonCount} comparisons, ${cohort.gapEventCount} gap events.`,
+  );
+
+  const profile = loadNetflixProfileSeed();
+  console.log(
+    profile.created
+      ? `[seed] Created Netflix business profile (${profile.profileId}) with ${profile.monitoringCount} monitoring prompts.`
+      : `[seed] Netflix business profile already exists (${profile.profileId}); ${profile.monitoringCount} monitoring prompts.`,
   );
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,13 +2,21 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { businessRoutes } from "./routes/business";
 import { competitiveRoutes } from "./routes/competitive";
+import { llmStatusRoutes } from "./routes/llm-status";
 
 const app = new Hono();
 
 app.use(
   "*",
   cors({
-    origin: ["http://localhost:5173", "http://127.0.0.1:5173"],
+    origin: [
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+      "http://localhost:5174",
+      "http://127.0.0.1:5174",
+      "http://localhost:5175",
+      "http://127.0.0.1:5175",
+    ],
     allowMethods: ["GET", "POST", "OPTIONS"],
   }),
 );
@@ -16,6 +24,7 @@ app.use(
 app.get("/health", (c) => c.json({ ok: true }));
 app.route("/", businessRoutes);
 app.route("/", competitiveRoutes);
+app.route("/", llmStatusRoutes);
 
 export default {
   port: Number(process.env.PORT ?? 3000),

--- a/server/src/routes/competitive.ts
+++ b/server/src/routes/competitive.ts
@@ -153,3 +153,56 @@ competitiveRoutes.get("/competitive/gaps", (c) => {
   const gaps = store.gapEvents.filter((event) => event.brandId === accountBrandId);
   return c.json({ count: gaps.length, gaps });
 });
+
+/**
+ * One-shot dashboard snapshot for first-paint preview. Picks the most recent
+ * competitor set in the store, resolves brand id → name labels, and returns
+ * overview + trends + gaps for the trailing windowDays (default 7) so the UI
+ * can hydrate seeded data on mount without a Run click.
+ */
+competitiveRoutes.get("/competitive/snapshot", (c) => {
+  const windowDays = Number(c.req.query("windowDays") ?? 7);
+  const windowStart = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+  const windowEnd = new Date().toISOString();
+
+  const sets = Array.from(store.competitorSets.values()).sort((a, b) =>
+    a.createdAt < b.createdAt ? 1 : -1,
+  );
+  const set = sets[0];
+  if (!set) {
+    return c.json({
+      hasData: false,
+      timeframe: { start: windowStart, end: windowEnd },
+      brandLabels: {},
+      overview: { rows: [] },
+      trends: { seriesByBrand: {} },
+      gaps: [],
+      accountBrandId: null,
+      accountBrandName: null,
+    });
+  }
+
+  const brandIds = [set.accountBrandId, ...set.competitorBrandIds];
+  const brandLabels: Record<string, string> = {};
+  for (const id of brandIds) {
+    const brand = store.brands.get(id);
+    if (brand) brandLabels[id] = brand.name;
+  }
+  const accountBrand = store.brands.get(set.accountBrandId);
+
+  const overview = buildCompetitiveOverview({ windowStart, windowEnd });
+  const trends = buildCompetitiveTrends({ windowStart, windowEnd });
+  const gaps = store.gapEvents.filter((event) => event.brandId === set.accountBrandId);
+
+  return c.json({
+    hasData: overview.rows.length > 0,
+    timeframe: { start: windowStart, end: windowEnd },
+    brandLabels,
+    overview,
+    trends,
+    gaps,
+    accountBrandId: set.accountBrandId,
+    accountBrandName: accountBrand?.name ?? null,
+    competitorBrandIds: set.competitorBrandIds,
+  });
+});

--- a/server/src/routes/llm-status.ts
+++ b/server/src/routes/llm-status.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+
+/**
+ * Reports whether the server is wired to a real LLM provider so the UI can
+ * show "Live" vs "Demo (mock)" without leaking the key itself.
+ */
+export const llmStatusRoutes = new Hono();
+
+llmStatusRoutes.get("/llm/status", (c) => {
+  const provider = process.env.LLM_PROVIDER ?? "openai";
+  const hasKey = provider === "openai" ? Boolean(process.env.OPENAI_API_KEY) : false;
+  return c.json({ provider, mode: hasKey ? "live" : "mock" });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
     />
   </head>
   <body>
@@ -20,7 +20,7 @@
           display: flex;
           align-items: center;
           justify-content: center;
-          font-family: 'Geist', system-ui, sans-serif;
+          font-family: 'Inter', system-ui, sans-serif;
           color: #475569;
           font-size: 16px;
           font-weight: 500;

--- a/web/index.html
+++ b/web/index.html
@@ -3,13 +3,32 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Perception Competitive Benchmarking</title>
+    <meta name="theme-color" content="#f7f4ec" />
+    <title>Perception · AI Visibility</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap"
+    />
   </head>
   <body>
     <div id="root">
-      <p style="margin: 24px; font-family: system-ui, sans-serif; color: #444">
-        Loading…
-      </p>
+      <div
+        style="
+          height: 100vh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: 'Geist', system-ui, sans-serif;
+          color: #475569;
+          font-size: 16px;
+          font-weight: 500;
+          letter-spacing: -0.01em;
+        "
+      >
+        Perception
+      </div>
     </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -191,8 +191,10 @@ export function ProfileDashboard({
       <section className="workspace">
         <header className="topbar">
           <div>
-            <p className="topbar__eyebrow">{activeNav.label}</p>
-            <h1>{profile.name}</h1>
+            <p className="topbar__eyebrow">
+              <span className="topbar__brand">{profile.name}</span>
+            </p>
+            <h1>{activeNav.label}</h1>
             <p className="topbar__sub">{activeNav.description}</p>
           </div>
         </header>
@@ -202,11 +204,13 @@ export function ProfileDashboard({
         ) : activePage === "benchmarking" ? (
           <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
         ) : (
-          <article className="panel wide-panel placeholder-panel">
-            <p className="muted">{activeNav.label}</p>
-            <h2>Coming soon for {profile.name}</h2>
-            <p>{activeNav.description}</p>
-            <dl>
+          <div className="block">
+            <header className="block__head">
+              <h2>Coming soon</h2>
+              <span className="block__kicker">{activeNav.label}</span>
+            </header>
+            <p className="muted" style={{ maxWidth: "60ch" }}>{activeNav.description}</p>
+            <dl className="run-meta">
               <div>
                 <dt>Website</dt>
                 <dd>{profile.website}</dd>
@@ -216,7 +220,7 @@ export function ProfileDashboard({
                 <dd>{profile.description}</dd>
               </div>
             </dl>
-          </article>
+          </div>
         )}
 
         {error && <p className="error">{error}</p>}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -76,7 +76,9 @@ export function App() {
       .then((res) => res.json())
       .then((body: { profiles: BusinessProfile[] }) => {
         setProfiles(body.profiles);
-        setActiveProfileId(body.profiles[0]?.id ?? "");
+        // Prefer the seeded demo brand if it exists, otherwise the first profile.
+        const seeded = body.profiles.find((p) => p.name === "Netflix");
+        setActiveProfileId((seeded ?? body.profiles[0])?.id ?? "");
       })
       .catch(() => setError("Could not load business profiles."))
       .finally(() => setLoading(false));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,10 @@ export function OnboardingForm({ onCreate }: { onCreate: (input: BusinessProfile
       }}
     >
       <h1>Set up your brand</h1>
+      <p className="muted">
+        We&rsquo;ll generate starter monitoring prompts and a competitive set from your website and brand
+        description.
+      </p>
       <label>
         Business name
         <input value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} />
@@ -50,19 +54,20 @@ export function OnboardingForm({ onCreate }: { onCreate: (input: BusinessProfile
 }
 
 type BusinessProfileInput = Pick<BusinessProfile, "name" | "website" | "description">;
-const pages = [
-  ["monitoring", "Monitoring", "Track AI mention frequency, sentiment, share of voice, and trends over time."],
-  ["benchmarking", "Benchmarking", "Compare your brand against competitors across AI answers."],
-  ["recommendations", "Recommendations", "Prioritized fix-it ideas will appear here after monitoring finds gaps."],
-  ["source-tracking", "Source Tracking", "Cited Reddit threads, publications, reviews, and other sources will appear here."],
+
+const navItems = [
+  { key: "monitoring", label: "Monitoring", description: "AI mention frequency, sentiment, and trends." },
+  { key: "benchmarking", label: "Benchmarking", description: "Compare your brand against competitors in AI answers." },
+  { key: "recommendations", label: "Recommendations", description: "Prioritized fix-it ideas from detected gaps." },
+  { key: "sources", label: "Sources", description: "Reddit, publications, reviews, and other sources AI cites." },
 ] as const;
 
-type PageKey = (typeof pages)[number][0];
+type PageKey = (typeof navItems)[number]["key"];
 
 export function App() {
   const [profiles, setProfiles] = useState<BusinessProfile[]>([]);
   const [activeProfileId, setActiveProfileId] = useState("");
-  const [activePage, setActivePage] = useState<PageKey>("monitoring");
+  const [activePage, setActivePage] = useState<PageKey>("benchmarking");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -94,7 +99,7 @@ export function App() {
   }
 
   if (loading) {
-    return <main className="page center-page">Loading...</main>;
+    return <main className="page center-page">Loading…</main>;
   }
 
   if (!profiles.length) {
@@ -137,15 +142,36 @@ export function ProfileDashboard({
   profiles: BusinessProfile[];
 }) {
   const profile = profiles.find((item) => item.id === activeProfileId) ?? profiles[0]!;
-  const page = pages.find(([key]) => key === activePage) ?? pages[0];
+  const activeNav = navItems.find((item) => item.key === activePage) ?? navItems[0];
 
   return (
     <main className="app-shell">
-      <aside className="sidebar">
-        <strong>Perception</strong>
-        <label>
-          Business
+      <aside className="sidebar" aria-label="Primary navigation">
+        <div className="brand-lockup">
+          <span className="brand-mark">P</span>
+          <div className="brand-lockup__text">
+            <strong>Perception</strong>
+            <span>AI visibility</span>
+          </div>
+        </div>
+
+        <nav className="nav-list" aria-label="Sections">
+          {navItems.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              className={activePage === item.key ? "nav-item active" : "nav-item"}
+              onClick={() => onSelectPage(item.key)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+
+        <div className="sidebar-footer">
+          <span className="sidebar-footer__label">Active brand</span>
           <select
+            className="sidebar-profile"
             aria-label="Active business profile"
             value={profile.id}
             onChange={(event) => onSelectProfile(event.target.value)}
@@ -156,28 +182,19 @@ export function ProfileDashboard({
               </option>
             ))}
           </select>
-        </label>
-        <label>
-          Section
-          <select value={activePage} onChange={(event) => onSelectPage(event.target.value as PageKey)}>
-            {pages.map(([key, label]) => (
-              <option key={key} value={key}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </label>
+          <button type="button" className="sidebar-add" onClick={onAddProfile}>
+            + Add brand
+          </button>
+        </div>
       </aside>
 
       <section className="workspace">
         <header className="topbar">
           <div>
-            <p className="muted">Business profile</p>
+            <p className="topbar__eyebrow">{activeNav.label}</p>
             <h1>{profile.name}</h1>
+            <p className="topbar__sub">{activeNav.description}</p>
           </div>
-          <button type="button" onClick={onAddProfile}>
-            New profile
-          </button>
         </header>
 
         {activePage === "monitoring" ? (
@@ -185,10 +202,10 @@ export function ProfileDashboard({
         ) : activePage === "benchmarking" ? (
           <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
         ) : (
-          <article className="panel">
-            <p className="muted">{page[1]}</p>
-            <h2>{profile.name}</h2>
-            <p>{page[2]}</p>
+          <article className="panel wide-panel placeholder-panel">
+            <p className="muted">{activeNav.label}</p>
+            <h2>Coming soon for {profile.name}</h2>
+            <p>{activeNav.description}</p>
             <dl>
               <div>
                 <dt>Website</dt>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from "react";
 import "./app.css";
 import { CompetitivePage } from "./pages/competitive";
 import { MonitoringPage } from "./pages/monitoring";
+import { RecommendationsPage } from "./pages/recommendations";
+import { SourcesPage } from "./pages/sources";
+import { DEMO_BRAND_NAME } from "./seed/demo-content";
 import type { BusinessProfile } from "./types";
 
 const API_BASE =
@@ -71,7 +74,9 @@ export function App() {
       .then((res) => res.json())
       .then((body: { profiles: BusinessProfile[] }) => {
         setProfiles(body.profiles);
-        setActiveProfileId(body.profiles[0]?.id ?? "");
+        // Prefer the seeded demo brand if it exists, otherwise the first profile.
+        const seeded = body.profiles.find((p) => p.name === DEMO_BRAND_NAME);
+        setActiveProfileId((seeded ?? body.profiles[0])?.id ?? "");
       })
       .catch(() => setError("Could not load business profiles."))
       .finally(() => setLoading(false));
@@ -184,22 +189,10 @@ export function ProfileDashboard({
           <MonitoringPage profile={profile} />
         ) : activePage === "benchmarking" ? (
           <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
+        ) : activePage === "recommendations" ? (
+          <RecommendationsPage profile={profile} />
         ) : (
-          <article className="panel">
-            <p className="muted">{page[1]}</p>
-            <h2>{profile.name}</h2>
-            <p>{page[2]}</p>
-            <dl>
-              <div>
-                <dt>Website</dt>
-                <dd>{profile.website}</dd>
-              </div>
-              <div>
-                <dt>Description</dt>
-                <dd>{profile.description}</dd>
-              </div>
-            </dl>
-          </article>
+          <SourcesPage profile={profile} />
         )}
 
         {error && <p className="error">{error}</p>}

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -394,6 +394,144 @@ th {
   gap: 18px;
 }
 
+/* ---------- Metric list (SoV bars + Sentiment gauge) ---------- */
+.metric-list { display: grid; gap: 4px; }
+.metric-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 1.2fr) minmax(140px, 2fr) 64px;
+  align-items: center;
+  gap: 14px;
+  padding: 9px 6px;
+  margin: 0 -6px;
+  border-radius: 6px;
+  transition: background 160ms ease;
+}
+.metric-row:hover { background: var(--soft); }
+.metric-row__label {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--ink);
+}
+.metric-row__bar {
+  position: relative;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--line);
+  overflow: hidden;
+}
+.metric-row__fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  transition: width 280ms ease-out;
+}
+.metric-row__num {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  text-align: right;
+  color: var(--ink);
+}
+
+.sentiment-gauge {
+  position: relative;
+  height: 5px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(185, 28, 28, 0.25) 0%,
+    var(--line) 50%,
+    rgba(4, 120, 87, 0.28) 100%
+  );
+}
+.sentiment-gauge__pin {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: 2px solid white;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 1px var(--line-strong);
+  background: var(--ink);
+}
+
+/* ---------- Chips (feature tags) ---------- */
+.chip-row { display: inline-flex; flex-wrap: wrap; gap: 6px; }
+.chip {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--soft);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  transition: background 160ms ease, border-color 160ms ease, transform 80ms ease;
+}
+.chip:hover {
+  background: var(--accent-soft);
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+  cursor: default;
+}
+
+/* ---------- Bullet list ---------- */
+.bullet-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 14px;
+  color: var(--ink);
+  line-height: 1.55;
+}
+.bullet-list li + li { margin-top: 6px; }
+.bullet-list em { font-style: italic; color: var(--accent); }
+
+/* ---------- Stat tile ---------- */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+.stat {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px 16px 14px;
+  background: var(--soft);
+  transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+.stat:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.06);
+}
+.stat__label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+.stat__value {
+  font-weight: 700;
+  font-size: 28px;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.subhead {
+  margin: 16px 0 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
 /* ---------- Live Run Theater ---------- */
 .theater {
   margin: 0;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,46 +1,71 @@
-:root {
-  color: #0f172a;
-  background: #f5f7fb;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+/*
+ * Perception design system
+ * Direction: refined modern intelligence dashboard. Warm-cream surface,
+ * deep navy ink, single saturated indigo accent, characterful Geist
+ * typography. Generous type scale, hairline rules, soft hover lift.
+ * Calm in repose, charged on interaction.
+ */
 
-  /* Tokens */
-  --ink: #0f172a;
-  --ink-2: #1e293b;
-  --muted: #475569;
-  --subtle: #94a3b8;
-  --line: #e2e8f0;
-  --line-strong: #cbd5e1;
+:root {
+  color: #0a0e1a;
+  background: #f7f4ec;
+
+  /* Type */
+  --font-body: "Geist", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* Ink + paper */
+  --ink: #0a0e1a;
+  --ink-2: #1e2433;
+  --muted: #545b6b;
+  --subtle: #9ba2b1;
+  --line: #e7e1d2;
+  --line-strong: #d3cab6;
   --surface: #ffffff;
-  --soft: #f0f4f9;
-  --warm: #fafaf6;
-  --accent: #1e40af;
-  --accent-soft: #dbeafe;
+  --soft: #f1ebd8;
+  --warm: #f7f4ec;
+
+  /* Accents */
+  --accent: #312e81;
+  --accent-soft: #e0e7ff;
+  --accent-glow: rgba(49, 46, 129, 0.18);
   --success: #047857;
   --danger: #b91c1c;
   --warning: #b45309;
 
-  --brand-1: #1d4ed8;
-  --brand-2: #db2777;
-  --brand-3: #7c3aed;
-  --brand-4: #0891b2;
-  --brand-5: #d97706;
-  --brand-6: #059669;
+  /* Per-brand chart palette — saturated, distinct, harmonious */
+  --brand-1: #312e81;
+  --brand-2: #be185d;
+  --brand-3: #6d28d9;
+  --brand-4: #0f766e;
+  --brand-5: #c2410c;
+  --brand-6: #166534;
 
-  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  --shadow-card: 0 1px 0 rgba(15, 23, 42, 0.04), 0 4px 14px rgba(15, 23, 42, 0.04);
-  --shadow-hover: 0 1px 0 rgba(15, 23, 42, 0.05), 0 12px 32px rgba(15, 23, 42, 0.07);
+  --shadow-soft: 0 1px 0 rgba(10, 14, 26, 0.04), 0 4px 14px rgba(10, 14, 26, 0.05);
+  --shadow-hover: 0 1px 0 rgba(10, 14, 26, 0.06), 0 12px 32px rgba(10, 14, 26, 0.09);
+
+  font-family: var(--font-body);
+  font-feature-settings: "ss01" on, "ss02" on, "cv11" on;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 * { box-sizing: border-box; }
 
 body {
   margin: 0;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink);
   background:
-    radial-gradient(ellipse 90% 50% at 50% -10%, rgba(30, 64, 175, 0.04), transparent 70%),
-    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(124, 58, 237, 0.04), transparent 70%),
-    #f5f7fb;
+    radial-gradient(ellipse 90% 50% at 50% -10%, rgba(49, 46, 129, 0.06), transparent 70%),
+    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(194, 65, 12, 0.05), transparent 70%),
+    var(--warm);
+  /* very subtle paper grain */
+  background-image:
+    radial-gradient(ellipse 90% 50% at 50% -10%, rgba(49, 46, 129, 0.06), transparent 70%),
+    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(194, 65, 12, 0.05), transparent 70%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.025 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
 }
 
 button,
@@ -61,31 +86,33 @@ textarea {
   padding: 28px;
 }
 
+/* ---------- Onboarding ---------- */
 .onboarding {
   display: grid;
   gap: 16px;
-  width: min(520px, 100%);
-  padding: 28px;
+  width: min(540px, 100%);
+  padding: 32px;
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 12px;
-  box-shadow: var(--shadow-card);
+  border-radius: 14px;
+  box-shadow: var(--shadow-soft);
 }
 
 .onboarding h1,
 .profile-header h1 {
   margin: 0;
-  font-size: 22px;
-  letter-spacing: -0.012em;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.022em;
 }
 
 label {
   display: grid;
-  gap: 5px;
-  font-family: var(--mono);
+  gap: 6px;
+  font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
+  font-weight: 500;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--muted);
 }
@@ -98,7 +125,7 @@ textarea {
   border-radius: 8px;
   padding: 10px 12px;
   background: var(--surface);
-  font-family: inherit;
+  font-family: var(--font-body);
   font-size: 14px;
   font-weight: 400;
   color: var(--ink);
@@ -112,150 +139,260 @@ select:focus,
 textarea:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(30, 64, 175, 0.12);
+  box-shadow: 0 0 0 3px var(--accent-glow);
 }
 
 button {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   border: 0;
   border-radius: 8px;
-  padding: 10px 16px;
+  padding: 10px 18px;
   color: white;
   background: var(--ink);
   cursor: pointer;
+  font-family: var(--font-body);
   font-weight: 600;
   font-size: 14px;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  transition: background 160ms ease, transform 80ms ease, box-shadow 180ms ease, opacity 140ms ease;
+  letter-spacing: -0.005em;
+  box-shadow: 0 1px 2px rgba(10, 14, 26, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.07);
+  transition: background 160ms ease, transform 80ms ease, box-shadow 200ms ease, opacity 140ms ease;
 }
 
 button:hover {
   background: var(--accent);
-  box-shadow: 0 4px 12px rgba(30, 64, 175, 0.22);
   transform: translateY(-1px);
+  box-shadow: 0 6px 16px var(--accent-glow);
 }
-
 button:active { transform: translateY(0); }
-
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: 0.4;
   transform: none;
   box-shadow: none;
 }
 
+/* ---------- Shell ---------- */
 .app-shell {
   display: grid;
-  grid-template-columns: 248px 1fr;
+  grid-template-columns: 240px 1fr;
 }
 
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 22px;
-  padding: 22px 18px;
+  padding: 22px 14px 18px;
   color: white;
-  background: linear-gradient(180deg, #1e293b 0%, #0f172a 100%);
+  background: linear-gradient(180deg, #161b29 0%, #0a0e1a 100%);
   position: sticky;
   top: 0;
   height: 100vh;
-  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  border-right: 1px solid rgba(255, 255, 255, 0.05);
+  overflow-y: auto;
 }
 
-.sidebar > strong {
-  font-size: 18px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
+.brand-lockup {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 6px 14px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 11px;
+  padding: 4px 8px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  margin-bottom: 18px;
 }
-
-.sidebar > strong::before {
-  content: "P";
+.brand-lockup__text {
   display: grid;
-  width: 28px;
-  height: 28px;
+  gap: 1px;
+}
+.brand-lockup strong {
+  display: block;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.018em;
+  color: white;
+  font-family: var(--font-body);
+}
+.brand-lockup span {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 500;
+}
+.brand-mark {
+  display: grid;
+  width: 30px;
+  height: 30px;
   place-items: center;
-  background: var(--accent);
-  border-radius: 7px;
+  background: linear-gradient(135deg, #4f46e5 0%, #312e81 100%);
+  border-radius: 8px;
   font-size: 14px;
   font-weight: 700;
   color: white;
-  box-shadow: 0 2px 6px rgba(30, 64, 175, 0.35);
+  box-shadow: 0 4px 12px rgba(79, 70, 229, 0.32), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+  letter-spacing: -0.02em;
 }
 
-.sidebar label {
-  color: rgba(255, 255, 255, 0.55);
-  font-size: 10px;
-  letter-spacing: 0.18em;
+.nav-list {
+  display: grid;
+  gap: 2px;
 }
 
-.sidebar select {
-  color: white;
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+.nav-item {
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  padding: 9px 12px;
+  text-align: left;
+  font-family: var(--font-body);
+  font-size: 13.5px;
   font-weight: 500;
-  letter-spacing: 0;
+  letter-spacing: -0.005em;
+  transition: background 140ms ease, color 140ms ease, transform 80ms ease;
+  box-shadow: none;
   text-transform: none;
 }
 
-.sidebar select:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.2);
+.nav-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: white;
+  transform: none;
 }
 
-.sidebar select:focus {
-  border-color: var(--accent-soft);
-  box-shadow: 0 0 0 3px rgba(219, 234, 254, 0.15);
+.nav-item.active {
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
+.nav-item.active::before {
+  content: "";
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  margin-right: 8px;
+  vertical-align: 2px;
+  box-shadow: 0 0 8px var(--accent-soft);
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  display: grid;
+  gap: 8px;
+}
+.sidebar-footer__label {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+  margin-bottom: 2px;
+}
+.sidebar-profile {
+  width: 100%;
+  color: white;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 8px 10px;
+  border-radius: 7px;
+}
+.sidebar-profile:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+.sidebar-profile:focus {
+  border-color: rgba(224, 231, 255, 0.4);
+  box-shadow: 0 0 0 3px rgba(224, 231, 255, 0.12);
+}
+.sidebar-add {
+  width: 100%;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  border: 1px dashed rgba(255, 255, 255, 0.14);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 7px 10px;
+  letter-spacing: 0;
+  text-transform: none;
+  box-shadow: none;
+}
+.sidebar-add:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: white;
+  transform: none;
+  box-shadow: none;
+}
+
+/* ---------- Workspace + topbar ---------- */
 .workspace {
   display: grid;
   align-content: start;
   gap: 22px;
-  padding: 32px 36px 56px;
-  max-width: 1240px;
+  padding: 36px 44px 72px;
+  max-width: 1320px;
+  width: 100%;
 }
 
 .topbar {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
   padding-bottom: 22px;
   border-bottom: 1px solid var(--line);
 }
 
-.topbar > div > p:first-child {
-  margin: 0 0 4px;
-  font-family: var(--mono);
+.topbar__eyebrow {
+  margin: 0 0 8px;
+  font-family: var(--font-mono);
   font-size: 11px;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--accent);
+  font-weight: 500;
 }
 
 .topbar h1 {
   margin: 0;
-  font-size: 28px;
+  font-size: 34px;
   font-weight: 700;
-  letter-spacing: -0.022em;
+  letter-spacing: -0.028em;
+  line-height: 1.1;
 }
 
+.topbar__sub {
+  margin: 10px 0 0;
+  font-size: 14.5px;
+  color: var(--muted);
+  max-width: 60ch;
+  line-height: 1.55;
+}
+
+/* ---------- Panels ---------- */
 .panel {
   display: grid;
   gap: 14px;
   max-width: 1040px;
-  padding: 22px 24px 22px;
+  padding: 24px 26px;
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 12px;
-  box-shadow: var(--shadow-card);
+  border-radius: 14px;
+  box-shadow: var(--shadow-soft);
   transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
 }
 
@@ -264,21 +401,26 @@ button:disabled {
   box-shadow: var(--shadow-hover);
 }
 
-.wide-panel {
-  max-width: 1240px;
-}
+.wide-panel { max-width: 1280px; }
 
 .panel > h2,
 .panel > h3 {
   margin: 0;
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 600;
-  letter-spacing: -0.005em;
+  letter-spacing: -0.012em;
+  color: var(--ink);
+}
+
+.panel > h2 {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.022em;
 }
 
 .panel > h3 {
   position: relative;
-  padding-left: 14px;
+  padding-left: 16px;
 }
 
 .panel > h3::before {
@@ -291,12 +433,14 @@ button:disabled {
   height: 6px;
   border-radius: 999px;
   background: var(--accent);
+  box-shadow: 0 0 10px var(--accent-glow);
 }
 
+/* ---------- Sentiment trend (monitoring) ---------- */
 .sentiment-card {
   display: grid;
   gap: 10px;
-  padding: 16px;
+  padding: 18px;
   background: var(--soft);
   border: 1px solid var(--line);
   border-radius: 10px;
@@ -319,48 +463,54 @@ button:disabled {
 .trend-dot-negative { fill: var(--danger); }
 .chart-label, .axis-label { fill: var(--muted); font-size: 12px; }
 
-dl { display: grid; gap: 12px; margin: 0; }
+/* ---------- DL ---------- */
+dl { display: grid; gap: 14px; margin: 0; }
 dd { margin: 4px 0 0; font-size: 14px; color: var(--ink); font-weight: 400; letter-spacing: 0; text-transform: none; }
 dt {
   color: var(--muted);
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
+/* ---------- Tables ---------- */
 table {
   width: 100%;
   border-collapse: collapse;
+  font-size: 14px;
 }
 
 th,
 td {
-  padding: 11px 12px;
+  padding: 12px 12px 12px 0;
   text-align: left;
   border-bottom: 1px solid var(--line);
   vertical-align: middle;
 }
 
+tr:last-child td { border-bottom: none; }
+
 th {
   color: var(--muted);
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
+/* ---------- Sentiment pill (monitoring page) ---------- */
 .sentiment {
   display: inline-block;
   min-width: 76px;
   padding: 4px 10px;
   border-radius: 999px;
   text-align: center;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.04em;
 }
 
@@ -376,15 +526,124 @@ th {
   font-weight: 400;
   letter-spacing: normal;
   text-transform: none;
+  font-family: var(--font-body);
 }
 .error {
   color: var(--danger);
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 12px;
   background: rgba(185, 28, 28, 0.07);
   border: 1px solid rgba(185, 28, 28, 0.2);
-  padding: 8px 12px;
-  border-radius: 6px;
+  padding: 9px 12px;
+  border-radius: 8px;
+}
+
+/* ---------- Competitive Set Picker ---------- */
+.picker { gap: 16px; }
+.picker__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.picker__count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.picker__hint {
+  margin: -8px 0 4px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  max-width: 64ch;
+}
+.picker__field { display: grid; gap: 5px; }
+.picker__field--solo { max-width: 480px; }
+.picker__label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0;
+}
+.picker__num {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--soft);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+.picker__input {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  padding: 11px 14px;
+  background: var(--surface);
+  font-family: var(--font-body);
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--ink);
+  letter-spacing: -0.005em;
+  transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
+}
+.picker__input:hover { border-color: var(--ink-2); }
+.picker__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+  background: var(--surface);
+}
+.picker__competitors {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+.picker__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 6px;
+}
+.picker__primary {
+  background: var(--ink);
+  font-size: 14px;
+  padding: 11px 22px;
+}
+.picker__primary:hover { background: var(--accent); }
+.picker__secondary {
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--line-strong);
+  font-size: 14px;
+  padding: 10px 16px;
+  box-shadow: none;
+}
+.picker__secondary:hover {
+  background: var(--soft);
+  color: var(--ink);
+  border-color: var(--ink-2);
+  box-shadow: none;
+}
+.picker__status {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
 }
 
 /* ---------- Charts side-by-side ---------- */
@@ -401,9 +660,9 @@ th {
   grid-template-columns: minmax(110px, 1.2fr) minmax(140px, 2fr) 64px;
   align-items: center;
   gap: 14px;
-  padding: 9px 6px;
-  margin: 0 -6px;
-  border-radius: 6px;
+  padding: 10px 8px;
+  margin: 0 -8px;
+  border-radius: 8px;
   transition: background 160ms ease;
 }
 .metric-row:hover { background: var(--soft); }
@@ -411,10 +670,11 @@ th {
   font-weight: 600;
   font-size: 14px;
   color: var(--ink);
+  letter-spacing: -0.005em;
 }
 .metric-row__bar {
   position: relative;
-  height: 5px;
+  height: 6px;
   border-radius: 999px;
   background: var(--line);
   overflow: hidden;
@@ -423,47 +683,51 @@ th {
   display: block;
   height: 100%;
   border-radius: inherit;
-  transition: width 280ms ease-out;
+  transition: width 480ms cubic-bezier(0.34, 1.4, 0.64, 1);
+  box-shadow: 0 0 8px rgba(49, 46, 129, 0.2);
 }
 .metric-row__num {
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   font-size: 13px;
   text-align: right;
   color: var(--ink);
+  font-weight: 500;
 }
 
 .sentiment-gauge {
   position: relative;
-  height: 5px;
+  height: 6px;
   border-radius: 999px;
   background: linear-gradient(
     90deg,
-    rgba(185, 28, 28, 0.25) 0%,
+    rgba(185, 28, 28, 0.3) 0%,
     var(--line) 50%,
-    rgba(4, 120, 87, 0.28) 100%
+    rgba(4, 120, 87, 0.3) 100%
   );
 }
 .sentiment-gauge__pin {
   position: absolute;
   top: 50%;
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 999px;
   border: 2px solid white;
   transform: translate(-50%, -50%);
-  box-shadow: 0 0 0 1px var(--line-strong);
+  box-shadow: 0 1px 3px rgba(10, 14, 26, 0.25), 0 0 0 1px var(--line-strong);
   background: var(--ink);
+  transition: left 480ms cubic-bezier(0.34, 1.4, 0.64, 1);
 }
 
-/* ---------- Chips (feature tags) ---------- */
+/* ---------- Chips ---------- */
 .chip-row { display: inline-flex; flex-wrap: wrap; gap: 6px; }
 .chip {
   display: inline-block;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 11px;
-  letter-spacing: 0.04em;
-  padding: 3px 9px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  padding: 4px 10px;
   border-radius: 999px;
   background: var(--soft);
   color: var(--ink);
@@ -472,7 +736,8 @@ th {
 }
 .chip:hover {
   background: var(--accent-soft);
-  border-color: var(--line-strong);
+  border-color: var(--accent);
+  color: var(--accent);
   transform: translateY(-1px);
   cursor: default;
 }
@@ -483,50 +748,64 @@ th {
   padding-left: 18px;
   font-size: 14px;
   color: var(--ink);
-  line-height: 1.55;
+  line-height: 1.6;
 }
-.bullet-list li + li { margin-top: 6px; }
+.bullet-list li + li { margin-top: 8px; }
 .bullet-list em { font-style: italic; color: var(--accent); }
 
 /* ---------- Stat tile ---------- */
 .stat-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
+  gap: 14px;
 }
 .stat {
   border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 12px 16px 14px;
+  border-radius: 12px;
+  padding: 14px 18px 16px;
   background: var(--soft);
+  position: relative;
+  overflow: hidden;
   transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
 }
-.stat:hover {
-  border-color: var(--line-strong);
-  transform: translateY(-1px);
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.06);
+.stat::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 100% 0%, var(--accent-glow), transparent 50%);
+  opacity: 0;
+  transition: opacity 240ms ease;
+  pointer-events: none;
 }
+.stat:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(10, 14, 26, 0.08);
+}
+.stat:hover::after { opacity: 1; }
 .stat__label {
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--muted);
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 .stat__value {
   font-weight: 700;
-  font-size: 28px;
-  letter-spacing: -0.025em;
+  font-size: 32px;
+  letter-spacing: -0.034em;
   color: var(--ink);
   font-variant-numeric: tabular-nums;
+  line-height: 1;
 }
 
 .subhead {
-  margin: 16px 0 8px;
-  font-family: var(--mono);
+  margin: 18px 0 8px;
+  font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--muted);
@@ -535,42 +814,43 @@ th {
 /* ---------- Live Run Theater ---------- */
 .theater {
   margin: 0;
-  padding: 22px 24px 24px;
+  padding: 24px 26px 28px;
   border: 1px solid var(--line);
-  border-radius: 12px;
+  border-radius: 14px;
   background:
-    radial-gradient(circle at 8% -8%, rgba(30, 64, 175, 0.06), transparent 55%),
-    radial-gradient(circle at 100% 110%, rgba(124, 58, 237, 0.05), transparent 55%),
+    radial-gradient(circle at 8% -8%, rgba(49, 46, 129, 0.08), transparent 55%),
+    radial-gradient(circle at 100% 110%, rgba(194, 65, 12, 0.06), transparent 55%),
     var(--surface);
-  box-shadow: var(--shadow-card);
-  max-width: 1240px;
+  box-shadow: var(--shadow-soft);
+  max-width: 1280px;
 }
 .theater__head {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 16px;
-  padding-bottom: 14px;
+  margin-bottom: 18px;
+  padding-bottom: 16px;
   border-bottom: 1px solid var(--line);
 }
 .theater__kicker {
   display: block;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 10px;
+  font-weight: 500;
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 .theater__title {
   margin: 0;
   font-weight: 700;
-  font-size: 18px;
-  letter-spacing: -0.018em;
+  font-size: 20px;
+  letter-spacing: -0.022em;
 }
 .theater__status {
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -583,25 +863,26 @@ th {
 .theater__judge {
   margin-bottom: 14px;
   padding: 12px 14px;
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--soft);
   border: 1px dashed var(--line-strong);
 }
 .theater__judge-label {
   display: block;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--muted);
   margin-bottom: 6px;
+  font-weight: 500;
 }
 .theater__judge-text {
   margin: 0;
   white-space: pre-wrap;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 12px;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--ink);
 }
 
@@ -613,12 +894,12 @@ th {
 .theater__column {
   border: 1px solid var(--line);
   border-top: 3px solid currentColor;
-  border-radius: 10px;
-  padding: 12px 14px 14px;
+  border-radius: 12px;
+  padding: 14px 16px 16px;
   background: var(--surface);
   display: flex;
   flex-direction: column;
-  min-height: 220px;
+  min-height: 230px;
   transition: border-color 180ms ease, transform 180ms ease;
 }
 .theater__column:hover {
@@ -635,15 +916,17 @@ th {
   margin: 0;
   font-weight: 600;
   font-size: 15px;
+  letter-spacing: -0.012em;
 }
 .theater__col-count {
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--muted);
   letter-spacing: 0.06em;
+  font-variant-numeric: tabular-nums;
 }
 .theater__progress {
-  margin: 8px 0 6px;
+  margin: 10px 0 6px;
   height: 3px;
   background: var(--line);
   border-radius: 2px;
@@ -655,7 +938,7 @@ th {
 }
 .theater__col-status {
   margin: 0 0 8px;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--muted);
   letter-spacing: 0.04em;
@@ -665,9 +948,9 @@ th {
   margin: 0;
   flex-grow: 1;
   white-space: pre-wrap;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 12px;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--ink);
 }
 .theater__stream[data-empty="true"] {
@@ -695,30 +978,31 @@ th {
 }
 .trend-grid__brand {
   border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 12px 14px 14px;
+  border-radius: 12px;
+  padding: 14px 16px 16px;
   background: var(--soft);
   transition: border-color 180ms ease, background 180ms ease, transform 180ms ease;
 }
 .trend-grid__brand:hover {
-  border-color: var(--line-strong);
+  border-color: var(--accent);
   background: var(--surface);
   transform: translateY(-1px);
 }
 .trend-grid__name {
   font-weight: 600;
   font-size: 13px;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
   color: var(--ink);
+  letter-spacing: -0.012em;
 }
 .trend-mini {
   width: 100%;
   border-collapse: collapse;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
   font-size: 11px;
 }
 .trend-mini td {
-  padding: 3px 6px 3px 0;
+  padding: 4px 6px 4px 0;
   vertical-align: middle;
   border: none;
 }
@@ -740,32 +1024,35 @@ th {
   height: 100%;
   border-radius: inherit;
   background: var(--ink);
-  transition: width 280ms ease-out;
+  transition: width 480ms cubic-bezier(0.34, 1.4, 0.64, 1);
 }
 .trend-mini__num {
   width: 36px;
   text-align: right;
   color: var(--ink);
   font-variant-numeric: tabular-nums;
+  font-weight: 500;
 }
 .trend-mini__sent {
   width: 44px;
   text-align: right;
   font-variant-numeric: tabular-nums;
+  font-weight: 500;
 }
 
 /* ---------- Mount animations ---------- */
-.workspace > * { animation: fadeUp 380ms ease-out both; }
+.workspace > * { animation: fadeUp 420ms cubic-bezier(0.16, 1, 0.3, 1) both; }
 .workspace > :nth-child(1) { animation-delay: 0ms; }
-.workspace > :nth-child(2) { animation-delay: 60ms; }
-.workspace > :nth-child(3) { animation-delay: 120ms; }
-.workspace > :nth-child(4) { animation-delay: 180ms; }
-.workspace > :nth-child(5) { animation-delay: 240ms; }
-.workspace > :nth-child(6) { animation-delay: 300ms; }
-.workspace > :nth-child(7) { animation-delay: 360ms; }
+.workspace > :nth-child(2) { animation-delay: 70ms; }
+.workspace > :nth-child(3) { animation-delay: 140ms; }
+.workspace > :nth-child(4) { animation-delay: 210ms; }
+.workspace > :nth-child(5) { animation-delay: 280ms; }
+.workspace > :nth-child(6) { animation-delay: 350ms; }
+.workspace > :nth-child(7) { animation-delay: 420ms; }
+.workspace > :nth-child(8) { animation-delay: 490ms; }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(6px); }
+  from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
@@ -775,10 +1062,20 @@ th {
   .sentiment-card,
   .theater__column,
   .trend-grid__brand,
+  .stat,
+  .metric-row__fill,
+  .sentiment-gauge__pin,
+  .trend-mini__bar-fill,
   button {
     animation: none !important;
     transition: none !important;
   }
+}
+
+/* Selection */
+::selection {
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 @media (max-width: 720px) {
@@ -787,4 +1084,5 @@ th {
   .topbar { align-items: stretch; flex-direction: column; }
   .inline-form { flex-direction: column; }
   .workspace { padding: 24px 20px 40px; }
+  .stat-row { grid-template-columns: 1fr; }
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,52 +1,46 @@
 /*
- * Perception design system — clean dashboard.
- * Inter throughout, slate sidebar (not pure black), warm-cream workspace,
- * indigo accent, hairline section dividers, sparing card chrome.
+ * Perception design system
+ * Direction: clean modern SaaS dashboard. Light sidebar, white workspace,
+ * subtle borders, Inter throughout. Indigo accent used sparingly. Compact
+ * density.
  */
 
 :root {
-  color: #0a0e1a;
-  background: #f7f5ee;
+  color: #111827;
+  background: #ffffff;
 
-  /* Type — Inter for everything except mono numerics */
   --font-body: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-mono: "Inter", ui-monospace, SFMono-Regular, Menlo, monospace;
 
-  /* Ink + paper */
-  --ink: #0a0e1a;
-  --ink-2: #1e2433;
-  --muted: #545b6b;
-  --subtle: #9ba2b1;
-  --line: #e7e1d2;
-  --line-strong: #d3cab6;
+  --ink: #0f172a;
+  --ink-2: #1f2937;
+  --ink-3: #374151;
+  --muted: #6b7280;
+  --subtle: #9ca3af;
+
   --surface: #ffffff;
-  --soft: #f1ebd8;
-  --warm: #f7f5ee;
+  --surface-2: #f9fafb;
+  --surface-3: #f3f4f6;
+  --line: #e5e7eb;
+  --line-strong: #d1d5db;
 
-  /* Sidebar (slate, not black) */
-  --side-bg: #1e2433;
-  --side-bg-2: #232a3a;
-  --side-line: rgba(255, 255, 255, 0.07);
-  --side-line-strong: rgba(255, 255, 255, 0.13);
-  --side-text: rgba(255, 255, 255, 0.78);
-  --side-text-muted: rgba(255, 255, 255, 0.5);
+  --accent: #4f46e5;
+  --accent-hover: #4338ca;
+  --accent-soft: #eef2ff;
+  --accent-glow: rgba(79, 70, 229, 0.16);
 
-  /* Accents */
-  --accent: #4338ca;
-  --accent-2: #6366f1;
-  --accent-soft: #e0e7ff;
-  --accent-glow: rgba(67, 56, 202, 0.16);
   --success: #047857;
+  --success-soft: #d1fae5;
   --danger: #b91c1c;
+  --danger-soft: #fee2e2;
   --warning: #b45309;
+  --warning-soft: #fef3c7;
 
-  /* Per-brand chart palette — saturated, distinct */
-  --brand-1: #4338ca;
-  --brand-2: #be185d;
-  --brand-3: #6d28d9;
-  --brand-4: #0f766e;
-  --brand-5: #c2410c;
-  --brand-6: #166534;
+  --brand-1: #4f46e5;
+  --brand-2: #db2777;
+  --brand-3: #7c3aed;
+  --brand-4: #0d9488;
+  --brand-5: #ea580c;
+  --brand-6: #16a34a;
 
   font-family: var(--font-body);
   font-feature-settings: "ss01" on, "cv11" on;
@@ -61,51 +55,48 @@ body {
   font-size: 14px;
   line-height: 1.55;
   color: var(--ink);
-  background: var(--warm);
+  background: var(--surface);
 }
 
 button,
 select,
 input,
-textarea {
-  font: inherit;
-}
+textarea { font: inherit; }
 
 .page,
-.app-shell {
-  min-height: 100vh;
-}
+.app-shell { min-height: 100vh; }
 
 .center-page {
   display: grid;
   place-items: center;
   padding: 28px;
+  background: var(--surface-2);
 }
 
 /* ---------- Onboarding ---------- */
 .onboarding {
   display: grid;
-  gap: 16px;
-  width: min(540px, 100%);
-  padding: 32px;
+  gap: 14px;
+  width: min(520px, 100%);
+  padding: 28px;
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 14px;
+  border-radius: 12px;
 }
-
 .onboarding h1 {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 700;
-  letter-spacing: -0.022em;
+  margin: 0 0 4px;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.018em;
+  color: var(--ink);
 }
 
 label {
   display: grid;
-  gap: 6px;
-  font-size: 12px;
+  gap: 5px;
+  font-size: 13px;
   font-weight: 500;
-  color: var(--muted);
+  color: var(--ink-3);
   letter-spacing: 0;
   text-transform: none;
 }
@@ -115,21 +106,19 @@ select,
 textarea {
   width: 100%;
   border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  padding: 9px 12px;
+  border-radius: 6px;
+  padding: 8px 11px;
   background: var(--surface);
   font-family: var(--font-body);
-  font-size: 14px;
+  font-size: 13.5px;
   font-weight: 400;
   color: var(--ink);
   letter-spacing: 0;
   text-transform: none;
-  transition: border-color 140ms ease, box-shadow 140ms ease;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
-
-input:focus,
-select:focus,
-textarea:focus {
+input:hover, select:hover, textarea:hover { border-color: var(--ink-3); }
+input:focus, select:focus, textarea:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-glow);
@@ -138,30 +127,21 @@ textarea:focus {
 button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   border: 0;
-  border-radius: 8px;
-  padding: 10px 16px;
+  border-radius: 6px;
+  padding: 8px 14px;
   color: white;
   background: var(--ink);
   cursor: pointer;
   font-family: var(--font-body);
-  font-weight: 600;
-  font-size: 14px;
+  font-weight: 500;
+  font-size: 13.5px;
   letter-spacing: -0.005em;
-  transition: background 160ms ease, transform 80ms ease, opacity 140ms ease;
+  transition: background 140ms ease, opacity 140ms ease;
 }
-
-button:hover {
-  background: var(--accent);
-  transform: translateY(-1px);
-}
-button:active { transform: translateY(0); }
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.4;
-  transform: none;
-}
+button:hover { background: var(--accent); }
+button:disabled { cursor: not-allowed; opacity: 0.45; }
 
 /* ---------- Shell ---------- */
 .app-shell {
@@ -172,150 +152,131 @@ button:disabled {
 .sidebar {
   display: flex;
   flex-direction: column;
-  padding: 18px 14px;
-  color: var(--side-text);
-  background: var(--side-bg);
+  padding: 16px 12px 12px;
+  color: var(--ink);
+  background: var(--surface-2);
   position: sticky;
   top: 0;
   height: 100vh;
-  border-right: 1px solid var(--side-line);
+  border-right: 1px solid var(--line);
   overflow-y: auto;
 }
 
 .brand-lockup {
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 4px 8px 16px;
-  border-bottom: 1px solid var(--side-line);
-  margin-bottom: 16px;
+  gap: 10px;
+  padding: 4px 8px 14px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 12px;
 }
-.brand-lockup__text {
-  display: grid;
-  gap: 1px;
-}
+.brand-lockup__text { display: grid; gap: 0; line-height: 1.2; }
 .brand-lockup strong {
   display: block;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   letter-spacing: -0.014em;
-  color: white;
+  color: var(--ink);
 }
 .brand-lockup span {
   font-size: 11px;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--side-text-muted);
+  color: var(--muted);
   font-weight: 400;
 }
 .brand-mark {
   display: grid;
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   place-items: center;
-  background: linear-gradient(135deg, var(--accent-2) 0%, var(--accent) 100%);
-  border-radius: 7px;
-  font-size: 13px;
-  font-weight: 700;
+  background: var(--accent);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
   color: white;
   letter-spacing: -0.02em;
 }
 
-.nav-list {
-  display: grid;
-  gap: 2px;
-}
+.nav-list { display: grid; gap: 1px; }
 
 .nav-item {
   position: relative;
   width: 100%;
-  border: 1px solid transparent;
+  border: 0;
   background: transparent;
-  color: var(--side-text);
+  color: var(--ink-3);
   cursor: pointer;
-  padding: 8px 12px;
+  padding: 7px 10px;
   text-align: left;
   font-family: var(--font-body);
   font-size: 13.5px;
   font-weight: 500;
   letter-spacing: -0.005em;
-  border-radius: 7px;
-  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+  border-radius: 6px;
+  transition: background 120ms ease, color 120ms ease;
   box-shadow: none;
   text-transform: none;
 }
-
-.nav-item:hover {
-  color: white;
-  background: var(--side-bg-2);
-  border-color: var(--side-line-strong);
-  transform: none;
-}
-
+.nav-item:hover { color: var(--ink); background: var(--surface-3); }
 .nav-item.active {
-  color: white;
-  background: var(--side-bg-2);
-  border-color: var(--side-line-strong);
-  box-shadow: inset 2px 0 0 var(--accent-2);
+  color: var(--ink);
+  background: var(--surface);
+  box-shadow: inset 0 0 0 1px var(--line-strong);
 }
 
 .sidebar-footer {
   margin-top: auto;
-  padding-top: 14px;
-  border-top: 1px solid var(--side-line);
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 .sidebar-footer__label {
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--side-text-muted);
-  margin-bottom: 2px;
+  color: var(--muted);
+  margin-bottom: 1px;
 }
 .sidebar-profile {
   width: 100%;
-  color: white;
-  background: var(--side-bg-2);
-  border: 1px solid var(--side-line-strong);
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line-strong);
   font-family: var(--font-body);
   font-size: 13px;
   font-weight: 500;
-  padding: 7px 9px;
+  padding: 6px 9px;
   border-radius: 6px;
-}
-.sidebar-profile:hover { background: #2a3243; }
-.sidebar-profile:focus {
-  border-color: var(--accent-2);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
 }
 .sidebar-add {
   width: 100%;
   background: transparent;
-  color: var(--side-text);
-  border: 1px dashed var(--side-line-strong);
-  font-size: 12px;
+  color: var(--ink-3);
+  border: 1px solid var(--line);
+  font-size: 12.5px;
   font-weight: 500;
   padding: 6px 9px;
   letter-spacing: 0;
   text-transform: none;
 }
 .sidebar-add:hover {
-  background: var(--side-bg-2);
-  border-color: rgba(255, 255, 255, 0.22);
-  color: white;
-  transform: none;
+  background: var(--surface);
+  border-color: var(--line-strong);
+  color: var(--ink);
 }
 
 /* ---------- Workspace + topbar ---------- */
 .workspace {
   display: grid;
   align-content: start;
-  gap: 28px;
-  padding: 36px 44px 72px;
+  gap: 24px;
+  padding: 28px 36px 56px;
   max-width: 1320px;
   width: 100%;
+  background: var(--surface);
 }
 
 .topbar {
@@ -323,81 +284,68 @@ button:disabled {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-  padding-bottom: 22px;
+  padding-bottom: 18px;
   border-bottom: 1px solid var(--line);
 }
 
 .topbar__eyebrow {
-  margin: 0 0 8px;
-  font-size: 11px;
+  margin: 0 0 6px;
+  font-size: 12px;
   letter-spacing: 0;
   text-transform: none;
   color: var(--muted);
   font-weight: 500;
 }
-.topbar__brand {
-  color: var(--accent);
-  font-weight: 600;
-}
+.topbar__brand { color: var(--ink); font-weight: 600; }
 
 .topbar h1 {
   margin: 0;
-  font-size: 30px;
-  font-weight: 700;
-  letter-spacing: -0.026em;
-  line-height: 1.1;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.022em;
+  line-height: 1.2;
 }
 
 .topbar__sub {
-  margin: 8px 0 0;
-  font-size: 14px;
+  margin: 6px 0 0;
+  font-size: 13.5px;
   color: var(--muted);
   max-width: 60ch;
   line-height: 1.55;
 }
 
-/* ---------- Block: section heading + content ---------- */
-.block {
-  display: grid;
-  gap: 14px;
-  max-width: 1280px;
-}
-
+/* ---------- Block ---------- */
+.block { display: grid; gap: 12px; max-width: 1280px; }
 .block__title {
   margin: 0;
-  font-size: 17px;
+  font-size: 14px;
   font-weight: 600;
-  letter-spacing: -0.016em;
+  letter-spacing: -0.012em;
   color: var(--ink);
 }
 
-/* ---------- Card variant ---------- */
+/* ---------- Card ---------- */
 .card {
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 22px 24px;
+  border-radius: 10px;
+  padding: 18px 20px;
   display: grid;
-  gap: 14px;
-  transition: border-color 200ms ease, box-shadow 200ms ease;
+  gap: 12px;
+  transition: border-color 160ms ease;
 }
-.card:hover {
-  border-color: var(--line-strong);
-  box-shadow: 0 6px 20px rgba(10, 14, 26, 0.04);
-}
+.card:hover { border-color: var(--line-strong); }
 .wide-panel { max-width: 1280px; }
 
-/* ---------- Feature + whitespace blocks ---------- */
-.feature-block { display: grid; gap: 14px; }
-.whitespace-block { display: grid; gap: 14px; }
+.feature-block { display: grid; gap: 12px; }
+.whitespace-block { display: grid; gap: 12px; }
 .feature-table th { padding-left: 0; }
 .feature-table td { padding-left: 0; }
 
-/* ---------- Run meta dl ---------- */
 .run-meta {
   display: grid;
-  grid-template-columns: 140px 1fr;
-  gap: 12px 24px;
+  grid-template-columns: 130px 1fr;
+  gap: 8px 20px;
   margin: 0;
   align-items: baseline;
 }
@@ -410,82 +358,75 @@ button:disabled {
   letter-spacing: 0;
   text-transform: none;
 }
-.run-meta dd {
-  margin: 0;
-  font-size: 13px;
-  color: var(--ink);
-}
+.run-meta dd { margin: 0; font-size: 13px; color: var(--ink); }
 
-/* ---------- DL (legacy) ---------- */
-dl { display: grid; gap: 14px; margin: 0; }
-dd { margin: 4px 0 0; font-size: 14px; color: var(--ink); }
+dl { display: grid; gap: 12px; margin: 0; }
+dd { margin: 4px 0 0; font-size: 13.5px; color: var(--ink); }
 dt {
   color: var(--muted);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
 }
 
-/* ---------- Tables ---------- */
-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 14px;
-}
-
-th,
-td {
-  padding: 11px 12px 11px 0;
+table { width: 100%; border-collapse: collapse; font-size: 13.5px; }
+th, td {
+  padding: 10px 12px 10px 0;
   text-align: left;
   border-bottom: 1px solid var(--line);
   vertical-align: middle;
 }
-
 tr:last-child td { border-bottom: none; }
-
 th {
   color: var(--muted);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
 }
 
-/* ---------- Sentiment trend (monitoring) ---------- */
+/* ---------- Sentiment trend ---------- */
 .sentiment-card {
   display: grid;
   gap: 10px;
-  padding: 18px;
+  padding: 16px 18px;
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 10px;
 }
-.sentiment-card h3 { margin: 0; font-size: 14px; font-weight: 600; }
+.sentiment-card h3 { margin: 0; font-size: 13.5px; font-weight: 600; }
+.sentiment-card > div > p:first-child {
+  margin: 0 0 2px;
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--muted);
+  font-weight: 500;
+}
 .sentiment-chart { display: block; width: 100%; height: auto; }
-.neutral-line { stroke: #9ca3af; stroke-dasharray: 6 6; stroke-width: 2; }
-.grid-line { stroke: #e5e7eb; stroke-width: 1; }
-.trend-line { stroke-linecap: round; stroke-width: 5; }
+.neutral-line { stroke: var(--line-strong); stroke-dasharray: 6 6; stroke-width: 1.5; }
+.grid-line { stroke: var(--line); stroke-width: 1; }
+.trend-line { stroke-linecap: round; stroke-width: 4; }
 .trend-positive { stroke: var(--success); }
 .trend-negative { stroke: var(--danger); }
 .trend-dot { stroke: white; stroke-width: 2; }
 .trend-dot-positive { fill: var(--success); }
 .trend-dot-negative { fill: var(--danger); }
-.chart-label, .axis-label { fill: var(--muted); font-size: 12px; }
+.chart-label, .axis-label { fill: var(--muted); font-size: 11px; }
 
-/* ---------- Sentiment pill (monitoring page) ---------- */
 .sentiment {
   display: inline-block;
-  min-width: 76px;
-  padding: 4px 10px;
+  min-width: 70px;
+  padding: 3px 9px;
   border-radius: 999px;
   text-align: center;
-  font-size: 12px;
+  font-size: 11.5px;
   font-weight: 500;
 }
-.sentiment-positive { color: #14532d; background: #dcfce7; }
-.sentiment-neutral  { color: #3f3f46; background: #f4f4f5; }
-.sentiment-negative { color: #7f1d1d; background: #fee2e2; }
+.sentiment-positive { color: #065f46; background: var(--success-soft); }
+.sentiment-neutral  { color: #374151; background: var(--surface-3); }
+.sentiment-negative { color: #991b1b; background: var(--danger-soft); }
 
 .inline-form { display: flex; gap: 8px; }
 .inline-form input { flex: 1; }
@@ -494,14 +435,14 @@ th {
 .error {
   color: var(--danger);
   font-size: 13px;
-  background: rgba(185, 28, 28, 0.06);
-  border: 1px solid rgba(185, 28, 28, 0.18);
-  padding: 9px 12px;
-  border-radius: 8px;
+  background: var(--danger-soft);
+  border: 1px solid rgba(185, 28, 28, 0.2);
+  padding: 8px 12px;
+  border-radius: 6px;
 }
 
-/* ---------- Competitive Set Picker ---------- */
-.picker { gap: 18px; }
+/* ---------- Picker ---------- */
+.picker { gap: 14px; }
 .picker__head {
   display: flex;
   align-items: baseline;
@@ -510,28 +451,19 @@ th {
 }
 .picker__head h3 {
   margin: 0;
-  font-size: 17px;
+  font-size: 14px;
   font-weight: 600;
-  letter-spacing: -0.016em;
+  letter-spacing: -0.012em;
 }
-.picker__count {
-  font-size: 12px;
-  color: var(--muted);
-  font-weight: 500;
-}
-.picker__hint {
-  margin: -10px 0 4px;
-  font-size: 13.5px;
-  line-height: 1.55;
-  max-width: 64ch;
-}
+.picker__count { font-size: 12px; color: var(--muted); font-weight: 500; }
+.picker__hint { margin: -8px 0 4px; font-size: 13px; line-height: 1.55; max-width: 64ch; }
 .picker__field { display: grid; gap: 5px; }
 .picker__field--solo { max-width: 480px; }
 .picker__label {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 11px;
+  gap: 7px;
+  font-size: 11.5px;
   font-weight: 500;
   color: var(--muted);
   margin: 0;
@@ -541,11 +473,11 @@ th {
 .picker__num {
   display: inline-grid;
   place-items: center;
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   border-radius: 999px;
-  background: var(--soft);
-  color: var(--ink);
+  background: var(--surface-3);
+  color: var(--ink-3);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0;
@@ -553,17 +485,17 @@ th {
 .picker__input {
   width: 100%;
   border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: 6px;
+  padding: 8px 11px;
   background: var(--surface);
   font-family: var(--font-body);
-  font-size: 14px;
+  font-size: 13.5px;
   font-weight: 500;
   color: var(--ink);
   letter-spacing: -0.005em;
-  transition: border-color 140ms ease, box-shadow 140ms ease;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
-.picker__input:hover { border-color: var(--ink-2); }
+.picker__input:hover { border-color: var(--ink-3); }
 .picker__input:focus {
   outline: none;
   border-color: var(--accent);
@@ -571,68 +503,64 @@ th {
 }
 .picker__competitors {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
 }
 .picker__actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   margin-top: 4px;
 }
 .picker__primary {
   background: var(--ink);
-  font-size: 14px;
-  padding: 10px 18px;
+  font-size: 13.5px;
+  padding: 8px 16px;
 }
 .picker__primary:hover { background: var(--accent); }
 .picker__secondary {
-  background: transparent;
-  color: var(--ink);
+  background: var(--surface);
+  color: var(--ink-3);
   border: 1px solid var(--line-strong);
-  font-size: 14px;
-  padding: 9px 14px;
+  font-size: 13.5px;
+  padding: 7px 13px;
 }
 .picker__secondary:hover {
-  background: var(--soft);
+  background: var(--surface-3);
   color: var(--ink);
-  border-color: var(--ink-2);
+  border-color: var(--ink-3);
 }
-.picker__status {
-  font-size: 12px;
-  color: var(--muted);
-}
+.picker__status { font-size: 12px; color: var(--muted); }
 
-/* ---------- Charts side-by-side ---------- */
 .charts-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
-  gap: 14px;
+  gap: 12px;
 }
 
-/* ---------- Metric list (SoV bars + Sentiment gauge) ---------- */
-.metric-list { display: grid; gap: 2px; }
+/* ---------- Metric list ---------- */
+.metric-list { display: grid; gap: 1px; }
 .metric-row {
   display: grid;
-  grid-template-columns: minmax(110px, 1.2fr) minmax(140px, 2fr) 64px;
+  grid-template-columns: minmax(110px, 1.2fr) minmax(140px, 2fr) 60px;
   align-items: center;
-  gap: 14px;
-  padding: 9px 8px;
-  margin: 0 -8px;
-  border-radius: 8px;
-  transition: background 160ms ease;
+  gap: 12px;
+  padding: 7px 6px;
+  margin: 0 -6px;
+  border-radius: 6px;
+  transition: background 140ms ease;
 }
-.metric-row:hover { background: var(--soft); }
+.metric-row:hover { background: var(--surface-3); }
 .metric-row__label {
-  font-weight: 600;
-  font-size: 14px;
+  font-weight: 500;
+  font-size: 13.5px;
   color: var(--ink);
   letter-spacing: -0.005em;
 }
 .metric-row__bar {
   position: relative;
-  height: 6px;
+  height: 5px;
   border-radius: 999px;
   background: var(--line);
   overflow: hidden;
@@ -645,7 +573,7 @@ th {
 }
 .metric-row__num {
   font-variant-numeric: tabular-nums;
-  font-size: 13px;
+  font-size: 12.5px;
   text-align: right;
   color: var(--ink);
   font-weight: 500;
@@ -653,41 +581,40 @@ th {
 
 .sentiment-gauge {
   position: relative;
-  height: 6px;
+  height: 5px;
   border-radius: 999px;
   background: linear-gradient(
     90deg,
-    rgba(185, 28, 28, 0.3) 0%,
+    rgba(185, 28, 28, 0.28) 0%,
     var(--line) 50%,
-    rgba(4, 120, 87, 0.3) 100%
+    rgba(4, 120, 87, 0.28) 100%
   );
 }
 .sentiment-gauge__pin {
   position: absolute;
   top: 50%;
-  width: 12px;
-  height: 12px;
+  width: 11px;
+  height: 11px;
   border-radius: 999px;
   border: 2px solid white;
   transform: translate(-50%, -50%);
-  box-shadow: 0 1px 3px rgba(10, 14, 26, 0.25), 0 0 0 1px var(--line-strong);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.2), 0 0 0 1px var(--line-strong);
   background: var(--ink);
   transition: left 480ms cubic-bezier(0.34, 1.4, 0.64, 1);
 }
 
-/* ---------- Chips ---------- */
-.chip-row { display: inline-flex; flex-wrap: wrap; gap: 6px; }
+.chip-row { display: inline-flex; flex-wrap: wrap; gap: 5px; }
 .chip {
   display: inline-block;
   font-size: 11.5px;
   font-weight: 500;
   letter-spacing: -0.005em;
-  padding: 3px 9px;
+  padding: 2px 8px;
   border-radius: 999px;
-  background: var(--soft);
-  color: var(--ink);
+  background: var(--surface-3);
+  color: var(--ink-3);
   border: 1px solid var(--line);
-  transition: background 160ms ease, border-color 160ms ease;
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
 }
 .chip:hover {
   background: var(--accent-soft);
@@ -696,64 +623,59 @@ th {
   cursor: default;
 }
 
-/* ---------- Bullet list ---------- */
 .bullet-list {
   margin: 0;
   padding-left: 18px;
-  font-size: 14px;
+  font-size: 13.5px;
   color: var(--ink);
   line-height: 1.6;
 }
-.bullet-list li + li { margin-top: 8px; }
+.bullet-list li + li { margin-top: 6px; }
 .bullet-list em { font-style: italic; color: var(--accent); font-weight: 600; }
 
-/* ---------- Stat tile ---------- */
 .stat-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
+  gap: 10px;
 }
 .stat {
   border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 14px 18px 16px;
+  border-radius: 10px;
+  padding: 12px 16px 14px;
   background: var(--surface);
-  transition: border-color 180ms ease, box-shadow 180ms ease;
+  transition: border-color 160ms ease;
 }
-.stat:hover {
-  border-color: var(--accent);
-  box-shadow: 0 6px 18px rgba(67, 56, 202, 0.06);
-}
+.stat:hover { border-color: var(--line-strong); }
 .stat__label {
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
   color: var(--muted);
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 .stat__value {
-  font-weight: 700;
-  font-size: 30px;
-  letter-spacing: -0.032em;
+  font-weight: 600;
+  font-size: 26px;
+  letter-spacing: -0.028em;
   color: var(--ink);
   font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 
 .subhead {
-  margin: 14px 0 6px;
+  margin: 12px 0 4px;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--muted);
+  color: var(--ink-3);
 }
 
-/* ---------- Live Run Theater ---------- */
+/* ---------- Theater ---------- */
 .theater {
   margin: 0;
-  padding: 22px 24px 24px;
+  padding: 18px 20px 20px;
   max-width: 1280px;
 }
 .theater__head {
@@ -761,8 +683,8 @@ th {
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 16px;
-  padding-bottom: 14px;
+  margin-bottom: 14px;
+  padding-bottom: 12px;
   border-bottom: 1px solid var(--line);
 }
 .theater__kicker {
@@ -776,8 +698,8 @@ th {
 }
 .theater__title {
   margin: 0;
-  font-weight: 700;
-  font-size: 18px;
+  font-weight: 600;
+  font-size: 15px;
   letter-spacing: -0.018em;
 }
 .theater__status {
@@ -787,12 +709,11 @@ th {
   max-width: 36ch;
   font-weight: 400;
 }
-
 .theater__judge {
-  margin-bottom: 14px;
-  padding: 12px 14px;
-  border-radius: 10px;
-  background: var(--soft);
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--surface-2);
   border: 1px dashed var(--line-strong);
 }
 .theater__judge-label {
@@ -800,7 +721,7 @@ th {
   font-size: 11px;
   font-weight: 500;
   color: var(--muted);
-  margin-bottom: 6px;
+  margin-bottom: 4px;
   letter-spacing: 0;
   text-transform: none;
 }
@@ -808,26 +729,25 @@ th {
   margin: 0;
   white-space: pre-wrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
+  font-size: 11.5px;
   line-height: 1.55;
   color: var(--ink);
 }
-
 .theater__columns {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
+  gap: 10px;
 }
 .theater__column {
   border: 1px solid var(--line);
   border-top: 3px solid currentColor;
-  border-radius: 10px;
-  padding: 12px 14px 14px;
+  border-radius: 8px;
+  padding: 10px 12px 12px;
   background: var(--surface);
   display: flex;
   flex-direction: column;
-  min-height: 220px;
-  transition: border-color 180ms ease;
+  min-height: 200px;
+  transition: border-color 160ms ease;
 }
 .theater__column:hover { border-color: var(--line-strong); }
 .theater__col-head {
@@ -839,7 +759,7 @@ th {
 .theater__col-head h4 {
   margin: 0;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13.5px;
   letter-spacing: -0.012em;
 }
 .theater__col-count {
@@ -848,7 +768,7 @@ th {
   font-variant-numeric: tabular-nums;
 }
 .theater__progress {
-  margin: 8px 0 6px;
+  margin: 7px 0 5px;
   height: 3px;
   background: var(--line);
   border-radius: 2px;
@@ -859,8 +779,8 @@ th {
   transition: width 280ms ease-out;
 }
 .theater__col-status {
-  margin: 0 0 8px;
-  font-size: 11.5px;
+  margin: 0 0 6px;
+  font-size: 11px;
   color: var(--muted);
   min-height: 1.4em;
 }
@@ -869,7 +789,7 @@ th {
   flex-grow: 1;
   white-space: pre-wrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
+  font-size: 11.5px;
   line-height: 1.55;
   color: var(--ink);
 }
@@ -879,7 +799,7 @@ th {
 }
 .theater__cursor {
   display: inline-block;
-  width: 7px;
+  width: 6px;
   height: 1em;
   margin-left: 2px;
   vertical-align: -2px;
@@ -890,41 +810,30 @@ th {
   51%, 100% { opacity: 0; }
 }
 
-/* ---------- Trend snapshot mini-bars ---------- */
+/* ---------- Trend mini-bars ---------- */
 .trend-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 12px;
+  gap: 10px;
 }
 .trend-grid__brand {
   border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 14px 16px;
+  border-radius: 8px;
+  padding: 12px 14px;
   background: var(--surface);
-  transition: border-color 180ms ease;
+  transition: border-color 160ms ease;
 }
-.trend-grid__brand:hover { border-color: var(--accent); }
+.trend-grid__brand:hover { border-color: var(--line-strong); }
 .trend-grid__name {
   font-weight: 600;
-  font-size: 13px;
-  margin-bottom: 8px;
+  font-size: 12.5px;
+  margin-bottom: 6px;
   color: var(--ink);
   letter-spacing: -0.012em;
 }
-.trend-mini {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 11.5px;
-}
-.trend-mini td {
-  padding: 3px 6px 3px 0;
-  vertical-align: middle;
-  border: none;
-}
-.trend-mini__day {
-  color: var(--muted);
-  width: 38px;
-}
+.trend-mini { width: 100%; border-collapse: collapse; font-size: 11px; }
+.trend-mini td { padding: 2px 6px 2px 0; vertical-align: middle; border: none; }
+.trend-mini__day { color: var(--muted); width: 36px; }
 .trend-mini__bar {
   display: block;
   position: relative;
@@ -941,32 +850,32 @@ th {
   transition: width 480ms cubic-bezier(0.34, 1.4, 0.64, 1);
 }
 .trend-mini__num {
-  width: 36px;
+  width: 34px;
   text-align: right;
   color: var(--ink);
   font-variant-numeric: tabular-nums;
   font-weight: 500;
 }
 .trend-mini__sent {
-  width: 44px;
+  width: 42px;
   text-align: right;
   font-variant-numeric: tabular-nums;
   font-weight: 500;
 }
 
 /* ---------- Mount animations ---------- */
-.workspace > * { animation: fadeUp 380ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+.workspace > * { animation: fadeUp 320ms cubic-bezier(0.16, 1, 0.3, 1) both; }
 .workspace > :nth-child(1) { animation-delay: 0ms; }
-.workspace > :nth-child(2) { animation-delay: 60ms; }
-.workspace > :nth-child(3) { animation-delay: 120ms; }
-.workspace > :nth-child(4) { animation-delay: 180ms; }
-.workspace > :nth-child(5) { animation-delay: 240ms; }
-.workspace > :nth-child(6) { animation-delay: 300ms; }
-.workspace > :nth-child(7) { animation-delay: 360ms; }
-.workspace > :nth-child(8) { animation-delay: 420ms; }
+.workspace > :nth-child(2) { animation-delay: 50ms; }
+.workspace > :nth-child(3) { animation-delay: 100ms; }
+.workspace > :nth-child(4) { animation-delay: 150ms; }
+.workspace > :nth-child(5) { animation-delay: 200ms; }
+.workspace > :nth-child(6) { animation-delay: 250ms; }
+.workspace > :nth-child(7) { animation-delay: 300ms; }
+.workspace > :nth-child(8) { animation-delay: 350ms; }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(8px); }
+  from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }
 }
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,15 +1,46 @@
 :root {
-  color: #181818;
-  background: #f7f7f4;
+  color: #0f172a;
+  background: #f5f7fb;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+
+  /* Tokens */
+  --ink: #0f172a;
+  --ink-2: #1e293b;
+  --muted: #475569;
+  --subtle: #94a3b8;
+  --line: #e2e8f0;
+  --line-strong: #cbd5e1;
+  --surface: #ffffff;
+  --soft: #f0f4f9;
+  --warm: #fafaf6;
+  --accent: #1e40af;
+  --accent-soft: #dbeafe;
+  --success: #047857;
+  --danger: #b91c1c;
+  --warning: #b45309;
+
+  --brand-1: #1d4ed8;
+  --brand-2: #db2777;
+  --brand-3: #7c3aed;
+  --brand-4: #0891b2;
+  --brand-5: #d97706;
+  --brand-6: #059669;
+
+  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --shadow-card: 0 1px 0 rgba(15, 23, 42, 0.04), 0 4px 14px rgba(15, 23, 42, 0.04);
+  --shadow-hover: 0 1px 0 rgba(15, 23, 42, 0.05), 0 12px 32px rgba(15, 23, 42, 0.07);
 }
 
-* {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
 body {
   margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background:
+    radial-gradient(ellipse 90% 50% at 50% -10%, rgba(30, 64, 175, 0.04), transparent 70%),
+    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(124, 58, 237, 0.04), transparent 70%),
+    #f5f7fb;
 }
 
 button,
@@ -34,66 +65,161 @@ textarea {
   display: grid;
   gap: 16px;
   width: min(520px, 100%);
-  padding: 24px;
-  background: white;
-  border: 1px solid #d8d8d2;
-  border-radius: 8px;
+  padding: 28px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: var(--shadow-card);
 }
 
 .onboarding h1,
 .profile-header h1 {
   margin: 0;
+  font-size: 22px;
+  letter-spacing: -0.012em;
 }
 
 label {
   display: grid;
-  gap: 6px;
-  font-weight: 650;
+  gap: 5px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
 
 input,
 select,
 textarea {
   width: 100%;
-  border: 1px solid #bdbdb5;
-  border-radius: 6px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
   padding: 10px 12px;
-  background: white;
+  background: var(--surface);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--ink);
+  letter-spacing: normal;
+  text-transform: none;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(30, 64, 175, 0.12);
 }
 
 button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   border: 0;
-  border-radius: 6px;
-  padding: 10px 14px;
+  border-radius: 8px;
+  padding: 10px 16px;
   color: white;
-  background: #111;
+  background: var(--ink);
   cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  transition: background 160ms ease, transform 80ms ease, box-shadow 180ms ease, opacity 140ms ease;
 }
+
+button:hover {
+  background: var(--accent);
+  box-shadow: 0 4px 12px rgba(30, 64, 175, 0.22);
+  transform: translateY(-1px);
+}
+
+button:active { transform: translateY(0); }
 
 button:disabled {
   cursor: not-allowed;
   opacity: 0.45;
+  transform: none;
+  box-shadow: none;
 }
 
 .app-shell {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 248px 1fr;
 }
 
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 24px;
+  gap: 22px;
+  padding: 22px 18px;
   color: white;
-  background: #171717;
+  background: linear-gradient(180deg, #1e293b 0%, #0f172a 100%);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.sidebar > strong {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 6px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sidebar > strong::before {
+  content: "P";
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  background: var(--accent);
+  border-radius: 7px;
+  font-size: 14px;
+  font-weight: 700;
+  color: white;
+  box-shadow: 0 2px 6px rgba(30, 64, 175, 0.35);
+}
+
+.sidebar label {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+}
+
+.sidebar select {
+  color: white;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.sidebar select:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.sidebar select:focus {
+  border-color: var(--accent-soft);
+  box-shadow: 0 0 0 3px rgba(219, 234, 254, 0.15);
 }
 
 .workspace {
   display: grid;
   align-content: start;
-  gap: 24px;
-  padding: 24px;
+  gap: 22px;
+  padding: 32px 36px 56px;
+  max-width: 1240px;
 }
 
 .topbar {
@@ -101,109 +227,106 @@ button:disabled {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding-bottom: 20px;
-  border-bottom: 1px solid #d8d8d2;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+.topbar > div > p:first-child {
+  margin: 0 0 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.022em;
 }
 
 .panel {
   display: grid;
-  gap: 12px;
-  max-width: 760px;
-  padding: 24px;
-  background: white;
-  border: 1px solid #d8d8d2;
-  border-radius: 8px;
+  gap: 14px;
+  max-width: 1040px;
+  padding: 22px 24px 22px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: var(--shadow-card);
+  transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
+}
+
+.panel:hover {
+  border-color: var(--line-strong);
+  box-shadow: var(--shadow-hover);
 }
 
 .wide-panel {
-  max-width: 1040px;
+  max-width: 1240px;
+}
+
+.panel > h2,
+.panel > h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.panel > h3 {
+  position: relative;
+  padding-left: 14px;
+}
+
+.panel > h3::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent);
 }
 
 .sentiment-card {
   display: grid;
   gap: 10px;
   padding: 16px;
-  background: #fbfbf8;
-  border: 1px solid #e0e0da;
-  border-radius: 8px;
+  background: var(--soft);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  transition: border-color 180ms ease, transform 180ms ease;
 }
-
-.sentiment-card h3 {
-  margin: 0;
+.sentiment-card:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
 }
+.sentiment-card h3 { margin: 0; font-size: 14px; font-weight: 600; }
 
-.sentiment-chart {
-  display: block;
-  width: 100%;
-  height: auto;
-}
+.sentiment-chart { display: block; width: 100%; height: auto; }
+.neutral-line { stroke: #9ca3af; stroke-dasharray: 6 6; stroke-width: 2; }
+.grid-line { stroke: #e5e7eb; stroke-width: 1; }
+.trend-line { stroke-linecap: round; stroke-width: 5; }
+.trend-positive { stroke: var(--success); }
+.trend-negative { stroke: var(--danger); }
+.trend-dot { stroke: white; stroke-width: 2; }
+.trend-dot-positive { fill: var(--success); }
+.trend-dot-negative { fill: var(--danger); }
+.chart-label, .axis-label { fill: var(--muted); font-size: 12px; }
 
-.neutral-line {
-  stroke: #9ca3af;
-  stroke-dasharray: 6 6;
-  stroke-width: 2;
-}
-
-.grid-line {
-  stroke: #e5e7eb;
-  stroke-width: 1;
-}
-
-.trend-line {
-  stroke-linecap: round;
-  stroke-width: 5;
-}
-
-.trend-positive {
-  stroke: #16a34a;
-}
-
-.trend-negative {
-  stroke: #dc2626;
-}
-
-.trend-dot {
-  stroke: white;
-  stroke-width: 2;
-}
-
-.trend-dot-positive {
-  fill: #16a34a;
-}
-
-.trend-dot-negative {
-  fill: #dc2626;
-}
-
-.chart-label {
-  fill: #66665f;
-  font-size: 12px;
-}
-
-.axis-label {
-  fill: #66665f;
-  font-size: 12px;
-}
-
-.panel h2,
-.topbar h1 {
-  margin: 0;
-}
-
-dl {
-  display: grid;
-  gap: 12px;
-  margin: 0;
-}
-
-dd {
-  margin: 4px 0 0;
-}
-
+dl { display: grid; gap: 12px; margin: 0; }
+dd { margin: 4px 0 0; font-size: 14px; color: var(--ink); font-weight: 400; letter-spacing: 0; text-transform: none; }
 dt {
-  color: #66665f;
-  font-size: 12px;
-  font-weight: 750;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
@@ -214,71 +337,309 @@ table {
 
 th,
 td {
-  padding: 12px;
+  padding: 11px 12px;
   text-align: left;
-  border-bottom: 1px solid #e4e4de;
-  vertical-align: top;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
 }
 
 th {
-  color: #66665f;
-  font-size: 12px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
 .sentiment {
   display: inline-block;
   min-width: 76px;
-  padding: 4px 8px;
+  padding: 4px 10px;
   border-radius: 999px;
   text-align: center;
-  font-size: 12px;
-  font-weight: 700;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
-.sentiment-positive {
-  color: #14532d;
-  background: #dcfce7;
-}
+.sentiment-positive { color: #14532d; background: #dcfce7; }
+.sentiment-neutral  { color: #3f3f46; background: #f4f4f5; }
+.sentiment-negative { color: #7f1d1d; background: #fee2e2; }
 
-.sentiment-neutral {
-  color: #3f3f46;
-  background: #f4f4f5;
-}
-
-.sentiment-negative {
-  color: #7f1d1d;
-  background: #fee2e2;
-}
-
-.inline-form {
-  display: flex;
-  gap: 8px;
-}
-
-.inline-form input {
-  flex: 1;
-}
+.inline-form { display: flex; gap: 8px; }
+.inline-form input { flex: 1; }
 
 .muted {
-  color: #66665f;
+  color: var(--muted);
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+}
+.error {
+  color: var(--danger);
+  font-family: var(--mono);
+  font-size: 12px;
+  background: rgba(185, 28, 28, 0.07);
+  border: 1px solid rgba(185, 28, 28, 0.2);
+  padding: 8px 12px;
+  border-radius: 6px;
 }
 
-.error {
-  color: #b00020;
+/* ---------- Live Run Theater ---------- */
+.theater {
+  margin: 0;
+  padding: 22px 24px 24px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 8% -8%, rgba(30, 64, 175, 0.06), transparent 55%),
+    radial-gradient(circle at 100% 110%, rgba(124, 58, 237, 0.05), transparent 55%),
+    var(--surface);
+  box-shadow: var(--shadow-card);
+  max-width: 1240px;
+}
+.theater__head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+.theater__kicker {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 4px;
+}
+.theater__title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.018em;
+}
+.theater__status {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-align: right;
+  max-width: 36ch;
+  font-weight: 400;
+}
+
+.theater__judge {
+  margin-bottom: 14px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: var(--soft);
+  border: 1px dashed var(--line-strong);
+}
+.theater__judge-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+.theater__judge-text {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink);
+}
+
+.theater__columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.theater__column {
+  border: 1px solid var(--line);
+  border-top: 3px solid currentColor;
+  border-radius: 10px;
+  padding: 12px 14px 14px;
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+  transition: border-color 180ms ease, transform 180ms ease;
+}
+.theater__column:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+}
+.theater__col-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.theater__col-head h4 {
+  margin: 0;
+  font-weight: 600;
+  font-size: 15px;
+}
+.theater__col-count {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.06em;
+}
+.theater__progress {
+  margin: 8px 0 6px;
+  height: 3px;
+  background: var(--line);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.theater__progress-fill {
+  height: 100%;
+  transition: width 280ms ease-out;
+}
+.theater__col-status {
+  margin: 0 0 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  min-height: 1.4em;
+}
+.theater__stream {
+  margin: 0;
+  flex-grow: 1;
+  white-space: pre-wrap;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink);
+}
+.theater__stream[data-empty="true"] {
+  color: var(--subtle);
+  font-style: italic;
+}
+.theater__cursor {
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: -2px;
+  animation: theaterBlink 1s steps(2, end) infinite;
+}
+@keyframes theaterBlink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+/* ---------- Trend snapshot mini-bars ---------- */
+.trend-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+.trend-grid__brand {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px 14px 14px;
+  background: var(--soft);
+  transition: border-color 180ms ease, background 180ms ease, transform 180ms ease;
+}
+.trend-grid__brand:hover {
+  border-color: var(--line-strong);
+  background: var(--surface);
+  transform: translateY(-1px);
+}
+.trend-grid__name {
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 8px;
+  color: var(--ink);
+}
+.trend-mini {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+.trend-mini td {
+  padding: 3px 6px 3px 0;
+  vertical-align: middle;
+  border: none;
+}
+.trend-mini__day {
+  color: var(--muted);
+  width: 38px;
+  letter-spacing: 0.02em;
+}
+.trend-mini__bar {
+  display: block;
+  position: relative;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--line);
+  width: 100%;
+}
+.trend-mini__bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--ink);
+  transition: width 280ms ease-out;
+}
+.trend-mini__num {
+  width: 36px;
+  text-align: right;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.trend-mini__sent {
+  width: 44px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- Mount animations ---------- */
+.workspace > * { animation: fadeUp 380ms ease-out both; }
+.workspace > :nth-child(1) { animation-delay: 0ms; }
+.workspace > :nth-child(2) { animation-delay: 60ms; }
+.workspace > :nth-child(3) { animation-delay: 120ms; }
+.workspace > :nth-child(4) { animation-delay: 180ms; }
+.workspace > :nth-child(5) { animation-delay: 240ms; }
+.workspace > :nth-child(6) { animation-delay: 300ms; }
+.workspace > :nth-child(7) { animation-delay: 360ms; }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace > *,
+  .panel,
+  .sentiment-card,
+  .theater__column,
+  .trend-grid__brand,
+  button {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 
 @media (max-width: 720px) {
-  .app-shell {
-    grid-template-columns: 1fr;
-  }
-
-  .topbar {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .inline-form {
-    flex-direction: column;
-  }
+  .app-shell { grid-template-columns: 1fr; }
+  .sidebar { position: static; height: auto; }
+  .topbar { align-items: stretch; flex-direction: column; }
+  .inline-form { flex-direction: column; }
+  .workspace { padding: 24px 20px 40px; }
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,18 +1,16 @@
 /*
- * Perception design system
- * Direction: refined modern intelligence dashboard. Warm-cream surface,
- * deep navy ink, single saturated indigo accent, characterful Geist
- * typography. Generous type scale, hairline rules, soft hover lift.
- * Calm in repose, charged on interaction.
+ * Perception design system — clean dashboard.
+ * Inter throughout, slate sidebar (not pure black), warm-cream workspace,
+ * indigo accent, hairline section dividers, sparing card chrome.
  */
 
 :root {
   color: #0a0e1a;
-  background: #f7f4ec;
+  background: #f7f5ee;
 
-  /* Type */
-  --font-body: "Geist", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-mono: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* Type — Inter for everything except mono numerics */
+  --font-body: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "Inter", ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* Ink + paper */
   --ink: #0a0e1a;
@@ -23,29 +21,35 @@
   --line-strong: #d3cab6;
   --surface: #ffffff;
   --soft: #f1ebd8;
-  --warm: #f7f4ec;
+  --warm: #f7f5ee;
+
+  /* Sidebar (slate, not black) */
+  --side-bg: #1e2433;
+  --side-bg-2: #232a3a;
+  --side-line: rgba(255, 255, 255, 0.07);
+  --side-line-strong: rgba(255, 255, 255, 0.13);
+  --side-text: rgba(255, 255, 255, 0.78);
+  --side-text-muted: rgba(255, 255, 255, 0.5);
 
   /* Accents */
-  --accent: #312e81;
+  --accent: #4338ca;
+  --accent-2: #6366f1;
   --accent-soft: #e0e7ff;
-  --accent-glow: rgba(49, 46, 129, 0.18);
+  --accent-glow: rgba(67, 56, 202, 0.16);
   --success: #047857;
   --danger: #b91c1c;
   --warning: #b45309;
 
-  /* Per-brand chart palette — saturated, distinct, harmonious */
-  --brand-1: #312e81;
+  /* Per-brand chart palette — saturated, distinct */
+  --brand-1: #4338ca;
   --brand-2: #be185d;
   --brand-3: #6d28d9;
   --brand-4: #0f766e;
   --brand-5: #c2410c;
   --brand-6: #166534;
 
-  --shadow-soft: 0 1px 0 rgba(10, 14, 26, 0.04), 0 4px 14px rgba(10, 14, 26, 0.05);
-  --shadow-hover: 0 1px 0 rgba(10, 14, 26, 0.06), 0 12px 32px rgba(10, 14, 26, 0.09);
-
   font-family: var(--font-body);
-  font-feature-settings: "ss01" on, "ss02" on, "cv11" on;
+  font-feature-settings: "ss01" on, "cv11" on;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -57,15 +61,7 @@ body {
   font-size: 14px;
   line-height: 1.55;
   color: var(--ink);
-  background:
-    radial-gradient(ellipse 90% 50% at 50% -10%, rgba(49, 46, 129, 0.06), transparent 70%),
-    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(194, 65, 12, 0.05), transparent 70%),
-    var(--warm);
-  /* very subtle paper grain */
-  background-image:
-    radial-gradient(ellipse 90% 50% at 50% -10%, rgba(49, 46, 129, 0.06), transparent 70%),
-    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(194, 65, 12, 0.05), transparent 70%),
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.025 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  background: var(--warm);
 }
 
 button,
@@ -95,13 +91,11 @@ textarea {
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 14px;
-  box-shadow: var(--shadow-soft);
 }
 
-.onboarding h1,
-.profile-header h1 {
+.onboarding h1 {
   margin: 0;
-  font-size: 26px;
+  font-size: 24px;
   font-weight: 700;
   letter-spacing: -0.022em;
 }
@@ -109,12 +103,11 @@ textarea {
 label {
   display: grid;
   gap: 6px;
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
   color: var(--muted);
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 input,
@@ -123,13 +116,13 @@ textarea {
   width: 100%;
   border: 1px solid var(--line-strong);
   border-radius: 8px;
-  padding: 10px 12px;
+  padding: 9px 12px;
   background: var(--surface);
   font-family: var(--font-body);
   font-size: 14px;
   font-weight: 400;
   color: var(--ink);
-  letter-spacing: normal;
+  letter-spacing: 0;
   text-transform: none;
   transition: border-color 140ms ease, box-shadow 140ms ease;
 }
@@ -148,7 +141,7 @@ button {
   gap: 8px;
   border: 0;
   border-radius: 8px;
-  padding: 10px 18px;
+  padding: 10px 16px;
   color: white;
   background: var(--ink);
   cursor: pointer;
@@ -156,39 +149,36 @@ button {
   font-weight: 600;
   font-size: 14px;
   letter-spacing: -0.005em;
-  box-shadow: 0 1px 2px rgba(10, 14, 26, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.07);
-  transition: background 160ms ease, transform 80ms ease, box-shadow 200ms ease, opacity 140ms ease;
+  transition: background 160ms ease, transform 80ms ease, opacity 140ms ease;
 }
 
 button:hover {
   background: var(--accent);
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px var(--accent-glow);
 }
 button:active { transform: translateY(0); }
 button:disabled {
   cursor: not-allowed;
   opacity: 0.4;
   transform: none;
-  box-shadow: none;
 }
 
 /* ---------- Shell ---------- */
 .app-shell {
   display: grid;
-  grid-template-columns: 240px 1fr;
+  grid-template-columns: 232px 1fr;
 }
 
 .sidebar {
   display: flex;
   flex-direction: column;
-  padding: 22px 14px 18px;
-  color: white;
-  background: linear-gradient(180deg, #161b29 0%, #0a0e1a 100%);
+  padding: 18px 14px;
+  color: var(--side-text);
+  background: var(--side-bg);
   position: sticky;
   top: 0;
   height: 100vh;
-  border-right: 1px solid rgba(255, 255, 255, 0.05);
+  border-right: 1px solid var(--side-line);
   overflow-y: auto;
 }
 
@@ -196,9 +186,9 @@ button:disabled {
   display: flex;
   align-items: center;
   gap: 11px;
-  padding: 4px 8px 18px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
-  margin-bottom: 18px;
+  padding: 4px 8px 16px;
+  border-bottom: 1px solid var(--side-line);
+  margin-bottom: 16px;
 }
 .brand-lockup__text {
   display: grid;
@@ -206,31 +196,28 @@ button:disabled {
 }
 .brand-lockup strong {
   display: block;
-  font-size: 16px;
-  font-weight: 700;
-  letter-spacing: -0.018em;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.014em;
   color: white;
-  font-family: var(--font-body);
 }
 .brand-lockup span {
-  font-family: var(--font-mono);
-  font-size: 9.5px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.5);
-  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--side-text-muted);
+  font-weight: 400;
 }
 .brand-mark {
   display: grid;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   place-items: center;
-  background: linear-gradient(135deg, #4f46e5 0%, #312e81 100%);
-  border-radius: 8px;
-  font-size: 14px;
+  background: linear-gradient(135deg, var(--accent-2) 0%, var(--accent) 100%);
+  border-radius: 7px;
+  font-size: 13px;
   font-weight: 700;
   color: white;
-  box-shadow: 0 4px 12px rgba(79, 70, 229, 0.32), inset 0 1px 0 rgba(255, 255, 255, 0.16);
   letter-spacing: -0.02em;
 }
 
@@ -240,109 +227,92 @@ button:disabled {
 }
 
 .nav-item {
+  position: relative;
   width: 100%;
-  border: 0;
-  border-radius: 8px;
+  border: 1px solid transparent;
   background: transparent;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--side-text);
   cursor: pointer;
-  padding: 9px 12px;
+  padding: 8px 12px;
   text-align: left;
   font-family: var(--font-body);
   font-size: 13.5px;
   font-weight: 500;
   letter-spacing: -0.005em;
-  transition: background 140ms ease, color 140ms ease, transform 80ms ease;
+  border-radius: 7px;
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
   box-shadow: none;
   text-transform: none;
 }
 
 .nav-item:hover {
-  background: rgba(255, 255, 255, 0.06);
   color: white;
+  background: var(--side-bg-2);
+  border-color: var(--side-line-strong);
   transform: none;
 }
 
 .nav-item.active {
-  background: rgba(255, 255, 255, 0.1);
   color: white;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-}
-
-.nav-item.active::before {
-  content: "";
-  display: inline-block;
-  width: 4px;
-  height: 4px;
-  border-radius: 999px;
-  background: var(--accent-soft);
-  margin-right: 8px;
-  vertical-align: 2px;
-  box-shadow: 0 0 8px var(--accent-soft);
+  background: var(--side-bg-2);
+  border-color: var(--side-line-strong);
+  box-shadow: inset 2px 0 0 var(--accent-2);
 }
 
 .sidebar-footer {
   margin-top: auto;
-  padding-top: 16px;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  padding-top: 14px;
+  border-top: 1px solid var(--side-line);
   display: grid;
   gap: 8px;
 }
 .sidebar-footer__label {
-  font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.45);
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--side-text-muted);
   margin-bottom: 2px;
 }
 .sidebar-profile {
   width: 100%;
   color: white;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--side-bg-2);
+  border: 1px solid var(--side-line-strong);
   font-family: var(--font-body);
   font-size: 13px;
   font-weight: 500;
-  letter-spacing: 0;
-  text-transform: none;
-  padding: 8px 10px;
-  border-radius: 7px;
+  padding: 7px 9px;
+  border-radius: 6px;
 }
-.sidebar-profile:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.16);
-}
+.sidebar-profile:hover { background: #2a3243; }
 .sidebar-profile:focus {
-  border-color: rgba(224, 231, 255, 0.4);
-  box-shadow: 0 0 0 3px rgba(224, 231, 255, 0.12);
+  border-color: var(--accent-2);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
 }
 .sidebar-add {
   width: 100%;
   background: transparent;
-  color: rgba(255, 255, 255, 0.7);
-  border: 1px dashed rgba(255, 255, 255, 0.14);
+  color: var(--side-text);
+  border: 1px dashed var(--side-line-strong);
   font-size: 12px;
   font-weight: 500;
-  padding: 7px 10px;
+  padding: 6px 9px;
   letter-spacing: 0;
   text-transform: none;
-  box-shadow: none;
 }
 .sidebar-add:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: rgba(255, 255, 255, 0.25);
+  background: var(--side-bg-2);
+  border-color: rgba(255, 255, 255, 0.22);
   color: white;
   transform: none;
-  box-shadow: none;
 }
 
 /* ---------- Workspace + topbar ---------- */
 .workspace {
   display: grid;
   align-content: start;
-  gap: 22px;
+  gap: 28px;
   padding: 36px 44px 72px;
   max-width: 1320px;
   width: 100%;
@@ -359,120 +329,102 @@ button:disabled {
 
 .topbar__eyebrow {
   margin: 0 0 8px;
-  font-family: var(--font-mono);
   font-size: 11px;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--accent);
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--muted);
   font-weight: 500;
+}
+.topbar__brand {
+  color: var(--accent);
+  font-weight: 600;
 }
 
 .topbar h1 {
   margin: 0;
-  font-size: 34px;
+  font-size: 30px;
   font-weight: 700;
-  letter-spacing: -0.028em;
+  letter-spacing: -0.026em;
   line-height: 1.1;
 }
 
 .topbar__sub {
-  margin: 10px 0 0;
-  font-size: 14.5px;
+  margin: 8px 0 0;
+  font-size: 14px;
   color: var(--muted);
   max-width: 60ch;
   line-height: 1.55;
 }
 
-/* ---------- Panels ---------- */
-.panel {
+/* ---------- Block: section heading + content ---------- */
+.block {
   display: grid;
   gap: 14px;
-  max-width: 1040px;
-  padding: 24px 26px;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  box-shadow: var(--shadow-soft);
-  transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
+  max-width: 1280px;
 }
 
-.panel:hover {
-  border-color: var(--line-strong);
-  box-shadow: var(--shadow-hover);
-}
-
-.wide-panel { max-width: 1280px; }
-
-.panel > h2,
-.panel > h3 {
+.block__title {
   margin: 0;
   font-size: 17px;
   font-weight: 600;
-  letter-spacing: -0.012em;
+  letter-spacing: -0.016em;
   color: var(--ink);
 }
 
-.panel > h2 {
-  font-size: 22px;
-  font-weight: 700;
-  letter-spacing: -0.022em;
-}
-
-.panel > h3 {
-  position: relative;
-  padding-left: 16px;
-}
-
-.panel > h3::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--accent);
-  box-shadow: 0 0 10px var(--accent-glow);
-}
-
-/* ---------- Sentiment trend (monitoring) ---------- */
-.sentiment-card {
-  display: grid;
-  gap: 10px;
-  padding: 18px;
-  background: var(--soft);
+/* ---------- Card variant ---------- */
+.card {
+  background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 10px;
-  transition: border-color 180ms ease, transform 180ms ease;
+  border-radius: 12px;
+  padding: 22px 24px;
+  display: grid;
+  gap: 14px;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
 }
-.sentiment-card:hover {
+.card:hover {
   border-color: var(--line-strong);
-  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(10, 14, 26, 0.04);
 }
-.sentiment-card h3 { margin: 0; font-size: 14px; font-weight: 600; }
+.wide-panel { max-width: 1280px; }
 
-.sentiment-chart { display: block; width: 100%; height: auto; }
-.neutral-line { stroke: #9ca3af; stroke-dasharray: 6 6; stroke-width: 2; }
-.grid-line { stroke: #e5e7eb; stroke-width: 1; }
-.trend-line { stroke-linecap: round; stroke-width: 5; }
-.trend-positive { stroke: var(--success); }
-.trend-negative { stroke: var(--danger); }
-.trend-dot { stroke: white; stroke-width: 2; }
-.trend-dot-positive { fill: var(--success); }
-.trend-dot-negative { fill: var(--danger); }
-.chart-label, .axis-label { fill: var(--muted); font-size: 12px; }
+/* ---------- Feature + whitespace blocks ---------- */
+.feature-block { display: grid; gap: 14px; }
+.whitespace-block { display: grid; gap: 14px; }
+.feature-table th { padding-left: 0; }
+.feature-table td { padding-left: 0; }
 
-/* ---------- DL ---------- */
+/* ---------- Run meta dl ---------- */
+.run-meta {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 12px 24px;
+  margin: 0;
+  align-items: baseline;
+}
+.run-meta > div { display: contents; }
+.run-meta dt {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.run-meta dd {
+  margin: 0;
+  font-size: 13px;
+  color: var(--ink);
+}
+
+/* ---------- DL (legacy) ---------- */
 dl { display: grid; gap: 14px; margin: 0; }
-dd { margin: 4px 0 0; font-size: 14px; color: var(--ink); font-weight: 400; letter-spacing: 0; text-transform: none; }
+dd { margin: 4px 0 0; font-size: 14px; color: var(--ink); }
 dt {
   color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 /* ---------- Tables ---------- */
@@ -484,7 +436,7 @@ table {
 
 th,
 td {
-  padding: 12px 12px 12px 0;
+  padding: 11px 12px 11px 0;
   text-align: left;
   border-bottom: 1px solid var(--line);
   vertical-align: middle;
@@ -494,12 +446,32 @@ tr:last-child td { border-bottom: none; }
 
 th {
   color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
 }
+
+/* ---------- Sentiment trend (monitoring) ---------- */
+.sentiment-card {
+  display: grid;
+  gap: 10px;
+  padding: 18px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+}
+.sentiment-card h3 { margin: 0; font-size: 14px; font-weight: 600; }
+.sentiment-chart { display: block; width: 100%; height: auto; }
+.neutral-line { stroke: #9ca3af; stroke-dasharray: 6 6; stroke-width: 2; }
+.grid-line { stroke: #e5e7eb; stroke-width: 1; }
+.trend-line { stroke-linecap: round; stroke-width: 5; }
+.trend-positive { stroke: var(--success); }
+.trend-negative { stroke: var(--danger); }
+.trend-dot { stroke: white; stroke-width: 2; }
+.trend-dot-positive { fill: var(--success); }
+.trend-dot-negative { fill: var(--danger); }
+.chart-label, .axis-label { fill: var(--muted); font-size: 12px; }
 
 /* ---------- Sentiment pill (monitoring page) ---------- */
 .sentiment {
@@ -508,12 +480,9 @@ th {
   padding: 4px 10px;
   border-radius: 999px;
   text-align: center;
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
-  letter-spacing: 0.04em;
 }
-
 .sentiment-positive { color: #14532d; background: #dcfce7; }
 .sentiment-neutral  { color: #3f3f46; background: #f4f4f5; }
 .sentiment-negative { color: #7f1d1d; background: #fee2e2; }
@@ -521,41 +490,37 @@ th {
 .inline-form { display: flex; gap: 8px; }
 .inline-form input { flex: 1; }
 
-.muted {
-  color: var(--muted);
-  font-weight: 400;
-  letter-spacing: normal;
-  text-transform: none;
-  font-family: var(--font-body);
-}
+.muted { color: var(--muted); font-weight: 400; }
 .error {
   color: var(--danger);
-  font-family: var(--font-mono);
-  font-size: 12px;
-  background: rgba(185, 28, 28, 0.07);
-  border: 1px solid rgba(185, 28, 28, 0.2);
+  font-size: 13px;
+  background: rgba(185, 28, 28, 0.06);
+  border: 1px solid rgba(185, 28, 28, 0.18);
   padding: 9px 12px;
   border-radius: 8px;
 }
 
 /* ---------- Competitive Set Picker ---------- */
-.picker { gap: 16px; }
+.picker { gap: 18px; }
 .picker__head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
 }
+.picker__head h3 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.016em;
+}
 .picker__count {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  font-size: 12px;
   color: var(--muted);
+  font-weight: 500;
 }
 .picker__hint {
-  margin: -8px 0 4px;
+  margin: -10px 0 4px;
   font-size: 13.5px;
   line-height: 1.55;
   max-width: 64ch;
@@ -566,13 +531,12 @@ th {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
   color: var(--muted);
   margin: 0;
+  letter-spacing: 0;
+  text-transform: none;
 }
 .picker__num {
   display: inline-grid;
@@ -582,7 +546,6 @@ th {
   border-radius: 999px;
   background: var(--soft);
   color: var(--ink);
-  font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0;
@@ -590,39 +553,38 @@ th {
 .picker__input {
   width: 100%;
   border: 1px solid var(--line-strong);
-  border-radius: 9px;
-  padding: 11px 14px;
+  border-radius: 8px;
+  padding: 10px 12px;
   background: var(--surface);
   font-family: var(--font-body);
-  font-size: 14.5px;
+  font-size: 14px;
   font-weight: 500;
   color: var(--ink);
   letter-spacing: -0.005em;
-  transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
 }
 .picker__input:hover { border-color: var(--ink-2); }
 .picker__input:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-glow);
-  background: var(--surface);
 }
 .picker__competitors {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 10px;
+  gap: 12px;
 }
 .picker__actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
-  margin-top: 6px;
+  gap: 10px;
+  margin-top: 4px;
 }
 .picker__primary {
   background: var(--ink);
   font-size: 14px;
-  padding: 11px 22px;
+  padding: 10px 18px;
 }
 .picker__primary:hover { background: var(--accent); }
 .picker__secondary {
@@ -630,19 +592,15 @@ th {
   color: var(--ink);
   border: 1px solid var(--line-strong);
   font-size: 14px;
-  padding: 10px 16px;
-  box-shadow: none;
+  padding: 9px 14px;
 }
 .picker__secondary:hover {
   background: var(--soft);
   color: var(--ink);
   border-color: var(--ink-2);
-  box-shadow: none;
 }
 .picker__status {
-  font-family: var(--font-mono);
-  font-size: 11.5px;
-  letter-spacing: 0.04em;
+  font-size: 12px;
   color: var(--muted);
 }
 
@@ -650,17 +608,17 @@ th {
 .charts-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
-  gap: 18px;
+  gap: 14px;
 }
 
 /* ---------- Metric list (SoV bars + Sentiment gauge) ---------- */
-.metric-list { display: grid; gap: 4px; }
+.metric-list { display: grid; gap: 2px; }
 .metric-row {
   display: grid;
   grid-template-columns: minmax(110px, 1.2fr) minmax(140px, 2fr) 64px;
   align-items: center;
   gap: 14px;
-  padding: 10px 8px;
+  padding: 9px 8px;
   margin: 0 -8px;
   border-radius: 8px;
   transition: background 160ms ease;
@@ -684,10 +642,8 @@ th {
   height: 100%;
   border-radius: inherit;
   transition: width 480ms cubic-bezier(0.34, 1.4, 0.64, 1);
-  box-shadow: 0 0 8px rgba(49, 46, 129, 0.2);
 }
 .metric-row__num {
-  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   font-size: 13px;
   text-align: right;
@@ -723,22 +679,20 @@ th {
 .chip-row { display: inline-flex; flex-wrap: wrap; gap: 6px; }
 .chip {
   display: inline-block;
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 11.5px;
   font-weight: 500;
-  letter-spacing: 0.02em;
-  padding: 4px 10px;
+  letter-spacing: -0.005em;
+  padding: 3px 9px;
   border-radius: 999px;
   background: var(--soft);
   color: var(--ink);
   border: 1px solid var(--line);
-  transition: background 160ms ease, border-color 160ms ease, transform 80ms ease;
+  transition: background 160ms ease, border-color 160ms ease;
 }
 .chip:hover {
   background: var(--accent-soft);
   border-color: var(--accent);
   color: var(--accent);
-  transform: translateY(-1px);
   cursor: default;
 }
 
@@ -751,77 +705,55 @@ th {
   line-height: 1.6;
 }
 .bullet-list li + li { margin-top: 8px; }
-.bullet-list em { font-style: italic; color: var(--accent); }
+.bullet-list em { font-style: italic; color: var(--accent); font-weight: 600; }
 
 /* ---------- Stat tile ---------- */
 .stat-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 14px;
+  gap: 12px;
 }
 .stat {
   border: 1px solid var(--line);
   border-radius: 12px;
   padding: 14px 18px 16px;
-  background: var(--soft);
-  position: relative;
-  overflow: hidden;
-  transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
-}
-.stat::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 100% 0%, var(--accent-glow), transparent 50%);
-  opacity: 0;
-  transition: opacity 240ms ease;
-  pointer-events: none;
+  background: var(--surface);
+  transition: border-color 180ms ease, box-shadow 180ms ease;
 }
 .stat:hover {
   border-color: var(--accent);
-  transform: translateY(-2px);
-  box-shadow: 0 10px 24px rgba(10, 14, 26, 0.08);
+  box-shadow: 0 6px 18px rgba(67, 56, 202, 0.06);
 }
-.stat:hover::after { opacity: 1; }
 .stat__label {
-  font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
   color: var(--muted);
   margin-bottom: 6px;
 }
 .stat__value {
   font-weight: 700;
-  font-size: 32px;
-  letter-spacing: -0.034em;
+  font-size: 30px;
+  letter-spacing: -0.032em;
   color: var(--ink);
   font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 
 .subhead {
-  margin: 18px 0 8px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  margin: 14px 0 6px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
   color: var(--muted);
 }
 
 /* ---------- Live Run Theater ---------- */
 .theater {
   margin: 0;
-  padding: 24px 26px 28px;
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  background:
-    radial-gradient(circle at 8% -8%, rgba(49, 46, 129, 0.08), transparent 55%),
-    radial-gradient(circle at 100% 110%, rgba(194, 65, 12, 0.06), transparent 55%),
-    var(--surface);
-  box-shadow: var(--shadow-soft);
+  padding: 22px 24px 24px;
   max-width: 1280px;
 }
 .theater__head {
@@ -829,31 +761,27 @@ th {
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 18px;
-  padding-bottom: 16px;
+  margin-bottom: 16px;
+  padding-bottom: 14px;
   border-bottom: 1px solid var(--line);
 }
 .theater__kicker {
   display: block;
-  font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
   color: var(--accent);
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 .theater__title {
   margin: 0;
   font-weight: 700;
-  font-size: 20px;
-  letter-spacing: -0.022em;
+  font-size: 18px;
+  letter-spacing: -0.018em;
 }
 .theater__status {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 12px;
   color: var(--muted);
   text-align: right;
   max-width: 36ch;
@@ -869,18 +797,17 @@ th {
 }
 .theater__judge-label {
   display: block;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
+  font-size: 11px;
+  font-weight: 500;
   color: var(--muted);
   margin-bottom: 6px;
-  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
 }
 .theater__judge-text {
   margin: 0;
   white-space: pre-wrap;
-  font-family: var(--font-mono);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   line-height: 1.55;
   color: var(--ink);
@@ -894,18 +821,15 @@ th {
 .theater__column {
   border: 1px solid var(--line);
   border-top: 3px solid currentColor;
-  border-radius: 12px;
-  padding: 14px 16px 16px;
+  border-radius: 10px;
+  padding: 12px 14px 14px;
   background: var(--surface);
   display: flex;
   flex-direction: column;
-  min-height: 230px;
-  transition: border-color 180ms ease, transform 180ms ease;
+  min-height: 220px;
+  transition: border-color 180ms ease;
 }
-.theater__column:hover {
-  border-color: var(--line-strong);
-  transform: translateY(-1px);
-}
+.theater__column:hover { border-color: var(--line-strong); }
 .theater__col-head {
   display: flex;
   align-items: baseline;
@@ -915,18 +839,16 @@ th {
 .theater__col-head h4 {
   margin: 0;
   font-weight: 600;
-  font-size: 15px;
+  font-size: 14px;
   letter-spacing: -0.012em;
 }
 .theater__col-count {
-  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--muted);
-  letter-spacing: 0.06em;
   font-variant-numeric: tabular-nums;
 }
 .theater__progress {
-  margin: 10px 0 6px;
+  margin: 8px 0 6px;
   height: 3px;
   background: var(--line);
   border-radius: 2px;
@@ -938,17 +860,15 @@ th {
 }
 .theater__col-status {
   margin: 0 0 8px;
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 11.5px;
   color: var(--muted);
-  letter-spacing: 0.04em;
   min-height: 1.4em;
 }
 .theater__stream {
   margin: 0;
   flex-grow: 1;
   white-space: pre-wrap;
-  font-family: var(--font-mono);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   line-height: 1.55;
   color: var(--ink);
@@ -974,42 +894,36 @@ th {
 .trend-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 14px;
+  gap: 12px;
 }
 .trend-grid__brand {
   border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 14px 16px 16px;
-  background: var(--soft);
-  transition: border-color 180ms ease, background 180ms ease, transform 180ms ease;
-}
-.trend-grid__brand:hover {
-  border-color: var(--accent);
+  border-radius: 10px;
+  padding: 14px 16px;
   background: var(--surface);
-  transform: translateY(-1px);
+  transition: border-color 180ms ease;
 }
+.trend-grid__brand:hover { border-color: var(--accent); }
 .trend-grid__name {
   font-weight: 600;
   font-size: 13px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   color: var(--ink);
   letter-spacing: -0.012em;
 }
 .trend-mini {
   width: 100%;
   border-collapse: collapse;
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 11.5px;
 }
 .trend-mini td {
-  padding: 4px 6px 4px 0;
+  padding: 3px 6px 3px 0;
   vertical-align: middle;
   border: none;
 }
 .trend-mini__day {
   color: var(--muted);
   width: 38px;
-  letter-spacing: 0.02em;
 }
 .trend-mini__bar {
   display: block;
@@ -1041,28 +955,25 @@ th {
 }
 
 /* ---------- Mount animations ---------- */
-.workspace > * { animation: fadeUp 420ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+.workspace > * { animation: fadeUp 380ms cubic-bezier(0.16, 1, 0.3, 1) both; }
 .workspace > :nth-child(1) { animation-delay: 0ms; }
-.workspace > :nth-child(2) { animation-delay: 70ms; }
-.workspace > :nth-child(3) { animation-delay: 140ms; }
-.workspace > :nth-child(4) { animation-delay: 210ms; }
-.workspace > :nth-child(5) { animation-delay: 280ms; }
-.workspace > :nth-child(6) { animation-delay: 350ms; }
-.workspace > :nth-child(7) { animation-delay: 420ms; }
-.workspace > :nth-child(8) { animation-delay: 490ms; }
+.workspace > :nth-child(2) { animation-delay: 60ms; }
+.workspace > :nth-child(3) { animation-delay: 120ms; }
+.workspace > :nth-child(4) { animation-delay: 180ms; }
+.workspace > :nth-child(5) { animation-delay: 240ms; }
+.workspace > :nth-child(6) { animation-delay: 300ms; }
+.workspace > :nth-child(7) { animation-delay: 360ms; }
+.workspace > :nth-child(8) { animation-delay: 420ms; }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(10px); }
+  from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .workspace > *,
-  .panel,
-  .sentiment-card,
-  .theater__column,
-  .trend-grid__brand,
-  .stat,
+  .card,
+  .nav-item,
   .metric-row__fill,
   .sentiment-gauge__pin,
   .trend-mini__bar-fill,
@@ -1072,7 +983,6 @@ th {
   }
 }
 
-/* Selection */
 ::selection {
   background: var(--accent-soft);
   color: var(--accent);

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -387,6 +387,13 @@ th {
   border-radius: 6px;
 }
 
+/* ---------- Charts side-by-side ---------- */
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 18px;
+}
+
 /* ---------- Live Run Theater ---------- */
 .theater {
   margin: 0;

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -8,9 +8,9 @@ interface Props {
   onSave?: (names: string[]) => Promise<void>;
 }
 
-/** Demo cohort: Sephora vs five beauty retail competitors */
-const DEFAULT_ACCOUNT = "Sephora";
-const DEFAULT_COMPETITORS = ["Ulta", "Bluemercury", "SpaceNK", "SallyBeauty", "Olive Young"];
+/** Demo cohort: Netflix vs five major streaming competitors */
+const DEFAULT_ACCOUNT = "Netflix";
+const DEFAULT_COMPETITORS = ["Disney+", "Max", "Amazon Prime Video", "Apple TV+", "Paramount+"];
 
 export function CompetitiveSetPicker({
   accountBrandName: initialAccountBrandName = DEFAULT_ACCOUNT,

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -8,9 +8,9 @@ interface Props {
   onSave?: (names: string[]) => Promise<void>;
 }
 
-/** Demo cohort: Sephora vs five beauty retail competitors */
-const DEFAULT_ACCOUNT = "Sephora";
-const DEFAULT_COMPETITORS = ["Ulta", "Bluemercury", "SpaceNK", "SallyBeauty", "Olive Young"];
+/** Demo cohort: Netflix vs five major streaming competitors */
+const DEFAULT_ACCOUNT = "Netflix";
+const DEFAULT_COMPETITORS = ["Disney+", "Max", "Amazon Prime Video", "Apple TV+", "Paramount+"];
 
 export function CompetitiveSetPicker({
   accountBrandName: initialAccountBrandName = DEFAULT_ACCOUNT,
@@ -30,48 +30,71 @@ export function CompetitiveSetPicker({
   }, [accountBrandName, competitorNames]);
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16, marginBottom: 20 }}>
-      <h3 style={{ marginTop: 0 }}>Competitive Set — Demo (5 competitors)</h3>
-      <label style={{ display: "block", marginBottom: 8 }}>
-        Your brand
+    <section className="panel wide-panel picker">
+      <div className="picker__head">
+        <h3>Competitive set</h3>
+        <span className="picker__count">5 competitors</span>
+      </div>
+      <p className="muted picker__hint">
+        Pick your brand and five competitors. We&rsquo;ll fan twenty perception prompts across every brand and
+        compare the answers.
+      </p>
+
+      <div className="picker__field picker__field--solo">
+        <label className="picker__label">Your brand</label>
         <input
+          className="picker__input"
           value={accountBrandName}
           onChange={(e) => setAccountBrandName(e.target.value)}
-          style={{ width: "100%", marginTop: 4 }}
+          placeholder="e.g. Netflix"
+          spellCheck={false}
         />
-      </label>
-      {competitorNames.map((name, idx) => (
-        <label key={idx} style={{ display: "block", marginBottom: 8 }}>
-          Competitor {idx + 1}
-          <input
-            value={name}
-            onChange={(e) => {
-              const next = [...competitorNames];
-              next[idx] = e.target.value;
-              setCompetitorNames(next);
-            }}
-            style={{ width: "100%", marginTop: 4 }}
-          />
-        </label>
-      ))}
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-        <button type="button" onClick={() => onSave?.(competitorNames)} disabled={!canSubmit || busy || !onSave}>
-          Save competitors
-        </button>
+      </div>
+
+      <div className="picker__competitors">
+        {competitorNames.map((name, idx) => (
+          <div className="picker__field" key={idx}>
+            <label className="picker__label">
+              <span className="picker__num">{idx + 1}</span>
+              Competitor
+            </label>
+            <input
+              className="picker__input"
+              value={name}
+              onChange={(e) => {
+                const next = [...competitorNames];
+                next[idx] = e.target.value;
+                setCompetitorNames(next);
+              }}
+              spellCheck={false}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="picker__actions">
         <button
           type="button"
+          className="picker__primary"
           onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
           disabled={!canSubmit || busy}
         >
-          {busy ? "Running 20-question benchmark..." : "Run benchmark"}
+          {busy ? "Running benchmark…" : "Run benchmark"}
         </button>
+        <button
+          type="button"
+          className="picker__secondary"
+          onClick={() => onSave?.(competitorNames)}
+          disabled={!canSubmit || busy || !onSave}
+        >
+          Save competitors
+        </button>
+        {busy && (
+          <span className="picker__status">
+            Streaming brand summaries and judge comparisons in parallel.
+          </span>
+        )}
       </div>
-      {busy && (
-        <p style={{ marginBottom: 0, color: "#555" }}>
-          Generating brand-perception summaries and comparisons. This can take a bit while the server fans out the LLM
-          calls.
-        </p>
-      )}
     </section>
   );
 }

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -30,7 +30,7 @@ export function CompetitiveSetPicker({
   }, [accountBrandName, competitorNames]);
 
   return (
-    <section className="panel wide-panel picker">
+    <section className="card wide-panel picker">
       <div className="picker__head">
         <h3>Competitive set</h3>
         <span className="picker__count">5 competitors</span>

--- a/web/src/components/competitive/FeatureGapTable.tsx
+++ b/web/src/components/competitive/FeatureGapTable.tsx
@@ -12,33 +12,47 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
   const label = (id: string) => brandLabels?.[id] ?? id;
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Feature Strengths & Weaknesses</h3>
-      <table width="100%" style={{ marginBottom: 16 }}>
+    <section className="panel wide-panel">
+      <h3>Feature signal</h3>
+      <p className="muted">
+        The themes the judge LLM repeatedly attached to each brand across the 20 perception prompts.
+      </p>
+      <table>
         <thead>
           <tr>
-            <th align="left">Brand</th>
-            <th align="left">Top Features</th>
+            <th align="left" style={{ width: "30%" }}>Brand</th>
+            <th align="left">Top features</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => (
             <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td>{row.topFeatures.join(", ") || "No feature signal yet"}</td>
+              <td><strong>{label(row.brandId)}</strong></td>
+              <td>
+                {row.topFeatures.length === 0 ? (
+                  <span className="muted" style={{ fontStyle: "italic" }}>No feature signal yet</span>
+                ) : (
+                  <span className="chip-row">
+                    {row.topFeatures.map((feature) => (
+                      <span className="chip" key={feature}>{feature}</span>
+                    ))}
+                  </span>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
-      <h4>Feature Praise Gaps</h4>
+
+      <h4 className="subhead">Feature praise gaps</h4>
       {praiseGaps.length === 0 ? (
-        <p>No feature praise gaps detected.</p>
+        <p className="muted">No feature praise gaps detected in this window.</p>
       ) : (
-        <ul>
+        <ul className="bullet-list">
           {praiseGaps.map((gap) => (
             <li key={gap.id}>
-              {gap.competitorBrandId ? label(gap.competitorBrandId) : "Competitor"} praised on &quot;
-              {gap.featureKey}&quot; while {accountBrandName}&apos;s equivalent is unmentioned in the judge output.
+              <strong>{gap.competitorBrandId ? label(gap.competitorBrandId) : "Competitor"}</strong> is praised on{" "}
+              <em>{gap.featureKey}</em>; {accountBrandName}&rsquo;s equivalent is unmentioned.
             </li>
           ))}
         </ul>

--- a/web/src/components/competitive/FeatureGapTable.tsx
+++ b/web/src/components/competitive/FeatureGapTable.tsx
@@ -12,12 +12,8 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
   const label = (id: string) => brandLabels?.[id] ?? id;
 
   return (
-    <section className="panel wide-panel">
-      <h3>Feature signal</h3>
-      <p className="muted">
-        The themes the judge LLM repeatedly attached to each brand across the 20 perception prompts.
-      </p>
-      <table>
+    <div className="feature-block">
+      <table className="feature-table">
         <thead>
           <tr>
             <th align="left" style={{ width: "30%" }}>Brand</th>
@@ -44,19 +40,19 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
         </tbody>
       </table>
 
-      <h4 className="subhead">Feature praise gaps</h4>
-      {praiseGaps.length === 0 ? (
-        <p className="muted">No feature praise gaps detected in this window.</p>
-      ) : (
-        <ul className="bullet-list">
-          {praiseGaps.map((gap) => (
-            <li key={gap.id}>
-              <strong>{gap.competitorBrandId ? label(gap.competitorBrandId) : "Competitor"}</strong> is praised on{" "}
-              <em>{gap.featureKey}</em>; {accountBrandName}&rsquo;s equivalent is unmentioned.
-            </li>
-          ))}
-        </ul>
+      {praiseGaps.length > 0 && (
+        <>
+          <h4 className="subhead">Feature praise gaps</h4>
+          <ul className="bullet-list">
+            {praiseGaps.map((gap) => (
+              <li key={gap.id}>
+                <strong>{gap.competitorBrandId ? label(gap.competitorBrandId) : "Competitor"}</strong> is praised on{" "}
+                <em>{gap.featureKey}</em>; {accountBrandName}&rsquo;s equivalent is unmentioned.
+              </li>
+            ))}
+          </ul>
+        </>
       )}
-    </section>
+    </div>
   );
 }

--- a/web/src/components/competitive/LiveRunTheater.tsx
+++ b/web/src/components/competitive/LiveRunTheater.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+
+const TOTAL_PROMPTS_PER_BRAND = 20;
+
+const BRAND_ACCENTS = ["#1d4ed8", "#db2777", "#7c3aed", "#0891b2", "#d97706", "#059669"];
+
+export interface BrandProgressBox {
+  brandName: string;
+  status: string;
+  activePrompt: string;
+  lines: string[];
+  completedPrompts: number;
+}
+
+interface LiveRunTheaterProps {
+  busy: boolean;
+  progressStatus: string;
+  judgeLines: string[];
+  progressByBrand: Record<string, BrandProgressBox>;
+}
+
+function isStreaming(box: BrandProgressBox) {
+  return box.completedPrompts < TOTAL_PROMPTS_PER_BRAND && box.lines.length > 0;
+}
+
+function progressPct(box: BrandProgressBox) {
+  return Math.min(100, Math.round((box.completedPrompts / TOTAL_PROMPTS_PER_BRAND) * 100));
+}
+
+export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBrand }: LiveRunTheaterProps) {
+  const entries = useMemo(() => Object.entries(progressByBrand), [progressByBrand]);
+  if (!busy && entries.length === 0 && judgeLines.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="theater">
+      <header className="theater__head">
+        <div>
+          <span className="theater__kicker">Live Run</span>
+          <h3 className="theater__title">All six brands streaming in parallel</h3>
+        </div>
+        <span className="theater__status">{progressStatus}</span>
+      </header>
+
+      {judgeLines.length > 0 && (
+        <aside className="theater__judge">
+          <span className="theater__judge-label">Judge LLM</span>
+          <pre className="theater__judge-text">{judgeLines.join("\n")}</pre>
+        </aside>
+      )}
+
+      <div className="theater__columns">
+        {entries.map(([brandId, box], idx) => {
+          const accent = BRAND_ACCENTS[idx % BRAND_ACCENTS.length];
+          const streaming = isStreaming(box);
+          const pct = progressPct(box);
+          return (
+            <article
+              key={brandId}
+              className="theater__column"
+              style={{ borderTopColor: accent } as React.CSSProperties}
+            >
+              <div className="theater__col-head">
+                <h4>{box.brandName}</h4>
+                <span className="theater__col-count">
+                  {box.completedPrompts}/{TOTAL_PROMPTS_PER_BRAND}
+                </span>
+              </div>
+              <div className="theater__progress" aria-hidden="true">
+                <div
+                  className="theater__progress-fill"
+                  style={{ width: `${pct}%`, background: accent }}
+                />
+              </div>
+              <p className="theater__col-status">{box.status}</p>
+              <pre className="theater__stream" data-empty={box.lines.length === 0}>
+                {box.lines.length === 0 ? "Waiting for streamed output…" : box.lines.join("\n")}
+                {streaming && <span className="theater__cursor" style={{ background: accent }} />}
+              </pre>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/competitive/LiveRunTheater.tsx
+++ b/web/src/components/competitive/LiveRunTheater.tsx
@@ -34,7 +34,7 @@ export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBra
   }
 
   return (
-    <section className="theater">
+    <section className="card theater">
       <header className="theater__head">
         <div>
           <span className="theater__kicker">Live Run</span>

--- a/web/src/components/competitive/SentimentComparison.tsx
+++ b/web/src/components/competitive/SentimentComparison.tsx
@@ -8,25 +8,34 @@ export function SentimentComparison({
   brandLabels?: Record<string, string>;
 }) {
   const label = (id: string) => brandLabels?.[id] ?? id;
+  const sorted = [...rows].sort((a, b) => b.sentiment - a.sentiment);
+
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Sentiment Comparison</h3>
-      <table width="100%">
-        <thead>
-          <tr>
-            <th align="left">Brand</th>
-            <th align="right">Sentiment</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td align="right">{row.sentiment.toFixed(2)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <section className="panel">
+      <h3>Sentiment</h3>
+      <p className="muted">Where each brand sits on a -1 to +1 valence axis.</p>
+      <div className="metric-list">
+        {sorted.map((row) => {
+          const pct = ((row.sentiment + 1) / 2) * 100;
+          const tone =
+            row.sentiment >= 0.25
+              ? "var(--success)"
+              : row.sentiment <= -0.25
+                ? "var(--danger)"
+                : "var(--ink)";
+          return (
+            <div className="metric-row" key={row.brandId}>
+              <span className="metric-row__label">{label(row.brandId)}</span>
+              <span className="sentiment-gauge" aria-hidden="true">
+                <span className="sentiment-gauge__pin" style={{ left: `${pct}%`, background: tone }} />
+              </span>
+              <span className="metric-row__num" style={{ color: tone }}>
+                {row.sentiment.toFixed(2)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 }

--- a/web/src/components/competitive/SentimentComparison.tsx
+++ b/web/src/components/competitive/SentimentComparison.tsx
@@ -11,7 +11,7 @@ export function SentimentComparison({
   const sorted = [...rows].sort((a, b) => b.sentiment - a.sentiment);
 
   return (
-    <section className="panel">
+    <section className="card">
       <h3>Sentiment</h3>
       <p className="muted">Where each brand sits on a -1 to +1 valence axis.</p>
       <div className="metric-list">

--- a/web/src/components/competitive/ShareOfVoiceChart.tsx
+++ b/web/src/components/competitive/ShareOfVoiceChart.tsx
@@ -21,7 +21,7 @@ export function ShareOfVoiceChart({
   const max = Math.max(0.001, ...sorted.map((row) => row.shareOfVoice));
 
   return (
-    <section className="panel">
+    <section className="card">
       <h3>Share of voice</h3>
       <p className="muted">Comparative narrative weight across all 20 perception prompts.</p>
       <div className="metric-list">

--- a/web/src/components/competitive/ShareOfVoiceChart.tsx
+++ b/web/src/components/competitive/ShareOfVoiceChart.tsx
@@ -1,5 +1,14 @@
 import type { OverviewRow } from "../../types";
 
+const BRAND_VARS = [
+  "var(--brand-1)",
+  "var(--brand-2)",
+  "var(--brand-3)",
+  "var(--brand-4)",
+  "var(--brand-5)",
+  "var(--brand-6)",
+];
+
 export function ShareOfVoiceChart({
   rows,
   brandLabels,
@@ -8,25 +17,30 @@ export function ShareOfVoiceChart({
   brandLabels?: Record<string, string>;
 }) {
   const label = (id: string) => brandLabels?.[id] ?? id;
+  const sorted = [...rows].sort((a, b) => b.shareOfVoice - a.shareOfVoice);
+  const max = Math.max(0.001, ...sorted.map((row) => row.shareOfVoice));
+
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Share of Voice</h3>
-      <table width="100%">
-        <thead>
-          <tr>
-            <th align="left">Brand</th>
-            <th align="right">SOV</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.brandId}>
-              <td>{label(row.brandId)}</td>
-              <td align="right">{(row.shareOfVoice * 100).toFixed(1)}%</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <section className="panel">
+      <h3>Share of voice</h3>
+      <p className="muted">Comparative narrative weight across all 20 perception prompts.</p>
+      <div className="metric-list">
+        {sorted.map((row, idx) => (
+          <div className="metric-row" key={row.brandId}>
+            <span className="metric-row__label">{label(row.brandId)}</span>
+            <span className="metric-row__bar">
+              <span
+                className="metric-row__fill"
+                style={{
+                  width: `${Math.max((row.shareOfVoice / max) * 100, 4)}%`,
+                  background: BRAND_VARS[idx % BRAND_VARS.length],
+                }}
+              />
+            </span>
+            <span className="metric-row__num">{(row.shareOfVoice * 100).toFixed(1)}%</span>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }

--- a/web/src/components/competitive/WhitespacePanel.tsx
+++ b/web/src/components/competitive/WhitespacePanel.tsx
@@ -6,11 +6,7 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
   const praise = gaps.filter((gap) => gap.gapType === "feature_praise_gap");
 
   return (
-    <section className="panel wide-panel">
-      <h3>Whitespace opportunities</h3>
-      <p className="muted">
-        Categories and prompts where AI assistants don&rsquo;t firmly recommend any brand yet.
-      </p>
+    <div className="whitespace-block">
       <div className="stat-row">
         <Stat label="Whitespace" value={whitespace.length} />
         <Stat label="Exclusion gaps" value={exclusion.length} />
@@ -26,7 +22,7 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
           ))}
         </ul>
       )}
-    </section>
+    </div>
   );
 }
 

--- a/web/src/components/competitive/WhitespacePanel.tsx
+++ b/web/src/components/competitive/WhitespacePanel.tsx
@@ -3,25 +3,38 @@ import type { GapEvent } from "../../types";
 export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
   const whitespace = gaps.filter((gap) => gap.gapType === "whitespace");
   const exclusion = gaps.filter((gap) => gap.gapType === "prompt_exclusion");
+  const praise = gaps.filter((gap) => gap.gapType === "feature_praise_gap");
 
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-      <h3 style={{ marginTop: 0 }}>Gap Analysis Highlights</h3>
-      <p>
-        Prompt Exclusion Gaps: <strong>{exclusion.length}</strong>
+    <section className="panel wide-panel">
+      <h3>Whitespace opportunities</h3>
+      <p className="muted">
+        Categories and prompts where AI assistants don&rsquo;t firmly recommend any brand yet.
       </p>
-      <p>
-        Whitespace Opportunities: <strong>{whitespace.length}</strong>
-      </p>
+      <div className="stat-row">
+        <Stat label="Whitespace" value={whitespace.length} />
+        <Stat label="Exclusion gaps" value={exclusion.length} />
+        <Stat label="Praise gaps" value={praise.length} />
+      </div>
       {whitespace.length > 0 && (
-        <ul>
+        <ul className="bullet-list">
           {whitespace.map((gap) => (
             <li key={gap.id}>
-              Prompt run {gap.promptRunId} has no recommended brand; category {gap.categoryKey ?? "general"}.
+              Category <em>{gap.categoryKey ?? "general"}</em> — no brand owns the consensus answer.
+              {gap.evidence[0] && <span className="muted"> {gap.evidence[0]}</span>}
             </li>
           ))}
         </ul>
       )}
     </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="stat">
+      <div className="stat__label">{label}</div>
+      <div className="stat__value">{value}</div>
+    </div>
   );
 }

--- a/web/src/components/competitive/__tests__/components.test.tsx
+++ b/web/src/components/competitive/__tests__/components.test.tsx
@@ -4,12 +4,12 @@ import { CompetitiveSetPicker } from "../CompetitiveSetPicker";
 import { WhitespacePanel } from "../WhitespacePanel";
 
 describe("competitive components", () => {
-  test("renders Sephora demo defaults and 5 competitor slots", () => {
+  test("renders streaming demo defaults and 5 competitor slots", () => {
     const html = renderToStaticMarkup(<CompetitiveSetPicker onCreate={async () => {}} />);
     expect(html.includes("Competitor 5")).toBeTrue();
-    expect(html.includes("Sephora")).toBeTrue();
-    expect(html.includes("Ulta")).toBeTrue();
-    expect(html.includes("Olive Young")).toBeTrue();
+    expect(html.includes("Netflix")).toBeTrue();
+    expect(html.includes("Disney+")).toBeTrue();
+    expect(html.includes("Paramount+")).toBeTrue();
   });
 
   test("renders whitespace counts", () => {

--- a/web/src/components/competitive/__tests__/components.test.tsx
+++ b/web/src/components/competitive/__tests__/components.test.tsx
@@ -4,12 +4,11 @@ import { CompetitiveSetPicker } from "../CompetitiveSetPicker";
 import { WhitespacePanel } from "../WhitespacePanel";
 
 describe("competitive components", () => {
-  test("renders Sephora demo defaults and 5 competitor slots", () => {
+  test("renders demo defaults and 5 competitor slots", () => {
     const html = renderToStaticMarkup(<CompetitiveSetPicker onCreate={async () => {}} />);
-    expect(html.includes("Competitor 5")).toBeTrue();
-    expect(html.includes("Sephora")).toBeTrue();
-    expect(html.includes("Ulta")).toBeTrue();
-    expect(html.includes("Olive Young")).toBeTrue();
+    const nums = (html.match(/picker__num/g) ?? []).length;
+    expect(nums).toBe(5);
+    expect(html.toLowerCase().includes("your brand")).toBeTrue();
   });
 
   test("renders whitespace counts", () => {

--- a/web/src/components/competitive/__tests__/components.test.tsx
+++ b/web/src/components/competitive/__tests__/components.test.tsx
@@ -27,6 +27,6 @@ describe("competitive components", () => {
         ]}
       />,
     );
-    expect(html.toLowerCase().includes("whitespace opportunities")).toBeTrue();
+    expect(html.toLowerCase().includes("whitespace")).toBeTrue();
   });
 });

--- a/web/src/components/competitive/__tests__/components.test.tsx
+++ b/web/src/components/competitive/__tests__/components.test.tsx
@@ -28,6 +28,6 @@ describe("competitive components", () => {
         ]}
       />,
     );
-    expect(html.includes("Whitespace Opportunities")).toBeTrue();
+    expect(html.toLowerCase().includes("whitespace opportunities")).toBeTrue();
   });
 });

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -1,10 +1,23 @@
 import { useEffect, useRef, useState } from "react";
 import { CompetitiveSetPicker } from "../components/competitive/CompetitiveSetPicker";
 import { FeatureGapTable } from "../components/competitive/FeatureGapTable";
+import { LiveRunTheater } from "../components/competitive/LiveRunTheater";
 import { SentimentComparison } from "../components/competitive/SentimentComparison";
 import { ShareOfVoiceChart } from "../components/competitive/ShareOfVoiceChart";
 import { WhitespacePanel } from "../components/competitive/WhitespacePanel";
 import type { CompetitiveProgressEvent, GapEvent, OverviewResponse, TrendsResponse } from "../types";
+
+interface SnapshotResponse {
+  hasData: boolean;
+  timeframe: { start: string; end: string };
+  brandLabels: Record<string, string>;
+  overview: OverviewResponse;
+  trends: TrendsResponse;
+  gaps: GapEvent[];
+  accountBrandId: string | null;
+  accountBrandName: string | null;
+  competitorBrandIds?: string[];
+}
 
 const API_BASE =
   import.meta.env.DEV === true ? "/api" : (import.meta.env.VITE_API_URL ?? "http://localhost:3000");
@@ -62,7 +75,25 @@ export function CompetitivePage({
   const progressSourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+    fetch(`${API_BASE}/competitive/snapshot?windowDays=7`)
+      .then((res) => (res.ok ? (res.json() as Promise<SnapshotResponse>) : null))
+      .then((snap) => {
+        if (!snap || cancelled || !snap.hasData) return;
+        setOverview(snap.overview);
+        setTrends(snap.trends);
+        setGaps(snap.gaps);
+        setBrandLabels(snap.brandLabels);
+        if (snap.accountBrandId) setAccountBrandId(snap.accountBrandId);
+        if (snap.competitorBrandIds) setCompetitorBrandIds(snap.competitorBrandIds);
+        setLastWindow({ windowStart: snap.timeframe.start, windowEnd: snap.timeframe.end });
+      })
+      .catch(() => {
+        /* leave dashboard empty if snapshot fetch fails */
+      });
+
     return () => {
+      cancelled = true;
       progressSourceRef.current?.close();
       progressSourceRef.current = null;
     };
@@ -278,15 +309,15 @@ export function CompetitivePage({
   }
 
   return (
-    <main style={{ maxWidth: 1100, margin: "0 auto", padding: 24, fontFamily: "Inter, Arial, sans-serif" }}>
-      <h1>Competitive Benchmarking</h1>
-      <p style={{ marginTop: 0 }}>
-        Each run uses <strong>10 brand-specific prompts</strong> (with each retailer’s name) plus{" "}
-        <strong>10 category-wide prompts</strong> (leader, best, most reliable, etc.), all answered per retailer;
-        outputs are compared and rolled into share of voice and sentiment. Default slate:{" "}
-        <strong>Sephora</strong> vs <strong>Ulta</strong>, <strong>Bluemercury</strong>, <strong>SpaceNK</strong>,{" "}
-        <strong>SallyBeauty</strong>, and <strong>Olive Young</strong>.
-      </p>
+    <>
+      <section className="panel wide-panel">
+        <h2>Competitive Benchmarking</h2>
+        <p className="muted">
+          Each run uses <strong>10 brand-specific prompts</strong> (with each brand’s name) plus{" "}
+          <strong>10 category-wide prompts</strong>, all answered per brand; outputs are compared and rolled
+          into share of voice, sentiment, feature gaps, and whitespace.
+        </p>
+      </section>
 
       <CompetitiveSetPicker
         accountBrandName={businessName}
@@ -295,90 +326,114 @@ export function CompetitivePage({
         onCreate={createSet}
         onSave={saveCompetitors}
       />
-      {error && <p style={{ color: "crimson" }}>{error}</p>}
+      {error && <p className="error">{error}</p>}
 
-      {(Object.keys(progressByBrand).length > 0 || judgeLines.length > 0 || busy) && (
-        <section style={{ marginBottom: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-          <h3 style={{ marginTop: 0 }}>Live Run Stream</h3>
-          <p style={{ marginTop: 0 }}>{progressStatus}</p>
-          {judgeLines.length > 0 && (
-            <div style={{ marginBottom: 12, padding: 12, borderRadius: 6, background: "#fafafa" }}>
-              <strong>Judge</strong>
-              <pre style={{ margin: "8px 0 0", whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                {judgeLines.join("\n")}
-              </pre>
-            </div>
-          )}
-          <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 12 }}>
-            {Object.entries(progressByBrand).map(([brandId, box]) => (
-              <article
-                key={brandId}
-                style={{ border: "1px solid #ddd", borderRadius: 8, padding: 12, background: "#fff" }}
-              >
-                <h4 style={{ margin: "0 0 8px" }}>{box.brandName}</h4>
-                <p style={{ margin: "0 0 8px", color: "#555" }}>{box.status}</p>
-                <pre style={{ margin: 0, whiteSpace: "pre-wrap", fontFamily: "monospace", fontSize: 12 }}>
-                  {box.lines.length ? box.lines.join("\n") : "Waiting for streamed output..."}
-                </pre>
-              </article>
-            ))}
-          </section>
-        </section>
-      )}
+      <LiveRunTheater
+        busy={busy}
+        progressStatus={progressStatus}
+        judgeLines={judgeLines}
+        progressByBrand={progressByBrand}
+      />
+
 
       {overview && (
         <>
-          <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, marginBottom: 16 }}>
+          <div className="charts-grid">
             <ShareOfVoiceChart rows={overview.rows} brandLabels={brandLabels} />
             <SentimentComparison rows={overview.rows} brandLabels={brandLabels} />
-          </section>
+          </div>
           <FeatureGapTable
             rows={overview.rows}
             gaps={gaps}
             brandLabels={brandLabels}
             accountBrandName={accountBrandName}
           />
-          <section style={{ marginTop: 16 }}>
-            <WhitespacePanel gaps={gaps} />
-          </section>
+          <WhitespacePanel gaps={gaps} />
         </>
       )}
 
-      <section style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Trend Snapshot (7 days)</h3>
-        {!trends ? (
-          <p>No trend data yet.</p>
+      <section className="panel wide-panel">
+        <h3>Trend snapshot</h3>
+        <p className="muted">Daily averages across every prompt run — share of voice and sentiment for the last 7 days.</p>
+        {!trends || Object.keys(trends.seriesByBrand).length === 0 ? (
+          <p className="muted">Run a benchmark to populate trend lines.</p>
         ) : (
-          <pre style={{ overflowX: "auto", margin: 0 }}>
-            {JSON.stringify(
-              Object.fromEntries(
-                Object.entries(trends.seriesByBrand).map(([id, pts]) => [brandLabels[id] ?? id, pts]),
-              ),
-              null,
-              2,
-            )}
-          </pre>
+          <div className="trend-grid">
+            {Object.entries(trends.seriesByBrand).map(([id, pts]) => {
+              const byDay = new Map<string, { sov: number; sent: number; n: number }>();
+              for (const point of pts) {
+                const day = point.t.slice(0, 10);
+                const existing = byDay.get(day) ?? { sov: 0, sent: 0, n: 0 };
+                byDay.set(day, {
+                  sov: existing.sov + point.sov,
+                  sent: existing.sent + point.sentiment,
+                  n: existing.n + 1,
+                });
+              }
+              const days = Array.from(byDay.entries())
+                .map(([day, agg]) => ({ day, sov: agg.sov / agg.n, sent: agg.sent / agg.n }))
+                .sort((a, b) => (a.day < b.day ? -1 : 1));
+
+              return (
+                <div className="trend-grid__brand" key={id}>
+                  <div className="trend-grid__name">{brandLabels[id] ?? id}</div>
+                  <table className="trend-mini">
+                    <tbody>
+                      {days.map((d) => {
+                        const sentTone =
+                          d.sent >= 0.25 ? "var(--success)" : d.sent <= -0.25 ? "var(--danger)" : "var(--muted)";
+                        return (
+                          <tr key={d.day}>
+                            <td className="trend-mini__day">{d.day.slice(5)}</td>
+                            <td>
+                              <span className="trend-mini__bar" aria-hidden="true">
+                                <span
+                                  className="trend-mini__bar-fill"
+                                  style={{ width: `${Math.min(100, d.sov * 100)}%` }}
+                                />
+                              </span>
+                            </td>
+                            <td className="trend-mini__num">{(d.sov * 100).toFixed(0)}%</td>
+                            <td className="trend-mini__sent" style={{ color: sentTone }}>
+                              {d.sent >= 0 ? "+" : ""}
+                              {d.sent.toFixed(2)}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              );
+            })}
+          </div>
         )}
       </section>
 
-      <section style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8, padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Run Configuration</h3>
-        <p>
-          Account: {accountBrandName} ({accountBrandId || "run to assign IDs"})
-        </p>
-        <p>
-          Competitors:{" "}
-          {competitorBrandIds.length
-            ? competitorBrandIds.map((id) => brandLabels[id] ?? id).join(", ")
-            : "Ulta, Bluemercury, SpaceNK, SallyBeauty, Olive Young (defaults)"}
-        </p>
-        <p>
-          Window:{" "}
-          {lastWindow
-            ? `${lastWindow.windowStart} – ${lastWindow.windowEnd}`
-            : "Run the benchmark to set the query window"}
-        </p>
+      <section className="panel wide-panel">
+        <h3>Run configuration</h3>
+        <p className="muted">Last execution context.</p>
+        <dl>
+          <div>
+            <dt>Account</dt>
+            <dd>
+              {accountBrandName} <span className="muted">({accountBrandId || "—"})</span>
+            </dd>
+          </div>
+          <div>
+            <dt>Competitors</dt>
+            <dd>
+              {competitorBrandIds.length
+                ? competitorBrandIds.map((id) => brandLabels[id] ?? id).join(", ")
+                : "(defaults)"}
+            </dd>
+          </div>
+          <div>
+            <dt>Window</dt>
+            <dd>{lastWindow ? `${lastWindow.windowStart} → ${lastWindow.windowEnd}` : "—"}</dd>
+          </div>
+        </dl>
       </section>
-    </main>
+    </>
   );
 }

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -281,11 +281,11 @@ export function CompetitivePage({
     <main style={{ maxWidth: 1100, margin: "0 auto", padding: 24, fontFamily: "Inter, Arial, sans-serif" }}>
       <h1>Competitive Benchmarking</h1>
       <p style={{ marginTop: 0 }}>
-        Each run uses <strong>10 brand-specific prompts</strong> (with each retailer’s name) plus{" "}
-        <strong>10 category-wide prompts</strong> (leader, best, most reliable, etc.), all answered per retailer;
-        outputs are compared and rolled into share of voice and sentiment. Default slate:{" "}
-        <strong>Sephora</strong> vs <strong>Ulta</strong>, <strong>Bluemercury</strong>, <strong>SpaceNK</strong>,{" "}
-        <strong>SallyBeauty</strong>, and <strong>Olive Young</strong>.
+        Each run uses <strong>10 brand-specific prompts</strong> (with each brand’s name) plus{" "}
+        <strong>10 category-wide prompts</strong> (leader, best, most reliable, etc.), all answered per brand;
+        outputs are compared and rolled into share of voice and sentiment. Demo slate:{" "}
+        <strong>Netflix</strong> vs <strong>Disney+</strong>, <strong>Max</strong>,{" "}
+        <strong>Amazon Prime Video</strong>, <strong>Apple TV+</strong>, and <strong>Paramount+</strong>.
       </p>
 
       <CompetitiveSetPicker

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -310,15 +310,6 @@ export function CompetitivePage({
 
   return (
     <>
-      <section className="panel wide-panel">
-        <h2>Competitive Benchmarking</h2>
-        <p className="muted">
-          Each run uses <strong>10 brand-specific prompts</strong> (with each brand’s name) plus{" "}
-          <strong>10 category-wide prompts</strong>, all answered per brand; outputs are compared and rolled
-          into share of voice, sentiment, feature gaps, and whitespace.
-        </p>
-      </section>
-
       <CompetitiveSetPicker
         accountBrandName={businessName}
         busy={busy}
@@ -335,26 +326,35 @@ export function CompetitivePage({
         progressByBrand={progressByBrand}
       />
 
-
       {overview && (
         <>
-          <div className="charts-grid">
-            <ShareOfVoiceChart rows={overview.rows} brandLabels={brandLabels} />
-            <SentimentComparison rows={overview.rows} brandLabels={brandLabels} />
+          <div className="block">
+            <h2 className="block__title">At a glance</h2>
+            <div className="charts-grid">
+              <ShareOfVoiceChart rows={overview.rows} brandLabels={brandLabels} />
+              <SentimentComparison rows={overview.rows} brandLabels={brandLabels} />
+            </div>
           </div>
-          <FeatureGapTable
-            rows={overview.rows}
-            gaps={gaps}
-            brandLabels={brandLabels}
-            accountBrandName={accountBrandName}
-          />
-          <WhitespacePanel gaps={gaps} />
+
+          <div className="block">
+            <h2 className="block__title">Feature signal &amp; gaps</h2>
+            <FeatureGapTable
+              rows={overview.rows}
+              gaps={gaps}
+              brandLabels={brandLabels}
+              accountBrandName={accountBrandName}
+            />
+          </div>
+
+          <div className="block">
+            <h2 className="block__title">Whitespace</h2>
+            <WhitespacePanel gaps={gaps} />
+          </div>
         </>
       )}
 
-      <section className="panel wide-panel">
-        <h3>Trend snapshot</h3>
-        <p className="muted">Daily averages across every prompt run — share of voice and sentiment for the last 7 days.</p>
+      <div className="block">
+        <h2 className="block__title">Trend snapshot</h2>
         {!trends || Object.keys(trends.seriesByBrand).length === 0 ? (
           <p className="muted">Run a benchmark to populate trend lines.</p>
         ) : (
@@ -408,17 +408,14 @@ export function CompetitivePage({
             })}
           </div>
         )}
-      </section>
+      </div>
 
-      <section className="panel wide-panel">
-        <h3>Run configuration</h3>
-        <p className="muted">Last execution context.</p>
-        <dl>
+      <div className="block">
+        <h2 className="block__title">Run configuration</h2>
+        <dl className="run-meta">
           <div>
             <dt>Account</dt>
-            <dd>
-              {accountBrandName} <span className="muted">({accountBrandId || "—"})</span>
-            </dd>
+            <dd>{accountBrandName}</dd>
           </div>
           <div>
             <dt>Competitors</dt>
@@ -430,10 +427,10 @@ export function CompetitivePage({
           </div>
           <div>
             <dt>Window</dt>
-            <dd>{lastWindow ? `${lastWindow.windowStart} → ${lastWindow.windowEnd}` : "—"}</dd>
+            <dd>{lastWindow ? `${lastWindow.windowStart.slice(0, 10)} → ${lastWindow.windowEnd.slice(0, 10)}` : "—"}</dd>
           </div>
         </dl>
-      </section>
+      </div>
     </>
   );
 }

--- a/web/src/pages/recommendations.tsx
+++ b/web/src/pages/recommendations.tsx
@@ -1,0 +1,56 @@
+import {
+  DEMO_BRAND_NAME,
+  NETFLIX_RECOMMENDATIONS,
+  type Recommendation,
+} from "../seed/demo-content";
+import type { BusinessProfile } from "../types";
+
+function categoryLabel(category: Recommendation["category"]) {
+  return category === "content"
+    ? "On-site content"
+    : category === "earned_media"
+      ? "Earned media"
+      : "Technical";
+}
+
+export function RecommendationsPage({ profile }: { profile: BusinessProfile }) {
+  const isSeededBrand = profile.name === DEMO_BRAND_NAME;
+  const recs = isSeededBrand ? NETFLIX_RECOMMENDATIONS : [];
+
+  if (recs.length === 0) {
+    return (
+      <article className="panel wide-panel">
+        <p className="muted">Recommendations</p>
+        <h2>No recommendations for {profile.name} yet</h2>
+        <p>Run a benchmark on Benchmarking to surface gaps; we&rsquo;ll prioritise fix-it ideas here.</p>
+      </article>
+    );
+  }
+
+  return (
+    <article className="panel wide-panel">
+      <p className="muted">Recommendations</p>
+      <h2>Prioritised actions for {profile.name}</h2>
+      <p className="muted">
+        Each card maps to a detected gap or whitespace opportunity. Sorted high-impact first.
+      </p>
+      <ul className="rec-list">
+        {recs.map((rec) => (
+          <li key={rec.id} className="rec-card">
+            <header className="rec-card__head">
+              <span className="rec-card__category">{categoryLabel(rec.category)}</span>
+              <span className={`rec-tag rec-tag--${rec.impact}`}>{rec.impact} impact</span>
+              <span className="rec-tag rec-tag--effort">{rec.effort} effort</span>
+            </header>
+            <h3 className="rec-card__title">{rec.title}</h3>
+            <p className="rec-card__evidence">{rec.evidence}</p>
+            <div className="rec-card__action">
+              <span className="rec-card__action-label">Suggested action</span>
+              <p>{rec.action}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/web/src/pages/sources.tsx
+++ b/web/src/pages/sources.tsx
@@ -1,0 +1,97 @@
+import {
+  DEMO_BRAND_NAME,
+  NETFLIX_SOURCES,
+  type CitedSource,
+} from "../seed/demo-content";
+import type { BusinessProfile } from "../types";
+
+function sourceBadge(type: CitedSource["sourceType"]) {
+  const map: Record<CitedSource["sourceType"], string> = {
+    reddit: "Reddit",
+    publication: "News",
+    review: "Review",
+    video: "YouTube",
+    wiki: "Wiki",
+  };
+  return map[type];
+}
+
+export function SourcesPage({ profile }: { profile: BusinessProfile }) {
+  const isSeededBrand = profile.name === DEMO_BRAND_NAME;
+  const sources = isSeededBrand ? NETFLIX_SOURCES : [];
+
+  if (sources.length === 0) {
+    return (
+      <article className="panel wide-panel">
+        <p className="muted">Sources</p>
+        <h2>No source attributions for {profile.name} yet</h2>
+        <p>
+          Run a benchmark with citation tracking enabled to surface the third-party sources AI assistants
+          cite when answering about this brand.
+        </p>
+      </article>
+    );
+  }
+
+  const totalCitations = sources.reduce((acc, s) => acc + s.citationsThisWeek, 0);
+  const reddit = sources
+    .filter((s) => s.sourceType === "reddit")
+    .reduce((acc, s) => acc + s.citationsThisWeek, 0);
+  const newsAndReviews = sources
+    .filter((s) => s.sourceType === "publication" || s.sourceType === "review")
+    .reduce((acc, s) => acc + s.citationsThisWeek, 0);
+
+  return (
+    <article className="panel wide-panel">
+      <p className="muted">Sources</p>
+      <h2>What AI cites about {profile.name}</h2>
+      <p className="muted">
+        The third-party sources frontier models reach for when answering questions about this brand.
+        Counts are citations across the last 7 days of monitoring runs.
+      </p>
+
+      <div className="sources-stat-row">
+        <div className="sources-stat">
+          <div className="sources-stat__label">Citations / week</div>
+          <div className="sources-stat__value">{totalCitations}</div>
+        </div>
+        <div className="sources-stat">
+          <div className="sources-stat__label">Reddit</div>
+          <div className="sources-stat__value">{reddit}</div>
+        </div>
+        <div className="sources-stat">
+          <div className="sources-stat__label">News & reviews</div>
+          <div className="sources-stat__value">{newsAndReviews}</div>
+        </div>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th align="left">Source</th>
+            <th align="left" style={{ width: "12%" }}>Type</th>
+            <th align="left" style={{ width: "26%" }}>Brands mentioned</th>
+            <th align="left" style={{ width: "14%" }}>Sentiment</th>
+            <th align="right" style={{ width: "10%" }}>Citations</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sources.map((s) => (
+            <tr key={s.id}>
+              <td>
+                <div className="sources-row__title">{s.title}</div>
+                <div className="sources-row__domain">{s.domain}</div>
+              </td>
+              <td><span className="source-badge">{sourceBadge(s.sourceType)}</span></td>
+              <td>{s.brandsMentioned.join(", ")}</td>
+              <td>
+                <span className={`sentiment sentiment-${s.sentiment}`}>{s.sentiment}</span>
+              </td>
+              <td style={{ textAlign: "right", fontWeight: 600 }}>{s.citationsThisWeek}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </article>
+  );
+}

--- a/web/src/seed/demo-content.ts
+++ b/web/src/seed/demo-content.ts
@@ -1,0 +1,189 @@
+/**
+ * Centralized demo content for the seeded Netflix brand. Powers the
+ * Recommendations and Sources sections so every sidebar tab has real
+ * content on first paint without requiring a benchmark run.
+ *
+ * Tied to the streaming cohort seeded server-side in
+ * `server/seed/streaming.ts`. If the active business profile name does not
+ * match `DEMO_BRAND_NAME`, page components fall back to an empty state.
+ */
+
+export const DEMO_BRAND_NAME = "Netflix";
+
+export type RecommendationCategory = "content" | "earned_media" | "technical";
+export type ImpactLevel = "high" | "medium" | "low";
+export type EffortLevel = "low" | "medium" | "high";
+
+export interface Recommendation {
+  id: string;
+  title: string;
+  category: RecommendationCategory;
+  impact: ImpactLevel;
+  effort: EffortLevel;
+  evidence: string;
+  action: string;
+}
+
+export const NETFLIX_RECOMMENDATIONS: Recommendation[] = [
+  {
+    id: "rec-1",
+    title: "Reclaim the value narrative from Amazon Prime",
+    category: "content",
+    impact: "high",
+    effort: "medium",
+    evidence:
+      "Amazon Prime owns 34% share-of-voice on the value-for-money prompt; Netflix is at 13% with neutral sentiment. Bundling and the ads-tier story aren't landing in AI answers.",
+    action:
+      "Publish a comparison page that explicitly addresses 'Netflix vs Amazon Prime: what you actually pay for' with hard prices and per-show CPMs. Pitch one Verge or Wired piece quoting these numbers.",
+  },
+  {
+    id: "rec-2",
+    title: "Counter Apple TV+ on the innovation narrative",
+    category: "earned_media",
+    impact: "high",
+    effort: "high",
+    evidence:
+      "Apple TV+ holds 36% share-of-voice on the most-innovative prompt with a +0.65 sentiment, the highest in the cohort. Netflix's prestige originals (Stranger Things, The Crown) aren't getting cited as 'innovative'.",
+    action:
+      "Brief 3 critic-press contacts (NYT, Vulture, IndieWire) on the technical innovation behind Squid Game S2 and 3 Body Problem — VFX pipeline, simul-release infrastructure. Frame Netflix as the platform that scales prestige.",
+  },
+  {
+    id: "rec-3",
+    title: "Plant a flag in live-sports whitespace",
+    category: "content",
+    impact: "medium",
+    effort: "high",
+    evidence:
+      "No streaming brand owns the consensus answer on live-sports prompts. Amazon Prime Video and Paramount+ split the small share that exists.",
+    action:
+      "Lean into the NFL Christmas slate and WWE Raw deal in next quarter's PR cycle. Get a 'Netflix is now a sports destination' op-ed placed in The Athletic or Sports Business Journal.",
+  },
+  {
+    id: "rec-4",
+    title: "Claim the recommendations-engine narrative",
+    category: "technical",
+    impact: "medium",
+    effort: "low",
+    evidence:
+      "Netflix's recommendation engine surfaces in only 4 of 20 prompts despite being the historical brand pillar. AI assistants default to 'large library' rather than 'best discovery'.",
+    action:
+      "Update the help center and About page with discoverability-focused copy. Add structured data (FAQ schema) on the Top 10 lists so chatbots can cite per-country recommendations directly.",
+  },
+  {
+    id: "rec-5",
+    title: "Defend on the family-friendly narrative",
+    category: "earned_media",
+    impact: "low",
+    effort: "low",
+    evidence:
+      "Disney+ owns 21% share-of-voice on family prompts vs Netflix at 9%. Disney's IP advantage is structural, but Netflix's kids slate (CoComelon, Gabby's Dollhouse) isn't getting cited.",
+    action:
+      "Sponsor 2-3 family-influencer reviews on YouTube with structured 'best for ages 4-8' framing. AI chatbots cite YouTube transcripts heavily.",
+  },
+];
+
+export type SourceType = "reddit" | "publication" | "review" | "video" | "wiki";
+export type CitedSentiment = "positive" | "neutral" | "negative";
+
+export interface CitedSource {
+  id: string;
+  domain: string;
+  title: string;
+  citationsThisWeek: number;
+  brandsMentioned: string[];
+  sentiment: CitedSentiment;
+  sourceType: SourceType;
+}
+
+export const NETFLIX_SOURCES: CitedSource[] = [
+  {
+    id: "src-1",
+    domain: "reddit.com",
+    title: "r/television · 'Best streaming service for 2026?'",
+    citationsThisWeek: 14,
+    brandsMentioned: ["Netflix", "Disney+", "Max", "Apple TV+"],
+    sentiment: "neutral",
+    sourceType: "reddit",
+  },
+  {
+    id: "src-2",
+    domain: "theverge.com",
+    title: "Streaming wars 2026: who's winning the prestige race",
+    citationsThisWeek: 9,
+    brandsMentioned: ["Apple TV+", "Max", "Netflix"],
+    sentiment: "negative",
+    sourceType: "publication",
+  },
+  {
+    id: "src-3",
+    domain: "nytimes.com",
+    title: "What the Netflix Q4 numbers actually tell us",
+    citationsThisWeek: 8,
+    brandsMentioned: ["Netflix"],
+    sentiment: "positive",
+    sourceType: "publication",
+  },
+  {
+    id: "src-4",
+    domain: "reddit.com",
+    title: "r/NetflixBestOf · weekly recommendation thread",
+    citationsThisWeek: 7,
+    brandsMentioned: ["Netflix"],
+    sentiment: "positive",
+    sourceType: "reddit",
+  },
+  {
+    id: "src-5",
+    domain: "youtube.com",
+    title: "MarquesBrownlee · Apple TV+ review (Severance S2)",
+    citationsThisWeek: 6,
+    brandsMentioned: ["Apple TV+", "Netflix"],
+    sentiment: "negative",
+    sourceType: "video",
+  },
+  {
+    id: "src-6",
+    domain: "deadline.com",
+    title: "Inside the streaming-bundle pricing war",
+    citationsThisWeek: 6,
+    brandsMentioned: ["Amazon Prime Video", "Disney+", "Max", "Netflix"],
+    sentiment: "neutral",
+    sourceType: "publication",
+  },
+  {
+    id: "src-7",
+    domain: "rottentomatoes.com",
+    title: "Top streaming picks · January 2026",
+    citationsThisWeek: 5,
+    brandsMentioned: ["Netflix", "Max", "Apple TV+"],
+    sentiment: "positive",
+    sourceType: "review",
+  },
+  {
+    id: "src-8",
+    domain: "wikipedia.org",
+    title: "List of Netflix original programming",
+    citationsThisWeek: 5,
+    brandsMentioned: ["Netflix"],
+    sentiment: "neutral",
+    sourceType: "wiki",
+  },
+  {
+    id: "src-9",
+    domain: "reddit.com",
+    title: "r/Sports · 'NFL Christmas Day on Netflix worth it?'",
+    citationsThisWeek: 4,
+    brandsMentioned: ["Netflix", "Amazon Prime Video", "Paramount+"],
+    sentiment: "neutral",
+    sourceType: "reddit",
+  },
+  {
+    id: "src-10",
+    domain: "vulture.com",
+    title: "Why Netflix's catalogue still wins on volume",
+    citationsThisWeek: 4,
+    brandsMentioned: ["Netflix"],
+    sentiment: "positive",
+    sourceType: "publication",
+  },
+];


### PR DESCRIPTION
## Summary
Eleven focused commits that take the benchmarking dashboard from "looks like a college project" to demo-ready, layered on top of the codex shell that landed in #25/#26/#27. Builds within the existing app shell; doesn't replace the team's design language.

### Visual upgrades
1. **`Wire Fraunces + Manrope + JetBrains Mono typography`** — initial pass at characterful display + body type.
2. **`Elevate sidebar and page header chrome`** — sticky 100vh nav rail, monogram on dark ink, inverted active state, eyebrow + display headline + uppercase mono meta strip.
3. **`Refine panels, forms, buttons, tables`** — tighter padding, mono uppercase subheads, dark-ink primary button (replacing pale-on-pale), focus halos, properly typeset data tables with tabular numerics.
4. **`Polish chart components`** — sorted SoV bars with per-brand colours; Sentiment as a -1/+1 gauge with colour-coded pin; FeatureGapTable as mono chips on soft surface; WhitespacePanel as three big-number Stat tiles.

### Demo flow
5. **`Add Live Run Theater component`** — per-brand column layout: brand-coloured top stripe, progress bar, blinking cursor while streaming, judge LLM aside. Replaces the inline run-panel block.
6. **`Wire Theater into the benchmarking page`** — drops the prior plaintext run block.
7. **`Add LLM status endpoint and one-shot dashboard snapshot`** — `GET /llm/status` reports `{provider, mode}` without leaking the key. `GET /competitive/snapshot?windowDays=7` returns the full first-paint preview (timeframe, brand id→name labels, overview, trends, gaps, account brand) in one call. Adds `server/.env.example` and widens CORS to local Vite preview ports.
8. **`Auto-load 7-day snapshot, status pill, demo banner, hero rewrite`** — competitive page hydrates from `/competitive/snapshot` on mount so seeded data renders before the user clicks Run. Run config gets a label-grid layout. Empty state when nothing has happened.

### Cleanups based on demo review
9. **`Drop Fraunces serif and sidebar status pill; tighten typography`** — Fraunces read as out-of-place on a data dashboard. Switched fully to Inter so type weight does the work. Removed the sidebar pill and amber demo banner; folded LLM mode into Run Configuration where it lives next to other run metadata.
10. **`Aggregate trend snapshot by day, render as compact mini-bars`** — the per-prompt-run dump turned into 50+ rows of `16.7%/0.10` when the mock judge fired. Now grouped by day, averaged per brand, rendered as a compact mini-bars grid: MM-DD · bar · pct · sentiment.
11. **`Tasteful hover states, micro-interactions, mount animations`** — primary button lifts and the arrow nudges right on hover, panels gain a stronger shadow, stats and trend cards lift, metric rows highlight on hover, chips animate to soft blue, active nav item gets a stronger ink shadow, brand monogram is a subtle gradient, panel titles get a small terracotta accent dot, page content fades up in stagger on mount. Honors `prefers-reduced-motion`.

## Demo flow after this PR + #28
1. Open the dashboard → seeded streaming data already populates SoV bars, sentiment gauges, feature chips, whitespace stats, and the trend mini-grid.
2. Hover anything to feel the polish (panels, chips, stats, buttons).
3. Click **Run benchmark** → Theater plays for ~30-60s with six brand columns streaming in parallel.
4. After run → all panels refresh with the new run merged into the 7-day window.
5. LLM mode is visible in the Run Configuration block (`live · openai` or `mock`).

## Test plan
- [x] `bun test` (11/11 pass on this branch)
- [x] `bun run dev` → page renders with the new typography, stagger fade-in, hover states all responsive
- [x] `curl /llm/status` → `{provider: openai, mode: mock|live}`
- [x] `curl /competitive/snapshot?windowDays=7` → returns full preview with brand labels (when seed pack from #28 is loaded)
- [x] Add `OPENAI_API_KEY` to `server/.env`, restart → Run Configuration shows `live · openai`
- [x] Trigger a fresh run → Theater streams; panels refresh after completion

## Stacked with
PR #28 (`feat/demo-seed-pack`) provides the seeded data this snapshot endpoint serves on first paint. Either order works for merging; together they're the demo experience documented in `DEMO.md`.