### PR TITLE
Persist real monitoring, recommendation, and source data flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:web": "bun run --cwd web dev",
     "build:web": "bun run --cwd web build",
     "demo": "echo 'Run: bun install && bun run dev  →  open http://localhost:5173  →  click Run Sephora demo benchmark'",
-    "test:server": "PERCEPTION_FORCE_MOCK_LLM=1 bun test --cwd server src/features/competitive/__tests__/pipeline.test.ts src/features/competitive/__tests__/benchmark.service.test.ts src/features/competitive/__tests__/gap-analysis.service.test.ts src/lib/llm-providers.test.ts src/routes/business.test.ts src/routes/competitive.test.ts",
+    "test:server": "PERCEPTION_FORCE_MOCK_LLM=1 bun test --cwd server src/features/competitive/__tests__/pipeline.test.ts src/features/competitive/__tests__/benchmark.service.test.ts src/features/competitive/__tests__/gap-analysis.service.test.ts src/features/monitoring/parse-response.test.ts src/lib/llm-providers.test.ts src/routes/business.test.ts src/routes/competitive.test.ts",
     "test:web": "bun test --cwd web src/__tests__/app.test.tsx src/components/competitive/__tests__/components.test.tsx",
     "test": "bun run test:server && bun run test:web"
   }

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,10 +2,17 @@
 # Without a key the server falls back to a deterministic mock LLM —
 # fine for UI demos, but no real AI answers.
 
-# Required for live LLM mode:
+# Configure one or more live monitoring providers:
 OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
 
-# Optional: pin a different provider (currently only "openai" is supported).
+# Optional provider model overrides:
+# OPENAI_MONITORING_MODEL=gpt-4.1-mini
+# ANTHROPIC_MONITORING_MODEL=claude-haiku-4-5
+# GEMINI_MONITORING_MODEL=gemini-2.0-flash
+
+# Optional: pin the provider used for structured generation and benchmarking.
 # LLM_PROVIDER=openai
 
 # Optional: turn the demo seed off if you want a fresh empty store.

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -66,6 +66,40 @@ export function runMigrations() {
       FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE,
       FOREIGN KEY (monitoring_prompt_id) REFERENCES monitoring_prompts(id) ON DELETE CASCADE
     );
+
+    CREATE TABLE IF NOT EXISTS monitoring_runs (
+      id TEXT PRIMARY KEY,
+      business_profile_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      completed_at TEXT,
+      FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS monitoring_attempts (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      business_profile_id TEXT NOT NULL,
+      monitoring_prompt_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      status TEXT NOT NULL,
+      raw_response TEXT,
+      score REAL,
+      mention_sentiment TEXT,
+      mention_position INTEGER,
+      recommended INTEGER NOT NULL DEFAULT 0,
+      feature_sentiment_json TEXT NOT NULL DEFAULT '{}',
+      sources_json TEXT NOT NULL DEFAULT '[]',
+      error TEXT,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (run_id) REFERENCES monitoring_runs(id) ON DELETE CASCADE,
+      FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE,
+      FOREIGN KEY (monitoring_prompt_id) REFERENCES monitoring_prompts(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS monitoring_attempts_profile_created_idx
+      ON monitoring_attempts (business_profile_id, created_at);
   `);
 }
 

--- a/server/src/db/monitoring-runs.ts
+++ b/server/src/db/monitoring-runs.ts
@@ -1,0 +1,128 @@
+import { db } from "./client";
+import type { MentionSentiment } from "./monitoring-prompts";
+
+export type MonitoringProvider = "openai" | "anthropic" | "gemini";
+export type MonitoringRunStatus = "running" | "completed" | "partial" | "failed";
+
+export interface MonitoringAttempt {
+  id: string;
+  runId: string;
+  businessProfileId: string;
+  monitoringPromptId: string;
+  provider: MonitoringProvider;
+  model: string;
+  status: "success" | "error";
+  rawResponse: string | null;
+  score: number | null;
+  mentionSentiment: MentionSentiment | null;
+  mentionPosition: number | null;
+  recommended: boolean;
+  featureSentiment: Record<string, MentionSentiment>;
+  sources: string[];
+  error: string | null;
+  createdAt: string;
+}
+
+interface AttemptRow {
+  id: string;
+  run_id: string;
+  business_profile_id: string;
+  monitoring_prompt_id: string;
+  provider: MonitoringProvider;
+  model: string;
+  status: "success" | "error";
+  raw_response: string | null;
+  score: number | null;
+  mention_sentiment: MentionSentiment | null;
+  mention_position: number | null;
+  recommended: number;
+  feature_sentiment_json: string;
+  sources_json: string;
+  error: string | null;
+  created_at: string;
+}
+
+const insertRun = db.query<null, [string, string, string, string]>(`
+  INSERT INTO monitoring_runs (id, business_profile_id, status, started_at)
+  VALUES (?, ?, ?, ?)
+`);
+
+const finishRun = db.query<null, [MonitoringRunStatus, string, string]>(`
+  UPDATE monitoring_runs SET status = ?, completed_at = ? WHERE id = ?
+`);
+
+const insertAttempt = db.query<AttemptRow, [
+  string, string, string, string, MonitoringProvider, string, string, string | null,
+  number | null, MentionSentiment | null, number | null, number, string, string, string | null, string,
+]>(`
+  INSERT INTO monitoring_attempts (
+    id, run_id, business_profile_id, monitoring_prompt_id, provider, model, status,
+    raw_response, score, mention_sentiment, mention_position, recommended,
+    feature_sentiment_json, sources_json, error, created_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  RETURNING *
+`);
+
+const listAttempts = db.query<AttemptRow, [string]>(`
+  SELECT * FROM monitoring_attempts
+  WHERE business_profile_id = ?
+  ORDER BY created_at ASC
+`);
+
+function fromRow(row: AttemptRow): MonitoringAttempt {
+  return {
+    id: row.id,
+    runId: row.run_id,
+    businessProfileId: row.business_profile_id,
+    monitoringPromptId: row.monitoring_prompt_id,
+    provider: row.provider,
+    model: row.model,
+    status: row.status,
+    rawResponse: row.raw_response,
+    score: row.score,
+    mentionSentiment: row.mention_sentiment,
+    mentionPosition: row.mention_position,
+    recommended: row.recommended === 1,
+    featureSentiment: JSON.parse(row.feature_sentiment_json) as Record<string, MentionSentiment>,
+    sources: JSON.parse(row.sources_json) as string[],
+    error: row.error,
+    createdAt: row.created_at,
+  };
+}
+
+export const monitoringRuns = {
+  start(businessProfileId: string) {
+    const id = crypto.randomUUID();
+    insertRun.run(id, businessProfileId, "running", new Date().toISOString());
+    return id;
+  },
+
+  finish(id: string, status: MonitoringRunStatus) {
+    finishRun.run(status, new Date().toISOString(), id);
+  },
+
+  addAttempt(input: Omit<MonitoringAttempt, "id" | "createdAt">) {
+    return fromRow(insertAttempt.get(
+      crypto.randomUUID(),
+      input.runId,
+      input.businessProfileId,
+      input.monitoringPromptId,
+      input.provider,
+      input.model,
+      input.status,
+      input.rawResponse,
+      input.score,
+      input.mentionSentiment,
+      input.mentionPosition,
+      input.recommended ? 1 : 0,
+      JSON.stringify(input.featureSentiment),
+      JSON.stringify(input.sources),
+      input.error,
+      new Date().toISOString(),
+    )!);
+  },
+
+  attempts(businessProfileId: string) {
+    return listAttempts.all(businessProfileId).map(fromRow);
+  },
+};

--- a/server/src/features/monitoring/parse-response.test.ts
+++ b/server/src/features/monitoring/parse-response.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { parseMonitoringResponse } from "./parse-response";
+
+test("parses brand position, recommendation, feature sentiment, and sources", () => {
+  const parsed = parseMonitoringResponse(
+    "Acme",
+    "Acme is a recommended and reliable option with good support. See https://example.com/acme.",
+  );
+
+  expect(parsed.mentionPosition).toBe(0);
+  expect(parsed.recommended).toBeTrue();
+  expect(parsed.mentionSentiment).toBe("positive");
+  expect(parsed.featureSentiment.support).toBe("positive");
+  expect(parsed.sources).toEqual(["https://example.com/acme"]);
+});
+
+test("does not claim a mention when the brand is absent", () => {
+  const parsed = parseMonitoringResponse("Acme", "Another product is a strong choice.");
+  expect(parsed.mentionPosition).toBeNull();
+  expect(parsed.recommended).toBeFalse();
+  expect(parsed.score).toBe(0);
+});

--- a/server/src/features/monitoring/parse-response.ts
+++ b/server/src/features/monitoring/parse-response.ts
@@ -1,0 +1,41 @@
+import type { MentionSentiment } from "../../db/monitoring-prompts";
+
+const positiveWords = ["best", "good", "great", "reliable", "recommended", "strong", "easy", "excellent"];
+const negativeWords = ["bad", "poor", "expensive", "unreliable", "weak", "difficult", "avoid", "problem"];
+const featureTerms = ["pricing", "support", "reliability", "quality", "features", "onboarding", "innovation"];
+
+function scoreText(text: string) {
+  const lower = text.toLowerCase();
+  const positive = positiveWords.filter((word) => lower.includes(word)).length;
+  const negative = negativeWords.filter((word) => lower.includes(word)).length;
+  return Math.max(-1, Math.min(1, (positive - negative) / Math.max(positive + negative, 1)));
+}
+
+function sentiment(score: number): MentionSentiment {
+  if (score >= 0.2) return "positive";
+  if (score <= -0.2) return "negative";
+  return "neutral";
+}
+
+export function parseMonitoringResponse(brandName: string, rawResponse: string) {
+  const lower = rawResponse.toLowerCase();
+  const brandIndex = lower.indexOf(brandName.toLowerCase());
+  const score = brandIndex === -1 ? 0 : scoreText(rawResponse);
+  const featureSentiment = Object.fromEntries(
+    featureTerms
+      .filter((feature) => lower.includes(feature))
+      .map((feature) => [feature, sentiment(score)]),
+  );
+  const sources = [...new Set(
+    (rawResponse.match(/https?:\/\/[^\s)\]}>,]+/g) ?? []).map((source) => source.replace(/[.!?:;]+$/, "")),
+  )];
+
+  return {
+    score,
+    mentionSentiment: sentiment(score),
+    mentionPosition: brandIndex === -1 ? null : brandIndex,
+    recommended: brandIndex !== -1 && /\b(recommend(?:ed)?|best|top choice|great option)\b/i.test(rawResponse),
+    featureSentiment,
+    sources,
+  };
+}

--- a/server/src/features/monitoring/providers.ts
+++ b/server/src/features/monitoring/providers.ts
@@ -1,0 +1,81 @@
+import { callLLM } from "../../lib/llm-providers";
+import type { MonitoringProvider } from "../../db/monitoring-runs";
+
+const providerModels: Record<MonitoringProvider, string> = {
+  openai: "gpt-4.1-mini",
+  anthropic: "claude-haiku-4-5",
+  gemini: "gemini-2.0-flash",
+};
+
+const runtimeEnv = () => process.env;
+
+export function monitoringProviderConfigured(provider: MonitoringProvider) {
+  if (runtimeEnv().PERCEPTION_FORCE_MOCK_LLM === "1" || runtimeEnv().NODE_ENV === "test" || runtimeEnv().BUN_ENV === "test") {
+    return true;
+  }
+  if (provider === "openai") return Boolean(runtimeEnv().OPENAI_API_KEY);
+  if (provider === "anthropic") return Boolean(runtimeEnv().ANTHROPIC_API_KEY);
+  return Boolean(runtimeEnv().GEMINI_API_KEY);
+}
+
+function mockAnswer(provider: MonitoringProvider, brandName: string, prompt: string) {
+  return `${providerModels[provider]} says ${brandName} is a recommended option for "${prompt}". ` +
+    `${brandName} is known for reliable features and good customer support. Source: https://example.com/${provider}`;
+}
+
+export async function callMonitoringProvider(input: {
+  provider: MonitoringProvider;
+  prompt: string;
+  brandName: string;
+}) {
+  const configuredModels: Record<MonitoringProvider, string | undefined> = {
+    openai: runtimeEnv().OPENAI_MONITORING_MODEL,
+    anthropic: runtimeEnv().ANTHROPIC_MONITORING_MODEL,
+    gemini: runtimeEnv().GEMINI_MONITORING_MODEL,
+  };
+  const model = configuredModels[input.provider] ?? providerModels[input.provider];
+  const forceMock = runtimeEnv().PERCEPTION_FORCE_MOCK_LLM === "1" || runtimeEnv().NODE_ENV === "test" || runtimeEnv().BUN_ENV === "test";
+  if (forceMock) {
+    const failedProviders = (runtimeEnv().PERCEPTION_MOCK_PROVIDER_FAILURES ?? "").split(",");
+    if (failedProviders.includes(input.provider)) {
+      throw new Error(`${input.provider} mock failure.`);
+    }
+    return { model, text: mockAnswer(input.provider, input.brandName, input.prompt) };
+  }
+
+  if (!monitoringProviderConfigured(input.provider)) {
+    throw new Error(`${input.provider} is not configured.`);
+  }
+
+  const prompt = `Answer this consumer question naturally. Include citations as URLs when available.\n\n${input.prompt}`;
+  if (input.provider === "openai") {
+    return { model, text: await callLLM({ provider: "openai", model, prompt, useSearch: true }) };
+  }
+
+  if (input.provider === "anthropic") {
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": runtimeEnv().ANTHROPIC_API_KEY!,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({ model, max_tokens: 1200, messages: [{ role: "user", content: prompt }] }),
+    });
+    if (!response.ok) throw new Error(`Anthropic request failed (${response.status}).`);
+    const body = await response.json() as { content?: Array<{ type: string; text?: string }> };
+    return { model, text: body.content?.map((item) => item.text ?? "").join("\n").trim() ?? "" };
+  }
+
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${encodeURIComponent(runtimeEnv().GEMINI_API_KEY!)}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
+    },
+  );
+  if (!response.ok) throw new Error(`Gemini request failed (${response.status}).`);
+  const body = await response.json() as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> };
+  return { model, text: body.candidates?.[0]?.content?.parts?.map((part) => part.text ?? "").join("\n").trim() ?? "" };
+}

--- a/server/src/features/monitoring/run-monitoring.ts
+++ b/server/src/features/monitoring/run-monitoring.ts
@@ -1,92 +1,136 @@
-import { z } from "zod";
 import type { BusinessProfile } from "../../db/business-profiles";
-import { monitoringPrompts, type MentionSentiment } from "../../db/monitoring-prompts";
-import { callStructuredLLM } from "../../lib/llm-providers";
+import { monitoringPrompts } from "../../db/monitoring-prompts";
+import {
+  monitoringRuns,
+  type MonitoringAttempt,
+  type MonitoringProvider,
+  type MonitoringRunStatus,
+} from "../../db/monitoring-runs";
+import { parseMonitoringResponse } from "./parse-response";
+import { callMonitoringProvider } from "./providers";
 
-const resultSchema = z.object({
-  results: z.array(z.object({
-    promptId: z.string(),
-    score: z.number().min(-1).max(1),
-    mentionSentiment: z.enum(["positive", "neutral", "negative"]),
-    answerSummary: z.string().min(1),
-    sources: z.array(z.string()).default([]),
-  })),
-});
+export const defaultMonitoringProviders: MonitoringProvider[] = ["openai", "anthropic", "gemini"];
 
-function sentimentForScore(score: number): MentionSentiment {
-  if (score >= 0.2) return "positive";
-  if (score <= -0.2) return "negative";
-  return "neutral";
-}
-
-function mockResults(profile: BusinessProfile, prompts: ReturnType<typeof monitoringPrompts.list>) {
-  return {
-    results: prompts.map((prompt, index) => {
-      const score = [0.42, 0.1, -0.24][index % 3]!;
-      return {
-        promptId: prompt.id,
-        score,
-        mentionSentiment: sentimentForScore(score),
-        answerSummary: `Mock monitoring summary for ${profile.name}: ${prompt.prompt.slice(0, 80)}`,
-        sources: ["example.com"],
-      };
-    }),
-  };
-}
-
-export async function runMonitoring(profile: BusinessProfile) {
+export async function runMonitoring(
+  profile: BusinessProfile,
+  providers: MonitoringProvider[] = defaultMonitoringProviders,
+) {
   const prompts = monitoringPrompts.list(profile.id);
   if (prompts.length === 0) {
-    return [];
+    return { runId: null, status: "completed" as const, attempts: [] };
   }
 
+  const runId = monitoringRuns.start(profile.id);
   monitoringPrompts.setStatus(profile.id, "generating");
-  try {
-    const result = await callStructuredLLM({
-      model: "gpt-4.1-mini",
-      schema: resultSchema,
-      schemaName: "monitoring_run_results",
-      useSearch: true,
-      mockValue: mockResults(profile, prompts),
-      prompt: `Run brand monitoring for these chatbot prompts.
 
-Business: ${profile.name}
-Website: ${profile.website}
-Description: ${profile.description}
+  const attempts = await Promise.all(
+    prompts.flatMap((prompt) =>
+      providers.map(async (provider): Promise<MonitoringAttempt> => {
+        try {
+          const response = await callMonitoringProvider({
+            provider,
+            prompt: prompt.prompt,
+            brandName: profile.name,
+          });
+          const parsed = parseMonitoringResponse(profile.name, response.text);
+          const attempt = monitoringRuns.addAttempt({
+            runId,
+            businessProfileId: profile.id,
+            monitoringPromptId: prompt.id,
+            provider,
+            model: response.model,
+            status: "success",
+            rawResponse: response.text,
+            score: parsed.score,
+            mentionSentiment: parsed.mentionSentiment,
+            mentionPosition: parsed.mentionPosition,
+            recommended: parsed.recommended,
+            featureSentiment: parsed.featureSentiment,
+            sources: parsed.sources,
+            error: null,
+          });
+          monitoringPrompts.addResult({
+            businessProfileId: profile.id,
+            monitoringPromptId: prompt.id,
+            score: parsed.score,
+            mentionSentiment: parsed.mentionSentiment,
+            answerSummary: response.text.slice(0, 280),
+            sources: parsed.sources,
+          });
+          return attempt;
+        } catch (error) {
+          return monitoringRuns.addAttempt({
+            runId,
+            businessProfileId: profile.id,
+            monitoringPromptId: prompt.id,
+            provider,
+            model: "unavailable",
+            status: "error",
+            rawResponse: null,
+            score: null,
+            mentionSentiment: null,
+            mentionPosition: null,
+            recommended: false,
+            featureSentiment: {},
+            sources: [],
+            error: error instanceof Error ? error.message : "Provider request failed.",
+          });
+        }
+      }),
+    ),
+  );
 
-Prompts:
-${prompts.map((prompt) => `- ${prompt.id}: ${prompt.prompt}`).join("\n")}
-
-For each prompt, estimate whether the brand is mentioned positively, neutrally, or negatively in current AI-answerable source material. Return one result per prompt.`,
-    });
-
-    const promptIds = new Set(prompts.map((prompt) => prompt.id));
-    const saved = result.results
-      .filter((item) => promptIds.has(item.promptId))
-      .map((item) =>
-        monitoringPrompts.addResult({
-          businessProfileId: profile.id,
-          monitoringPromptId: item.promptId,
-          score: item.score,
-          mentionSentiment: item.mentionSentiment,
-          answerSummary: item.answerSummary,
-          sources: item.sources,
-        }),
-      );
-
-    monitoringPrompts.setStatus(profile.id, "ready");
-    return saved;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Monitoring run failed.";
-    monitoringPrompts.setStatus(profile.id, "error", message);
-    throw error;
-  }
+  const successes = attempts.filter((attempt) => attempt.status === "success").length;
+  const status: MonitoringRunStatus =
+    successes === attempts.length ? "completed" : successes === 0 ? "failed" : "partial";
+  monitoringRuns.finish(runId, status);
+  monitoringPrompts.setStatus(
+    profile.id,
+    successes === 0 ? "error" : "ready",
+    status === "partial" ? "Some providers failed. Successful responses were saved." : successes === 0 ? "All providers failed." : null,
+  );
+  return { runId, status, attempts };
 }
 
 export function monitoringHistory(businessProfileId: string) {
-  const results = monitoringPrompts.results(businessProfileId);
-  return results.map((result) => ({
+  const attempts = monitoringRuns.attempts(businessProfileId).filter(
+    (attempt): attempt is MonitoringAttempt & { score: number } =>
+      attempt.status === "success" && attempt.score !== null,
+  );
+  if (attempts.length > 0) {
+    return attempts.map((attempt) => ({ t: attempt.createdAt, score: attempt.score, provider: attempt.provider }));
+  }
+  return monitoringPrompts.results(businessProfileId).map((result) => ({
     t: result.createdAt,
     score: result.score,
+    provider: "openai" as const,
   }));
+}
+
+export function monitoringSummary(businessProfileId: string) {
+  const attempts = monitoringRuns.attempts(businessProfileId);
+  const successful = attempts.filter((attempt) => attempt.status === "success");
+  const mentioned = successful.filter((attempt) => attempt.mentionPosition !== null);
+  const providerBreakdown = defaultMonitoringProviders.map((provider) => {
+    const providerAttempts = attempts.filter((attempt) => attempt.provider === provider);
+    const providerSuccesses = providerAttempts.filter((attempt) => attempt.status === "success");
+    const scores = providerSuccesses.flatMap((attempt) => attempt.score === null ? [] : [attempt.score]);
+    return {
+      provider,
+      attempts: providerAttempts.length,
+      successes: providerSuccesses.length,
+      mentions: providerSuccesses.filter((attempt) => attempt.mentionPosition !== null).length,
+      errors: providerAttempts.filter((attempt) => attempt.status === "error").length,
+      averageSentiment: scores.length ? scores.reduce((sum, score) => sum + score, 0) / scores.length : 0,
+    };
+  });
+  const latestRunId = attempts.at(-1)?.runId ?? null;
+
+  return {
+    totalResponses: successful.length,
+    mentionFrequency: successful.length ? mentioned.length / successful.length : 0,
+    recommendedResponses: successful.filter((attempt) => attempt.recommended).length,
+    providerBreakdown,
+    latestAttempts: latestRunId ? attempts.filter((attempt) => attempt.runId === latestRunId) : [],
+  };
 }

--- a/server/src/routes/business.test.ts
+++ b/server/src/routes/business.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { expect, test } from "bun:test";
 import { businessProfiles } from "../db/business-profiles";
+import { monitoringRuns } from "../db/monitoring-runs";
 import { store } from "../db/store";
 import { businessRoutes } from "./business";
 
@@ -263,10 +264,109 @@ test("runs monitoring and returns sentiment history", async () => {
 
   const runRes = await app.request(`/business-profiles/${profile.id}/monitoring/runs`, { method: "POST" });
   expect(runRes.status).toBe(200);
-  expect((await runRes.json()).results).toHaveLength(1);
+  const runBody = await runRes.json();
+  expect(runBody.status).toBe("completed");
+  expect(runBody.attempts).toHaveLength(3);
+  expect(new Set(runBody.attempts.map((attempt: { provider: string }) => attempt.provider))).toEqual(
+    new Set(["openai", "anthropic", "gemini"]),
+  );
+  expect(runBody.attempts.every((attempt: { rawResponse: string }) => attempt.rawResponse.includes(profile.name))).toBeTrue();
+  expect(monitoringRuns.attempts(profile.id)).toHaveLength(3);
 
   const monitoringRes = await app.request(`/business-profiles/${profile.id}/monitoring`);
   const monitoringBody = await monitoringRes.json();
-  expect(monitoringBody.history).toHaveLength(1);
+  expect(monitoringBody.history).toHaveLength(3);
+  expect(monitoringBody.summary.totalResponses).toBe(3);
+  expect(monitoringBody.summary.mentionFrequency).toBe(1);
   expect(monitoringBody.prompts[0].mentionSentiment).toBeTruthy();
+});
+
+test("keeps successful monitoring responses when one provider fails", async () => {
+  const profile = businessProfiles.create({
+    name: `PartialRun ${crypto.randomUUID()}`,
+    website: "https://partial-run.test",
+    description: "Partial provider failure profile.",
+  });
+  await app.request(`/business-profiles/${profile.id}/monitoring-prompts`, {
+    method: "POST",
+    body: JSON.stringify({ prompt: "Which AI visibility platform should a brand use?" }),
+    headers: { "content-type": "application/json" },
+  });
+
+  process.env.PERCEPTION_MOCK_PROVIDER_FAILURES = "anthropic";
+  try {
+    const runRes = await app.request(`/business-profiles/${profile.id}/monitoring/runs`, {
+      method: "POST",
+      body: JSON.stringify({ providers: ["openai", "anthropic", "gemini"] }),
+      headers: { "content-type": "application/json" },
+    });
+    const runBody = await runRes.json();
+    expect(runBody.status).toBe("partial");
+    expect(runBody.attempts.filter((attempt: { status: string }) => attempt.status === "success")).toHaveLength(2);
+    expect(runBody.attempts.find((attempt: { provider: string }) => attempt.provider === "anthropic").error).toContain(
+      "mock failure",
+    );
+
+    const monitoringBody = await (
+      await app.request(`/business-profiles/${profile.id}/monitoring`)
+    ).json();
+    expect(monitoringBody.summary.totalResponses).toBe(2);
+    expect(monitoringBody.summary.providerBreakdown.find(
+      (item: { provider: string }) => item.provider === "anthropic",
+    ).errors).toBe(1);
+  } finally {
+    delete process.env.PERCEPTION_MOCK_PROVIDER_FAILURES;
+  }
+});
+
+test("keeps recommendation feedback isolated for duplicate profile names", async () => {
+  const name = `Duplicate ${crypto.randomUUID()}`;
+  const firstProfile = businessProfiles.create({
+    name,
+    website: "https://first.test",
+    description: "First duplicate-name profile.",
+  });
+  const secondProfile = businessProfiles.create({
+    name,
+    website: "https://second.test",
+    description: "Second duplicate-name profile.",
+  });
+  const firstBrand = { id: crypto.randomUUID(), name };
+  const secondBrand = { id: crypto.randomUUID(), name };
+  store.brands.set(firstBrand.id, firstBrand);
+  store.brands.set(secondBrand.id, secondBrand);
+  store.businessProfileBrandIds.set(firstProfile.id, firstBrand.id);
+  store.businessProfileBrandIds.set(secondProfile.id, secondBrand.id);
+  store.recommendations.push({
+    id: "rec-second-feedback",
+    brandId: secondBrand.id,
+    sourceGapEventId: crypto.randomUUID(),
+    title: "Second profile recommendation",
+    category: "content",
+    impact: "medium",
+    effort: "low",
+    evidence: "Second profile evidence.",
+    action: "Act on the second profile.",
+    createdAt: new Date().toISOString(),
+  });
+
+  const saveRes = await app.request(`/business-profiles/${firstProfile.id}/recommendation-feedback`, {
+    method: "PUT",
+    body: JSON.stringify({ recommendationId: "rec-duplicate", rating: "good" }),
+    headers: { "content-type": "application/json" },
+  });
+  expect(saveRes.status).toBe(200);
+
+  const firstListRes = await app.request(`/business-profiles/${firstProfile.id}/recommendation-feedback`);
+  const secondListRes = await app.request(`/business-profiles/${secondProfile.id}/recommendation-feedback`);
+  expect((await firstListRes.json()).feedback).toHaveLength(1);
+  expect((await secondListRes.json()).feedback).toEqual([]);
+
+  const secondMetricsRes = await app.request(`/business-profiles/${secondProfile.id}/admin/metrics`);
+  expect((await secondMetricsRes.json()).recommendationFeedback).toEqual({
+    total: 0,
+    good: 0,
+    bad: 0,
+    unrated: 1,
+  });
 });

--- a/server/src/routes/business.ts
+++ b/server/src/routes/business.ts
@@ -6,7 +6,12 @@ import { recommendationFeedback } from "../db/recommendation-feedback";
 import { store } from "../db/store";
 import { sourcesForBrand } from "../features/competitive/sources.service";
 import { recommendationsForBrand } from "../features/fixit/recommendations";
-import { monitoringHistory, runMonitoring } from "../features/monitoring/run-monitoring";
+import {
+  defaultMonitoringProviders,
+  monitoringHistory,
+  monitoringSummary,
+  runMonitoring,
+} from "../features/monitoring/run-monitoring";
 import { generateMonitoringPrompts } from "../features/monitoring/prompt-generation";
 import { isLLMProviderConfigured } from "../lib/llm-providers";
 
@@ -21,15 +26,6 @@ export const businessRoutes = new Hono();
 function brandIdForProfile(profileId: string) {
   const brandId = store.businessProfileBrandIds.get(profileId);
   return brandId && store.brands.has(brandId) ? brandId : null;
-}
-
-function liveProviderUnavailable() {
-  return (
-    process.env.PERCEPTION_FORCE_MOCK_LLM !== "1" &&
-    process.env.NODE_ENV !== "test" &&
-    process.env.BUN_ENV !== "test" &&
-    !isLLMProviderConfigured("openai")
-  );
 }
 
 businessRoutes.get("/business-profiles", (c) => {
@@ -90,6 +86,7 @@ businessRoutes.get("/business-profiles/:id/monitoring", (c) => {
     error: state.error,
     prompts: monitoringPrompts.list(id),
     history: monitoringHistory(id),
+    summary: monitoringSummary(id),
   });
 });
 
@@ -98,11 +95,13 @@ businessRoutes.post("/business-profiles/:id/monitoring/runs", async (c) => {
   if (!profile) {
     return c.json({ error: "Business profile not found." }, 404);
   }
-  if (liveProviderUnavailable()) {
-    return c.json({ error: "OpenAI is not configured. Set OPENAI_API_KEY to run live monitoring." }, 503);
-  }
-  const results = await runMonitoring(profile);
-  return c.json({ results });
+  const body = await c.req.json().catch(() => ({}));
+  const runSchema = z.object({
+    providers: z.array(z.enum(["openai", "anthropic", "gemini"])).min(1).default(defaultMonitoringProviders),
+  });
+  const { providers } = runSchema.parse(body);
+  const run = await runMonitoring(profile, providers);
+  return c.json(run);
 });
 
 businessRoutes.get("/business-profiles/:id/monitoring/history", (c) => {

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -122,17 +122,22 @@ export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
     if (!prompt) {
       return;
     }
-    const res = await fetch(`${API_BASE}/business-profiles/${profile.id}/monitoring-prompts`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ prompt }),
-    });
-    if (!res.ok) {
-      setError("Could not add prompt.");
-      return;
+    setError("");
+    try {
+      const res = await fetch(`${API_BASE}/business-profiles/${profile.id}/monitoring-prompts`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt }),
+      });
+      if (!res.ok) {
+        setError("Could not add prompt.");
+        return;
+      }
+      setNewPrompt("");
+      await load();
+    } catch {
+      setError("Could not add prompt. Check your connection and try again.");
     }
-    setNewPrompt("");
-    await load();
   }
 
   async function runLiveMonitoring() {
@@ -170,6 +175,20 @@ export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
       <p className="muted">Monitoring</p>
       <h2>{profile.name}</h2>
       <p>Track the prompts where this business should appear in chatbot answers.</p>
+      <div className="stat-row">
+        <div className="stat">
+          <div className="stat__label">Stored responses</div>
+          <div className="stat__value">{data.summary.totalResponses}</div>
+        </div>
+        <div className="stat">
+          <div className="stat__label">Mention frequency</div>
+          <div className="stat__value">{Math.round(data.summary.mentionFrequency * 100)}%</div>
+        </div>
+        <div className="stat">
+          <div className="stat__label">Recommendations</div>
+          <div className="stat__value">{data.summary.recommendedResponses}</div>
+        </div>
+      </div>
       <SentimentTrend history={data.history} />
       <div className="inline-form">
         <button type="button" onClick={runLiveMonitoring} disabled={running || data.prompts.length === 0}>
@@ -197,6 +216,37 @@ export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
           ))}
         </tbody>
       </table>
+
+      <h3>Provider health</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Provider</th>
+            <th>Successful</th>
+            <th>Mentions</th>
+            <th>Errors</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.summary.providerBreakdown.map((item) => (
+            <tr key={item.provider}>
+              <td>{sentimentLabel(item.provider)}</td>
+              <td>{item.successes} / {item.attempts}</td>
+              <td>{item.mentions}</td>
+              <td>{item.errors}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {data.summary.latestAttempts.some((attempt) => attempt.status === "error") && (
+        <div className="error">
+          {data.summary.latestAttempts
+            .filter((attempt) => attempt.status === "error")
+            .map((attempt) => `${sentimentLabel(attempt.provider)}: ${attempt.error}`)
+            .join(" ")}
+        </div>
+      )}
 
       <div className="inline-form">
         <input

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -19,11 +19,47 @@ export interface MonitoringResponse {
   error: string | null;
   prompts: MonitoringPrompt[];
   history: MonitoringHistoryPoint[];
+  summary: MonitoringSummary;
 }
 
 export interface MonitoringHistoryPoint {
   t: string;
   score: number;
+  provider?: MonitoringProvider;
+}
+
+export type MonitoringProvider = "openai" | "anthropic" | "gemini";
+
+export interface MonitoringAttempt {
+  id: string;
+  runId: string;
+  monitoringPromptId: string;
+  provider: MonitoringProvider;
+  model: string;
+  status: "success" | "error";
+  rawResponse: string | null;
+  score: number | null;
+  mentionSentiment: "positive" | "negative" | "neutral" | null;
+  mentionPosition: number | null;
+  recommended: boolean;
+  sources: string[];
+  error: string | null;
+  createdAt: string;
+}
+
+export interface MonitoringSummary {
+  totalResponses: number;
+  mentionFrequency: number;
+  recommendedResponses: number;
+  providerBreakdown: Array<{
+    provider: MonitoringProvider;
+    attempts: number;
+    successes: number;
+    mentions: number;
+    errors: number;
+    averageSentiment: number;
+  }>;
+  latestAttempts: MonitoringAttempt[];
 }
 
 export type RecommendationRating = "good" | "bad";


### PR DESCRIPTION
## Summary
- add durable OpenAI, Anthropic, and Gemini monitoring runs
- persist raw responses, parsed mention position, sentiment, recommendations, feature signals, citations, and provider failures
- preserve successful provider results when another provider fails
- expose provider health and persisted monitoring history in the dashboard

## Tracking
Closes #38

## Dependency
Stacked on the review-sized monitoring foundation PRs that precede it.

## Verification
- `bun test`
- `bun run build:web`

Changed lines: 752