### PR TITLE
Add brand fact sheets and Accuracy Guard alerts

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -12,6 +12,10 @@ GEMINI_API_KEY=
 # ANTHROPIC_MONITORING_MODEL=claude-haiku-4-5
 # GEMINI_MONITORING_MODEL=gemini-2.0-flash
 
+# Optional Accuracy Guard delivery integrations. In-app alerts always work.
+# ACCURACY_ALERT_EMAIL_WEBHOOK=
+# ACCURACY_ALERT_SLACK_WEBHOOK=
+
 # Optional: pin the provider used for structured generation and benchmarking.
 # LLM_PROVIDER=openai
 

--- a/server/src/db/accuracy-guard.ts
+++ b/server/src/db/accuracy-guard.ts
@@ -1,0 +1,186 @@
+import { db } from "./client";
+
+export type FactCategory = "pricing" | "feature" | "executive" | "company" | "custom";
+export type AlertSeverity = "high" | "medium" | "low";
+export type AlertStatus = "open" | "acknowledged";
+
+export interface BrandFact {
+  id: string;
+  businessProfileId: string;
+  category: FactCategory;
+  label: string;
+  value: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FactRow {
+  id: string;
+  business_profile_id: string;
+  category: FactCategory;
+  label: string;
+  value: string;
+  active: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface AlertRow {
+  id: string;
+  business_profile_id: string;
+  monitoring_attempt_id: string;
+  brand_fact_id: string;
+  severity: AlertSeverity;
+  status: AlertStatus;
+  observed_claim: string;
+  expected_value: string;
+  explanation: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const listFacts = db.query<FactRow, [string]>(`
+  SELECT * FROM brand_facts WHERE business_profile_id = ? ORDER BY created_at ASC
+`);
+const getFact = db.query<FactRow, [string, string]>(`
+  SELECT * FROM brand_facts WHERE id = ? AND business_profile_id = ?
+`);
+const insertFact = db.query<FactRow, [string, string, FactCategory, string, string, string, string]>(`
+  INSERT INTO brand_facts (id, business_profile_id, category, label, value, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING *
+`);
+const updateFact = db.query<FactRow, [FactCategory, string, string, number, string, string, string]>(`
+  UPDATE brand_facts SET category = ?, label = ?, value = ?, active = ?, updated_at = ?
+  WHERE id = ? AND business_profile_id = ? RETURNING *
+`);
+const deleteFact = db.query<null, [string, string]>(`
+  DELETE FROM brand_facts WHERE id = ? AND business_profile_id = ?
+`);
+const insertAlert = db.query<AlertRow, [
+  string, string, string, string, AlertSeverity, string, string, string, string, string,
+]>(`
+  INSERT INTO accuracy_alerts (
+    id, business_profile_id, monitoring_attempt_id, brand_fact_id, severity, status,
+    observed_claim, expected_value, explanation, created_at, updated_at
+  ) VALUES (?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?)
+  ON CONFLICT(monitoring_attempt_id, brand_fact_id) DO UPDATE SET
+    observed_claim = excluded.observed_claim,
+    expected_value = excluded.expected_value,
+    explanation = excluded.explanation,
+    updated_at = excluded.updated_at
+  RETURNING *
+`);
+const listAlerts = db.query<AlertRow, [string]>(`
+  SELECT * FROM accuracy_alerts WHERE business_profile_id = ? ORDER BY created_at DESC
+`);
+const findOpenDuplicate = db.query<AlertRow, [string, string]>(`
+  SELECT * FROM accuracy_alerts
+  WHERE business_profile_id = ? AND brand_fact_id = ? AND status = 'open'
+  ORDER BY created_at DESC LIMIT 1
+`);
+const acknowledgeAlert = db.query<AlertRow, [string, string, string, string]>(`
+  UPDATE accuracy_alerts SET status = 'acknowledged', updated_at = ?
+  WHERE id = ? AND business_profile_id = ? AND status = ? RETURNING *
+`);
+
+function factFromRow(row: FactRow): BrandFact {
+  return {
+    id: row.id,
+    businessProfileId: row.business_profile_id,
+    category: row.category,
+    label: row.label,
+    value: row.value,
+    active: row.active === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function alertFromRow(row: AlertRow) {
+  return {
+    id: row.id,
+    businessProfileId: row.business_profile_id,
+    monitoringAttemptId: row.monitoring_attempt_id,
+    brandFactId: row.brand_fact_id,
+    severity: row.severity,
+    status: row.status,
+    observedClaim: row.observed_claim,
+    expectedValue: row.expected_value,
+    explanation: row.explanation,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export const accuracyGuard = {
+  facts(businessProfileId: string) {
+    return listFacts.all(businessProfileId).map(factFromRow);
+  },
+
+  fact(businessProfileId: string, id: string) {
+    const row = getFact.get(id, businessProfileId);
+    return row ? factFromRow(row) : null;
+  },
+
+  createFact(businessProfileId: string, input: { category: FactCategory; label: string; value: string }) {
+    const now = new Date().toISOString();
+    return factFromRow(insertFact.get(
+      crypto.randomUUID(), businessProfileId, input.category, input.label, input.value, now, now,
+    )!);
+  },
+
+  updateFact(
+    businessProfileId: string,
+    id: string,
+    input: { category: FactCategory; label: string; value: string; active: boolean },
+  ) {
+    const row = updateFact.get(
+      input.category, input.label, input.value, input.active ? 1 : 0, new Date().toISOString(), id, businessProfileId,
+    );
+    return row ? factFromRow(row) : null;
+  },
+
+  deleteFact(businessProfileId: string, id: string) {
+    deleteFact.run(id, businessProfileId);
+  },
+
+  createAlert(input: {
+    businessProfileId: string;
+    monitoringAttemptId: string;
+    brandFactId: string;
+    severity: AlertSeverity;
+    observedClaim: string;
+    expectedValue: string;
+    explanation: string;
+  }) {
+    const duplicate = findOpenDuplicate.get(
+      input.businessProfileId,
+      input.brandFactId,
+    );
+    if (duplicate) return alertFromRow(duplicate);
+
+    const now = new Date().toISOString();
+    return alertFromRow(insertAlert.get(
+      crypto.randomUUID(),
+      input.businessProfileId,
+      input.monitoringAttemptId,
+      input.brandFactId,
+      input.severity,
+      input.observedClaim,
+      input.expectedValue,
+      input.explanation,
+      now,
+      now,
+    )!);
+  },
+
+  alerts(businessProfileId: string) {
+    return listAlerts.all(businessProfileId).map(alertFromRow);
+  },
+
+  acknowledge(businessProfileId: string, id: string) {
+    const row = acknowledgeAlert.get(new Date().toISOString(), id, businessProfileId, "open");
+    return row ? alertFromRow(row) : null;
+  },
+};

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -100,6 +100,36 @@ export function runMigrations() {
 
     CREATE INDEX IF NOT EXISTS monitoring_attempts_profile_created_idx
       ON monitoring_attempts (business_profile_id, created_at);
+
+    CREATE TABLE IF NOT EXISTS brand_facts (
+      id TEXT PRIMARY KEY,
+      business_profile_id TEXT NOT NULL,
+      category TEXT NOT NULL,
+      label TEXT NOT NULL,
+      value TEXT NOT NULL,
+      active INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS accuracy_alerts (
+      id TEXT PRIMARY KEY,
+      business_profile_id TEXT NOT NULL,
+      monitoring_attempt_id TEXT NOT NULL,
+      brand_fact_id TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      status TEXT NOT NULL,
+      observed_claim TEXT NOT NULL,
+      expected_value TEXT NOT NULL,
+      explanation TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      UNIQUE (monitoring_attempt_id, brand_fact_id),
+      FOREIGN KEY (business_profile_id) REFERENCES business_profiles(id) ON DELETE CASCADE,
+      FOREIGN KEY (monitoring_attempt_id) REFERENCES monitoring_attempts(id) ON DELETE CASCADE,
+      FOREIGN KEY (brand_fact_id) REFERENCES brand_facts(id) ON DELETE CASCADE
+    );
   `);
 }
 

--- a/server/src/features/accuracy/detect-inaccuracies.ts
+++ b/server/src/features/accuracy/detect-inaccuracies.ts
@@ -1,0 +1,35 @@
+import { accuracyGuard, type BrandFact } from "../../db/accuracy-guard";
+import type { MonitoringAttempt } from "../../db/monitoring-runs";
+
+function sentenceContaining(text: string, needle: string) {
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .find((sentence) => sentence.toLowerCase().includes(needle.toLowerCase()))
+    ?.trim();
+}
+
+function severityForFact(fact: BrandFact) {
+  if (fact.category === "pricing" || fact.category === "executive") return "high" as const;
+  if (fact.category === "feature") return "medium" as const;
+  return "low" as const;
+}
+
+export function detectInaccuracies(attempt: MonitoringAttempt, facts: BrandFact[]) {
+  if (attempt.status !== "success" || !attempt.rawResponse) return [];
+
+  return facts.flatMap((fact) => {
+    if (!fact.active) return [];
+    const claim = sentenceContaining(attempt.rawResponse!, fact.label);
+    if (!claim || claim.toLowerCase().includes(fact.value.toLowerCase())) return [];
+
+    return [accuracyGuard.createAlert({
+      businessProfileId: attempt.businessProfileId,
+      monitoringAttemptId: attempt.id,
+      brandFactId: fact.id,
+      severity: severityForFact(fact),
+      observedClaim: claim,
+      expectedValue: fact.value,
+      explanation: `The response discussed "${fact.label}" but did not match the configured ground truth.`,
+    })];
+  });
+}

--- a/server/src/features/monitoring/run-monitoring.ts
+++ b/server/src/features/monitoring/run-monitoring.ts
@@ -1,4 +1,5 @@
 import type { BusinessProfile } from "../../db/business-profiles";
+import { accuracyGuard } from "../../db/accuracy-guard";
 import { monitoringPrompts } from "../../db/monitoring-prompts";
 import {
   monitoringRuns,
@@ -8,6 +9,7 @@ import {
 } from "../../db/monitoring-runs";
 import { parseMonitoringResponse } from "./parse-response";
 import { callMonitoringProvider } from "./providers";
+import { detectInaccuracies } from "../accuracy/detect-inaccuracies";
 
 export const defaultMonitoringProviders: MonitoringProvider[] = ["openai", "anthropic", "gemini"];
 
@@ -21,6 +23,7 @@ export async function runMonitoring(
   }
 
   const runId = monitoringRuns.start(profile.id);
+  const facts = accuracyGuard.facts(profile.id);
   monitoringPrompts.setStatus(profile.id, "generating");
 
   const attempts = await Promise.all(
@@ -57,6 +60,7 @@ export async function runMonitoring(
             answerSummary: response.text.slice(0, 280),
             sources: parsed.sources,
           });
+          detectInaccuracies(attempt, facts);
           return attempt;
         } catch (error) {
           return monitoringRuns.addAttempt({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,7 @@ app.use(
       "http://localhost:5175",
       "http://127.0.0.1:5175",
     ],
-    allowMethods: ["GET", "POST", "PUT", "OPTIONS"],
+    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
   }),
 );
 

--- a/server/src/routes/business.test.ts
+++ b/server/src/routes/business.test.ts
@@ -319,6 +319,84 @@ test("keeps successful monitoring responses when one provider fails", async () =
   }
 });
 
+test("creates deduplicated Accuracy Guard alerts from profile facts", async () => {
+  const profile = businessProfiles.create({
+    name: `Accuracy ${crypto.randomUUID()}`,
+    website: "https://accuracy.test",
+    description: "Accuracy Guard test profile.",
+  });
+  const factRes = await app.request(`/business-profiles/${profile.id}/facts`, {
+    method: "POST",
+    body: JSON.stringify({
+      category: "feature",
+      label: "customer support",
+      value: "24/7 phone support",
+    }),
+    headers: { "content-type": "application/json" },
+  });
+  expect(factRes.status).toBe(201);
+
+  await app.request(`/business-profiles/${profile.id}/monitoring-prompts`, {
+    method: "POST",
+    body: JSON.stringify({ prompt: "Which platform has reliable customer support?" }),
+    headers: { "content-type": "application/json" },
+  });
+  const runRes = await app.request(`/business-profiles/${profile.id}/monitoring/runs`, {
+    method: "POST",
+    body: JSON.stringify({ providers: ["openai", "anthropic", "gemini"] }),
+    headers: { "content-type": "application/json" },
+  });
+  expect(runRes.status).toBe(200);
+
+  const alertsRes = await app.request(`/business-profiles/${profile.id}/accuracy-alerts`);
+  const alertsBody = await alertsRes.json();
+  expect(alertsBody.alerts).toHaveLength(1);
+  expect(alertsBody.alerts[0].severity).toBe("medium");
+  expect(alertsBody.alerts[0].expectedValue).toBe("24/7 phone support");
+  expect(alertsBody.delivery.inApp).toBeTrue();
+
+  const acknowledgeRes = await app.request(
+    `/business-profiles/${profile.id}/accuracy-alerts/${alertsBody.alerts[0].id}/acknowledge`,
+    { method: "PUT" },
+  );
+  expect(acknowledgeRes.status).toBe(200);
+  expect((await acknowledgeRes.json()).status).toBe("acknowledged");
+});
+
+test("keeps fact sheets isolated between duplicate profile names", async () => {
+  const name = `Fact Duplicate ${crypto.randomUUID()}`;
+  const first = businessProfiles.create({
+    name,
+    website: "https://fact-first.test",
+    description: "First fact profile.",
+  });
+  const second = businessProfiles.create({
+    name,
+    website: "https://fact-second.test",
+    description: "Second fact profile.",
+  });
+  const createFactRes = await app.request(`/business-profiles/${first.id}/facts`, {
+    method: "POST",
+    body: JSON.stringify({ category: "pricing", label: "starting price", value: "$49" }),
+    headers: { "content-type": "application/json" },
+  });
+  const fact = await createFactRes.json();
+
+  expect((await (await app.request(`/business-profiles/${first.id}/facts`)).json()).facts).toHaveLength(1);
+  expect((await (await app.request(`/business-profiles/${second.id}/facts`)).json()).facts).toEqual([]);
+
+  const updateRes = await app.request(`/business-profiles/${first.id}/facts/${fact.id}`, {
+    method: "PUT",
+    body: JSON.stringify({ category: "pricing", label: "starting price", value: "$59", active: false }),
+    headers: { "content-type": "application/json" },
+  });
+  expect((await updateRes.json()).active).toBeFalse();
+
+  const deleteRes = await app.request(`/business-profiles/${first.id}/facts/${fact.id}`, { method: "DELETE" });
+  expect(deleteRes.status).toBe(204);
+  expect((await (await app.request(`/business-profiles/${first.id}/facts`)).json()).facts).toEqual([]);
+});
+
 test("keeps recommendation feedback isolated for duplicate profile names", async () => {
   const name = `Duplicate ${crypto.randomUUID()}`;
   const firstProfile = businessProfiles.create({

--- a/server/src/routes/business.ts
+++ b/server/src/routes/business.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
+import { accuracyGuard } from "../db/accuracy-guard";
 import { businessProfiles } from "../db/business-profiles";
 import { monitoringPrompts } from "../db/monitoring-prompts";
 import { recommendationFeedback } from "../db/recommendation-feedback";
@@ -75,6 +76,16 @@ const recommendationFeedbackSchema = z.object({
   rating: z.enum(["good", "bad"]),
 });
 
+const factSchema = z.object({
+  category: z.enum(["pricing", "feature", "executive", "company", "custom"]),
+  label: z.string().trim().min(2),
+  value: z.string().trim().min(1),
+});
+
+const factUpdateSchema = factSchema.extend({
+  active: z.boolean(),
+});
+
 businessRoutes.get("/business-profiles/:id/monitoring", (c) => {
   const id = c.req.param("id");
   if (!businessProfiles.get(id)) {
@@ -119,6 +130,64 @@ businessRoutes.post("/business-profiles/:id/monitoring-prompts", async (c) => {
   }
   const body = promptSchema.parse(await c.req.json());
   return c.json(monitoringPrompts.add(id, body.prompt), 201);
+});
+
+businessRoutes.get("/business-profiles/:id/facts", (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  return c.json({ facts: accuracyGuard.facts(id) });
+});
+
+businessRoutes.post("/business-profiles/:id/facts", async (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  return c.json(accuracyGuard.createFact(id, factSchema.parse(await c.req.json())), 201);
+});
+
+businessRoutes.put("/business-profiles/:id/facts/:factId", async (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  const fact = accuracyGuard.updateFact(id, c.req.param("factId"), factUpdateSchema.parse(await c.req.json()));
+  return fact ? c.json(fact) : c.json({ error: "Fact not found." }, 404);
+});
+
+businessRoutes.delete("/business-profiles/:id/facts/:factId", (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  accuracyGuard.deleteFact(id, c.req.param("factId"));
+  return c.body(null, 204);
+});
+
+businessRoutes.get("/business-profiles/:id/accuracy-alerts", (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  return c.json({
+    alerts: accuracyGuard.alerts(id),
+    delivery: {
+      inApp: true,
+      emailConfigured: Boolean(process.env.ACCURACY_ALERT_EMAIL_WEBHOOK),
+      slackConfigured: Boolean(process.env.ACCURACY_ALERT_SLACK_WEBHOOK),
+    },
+  });
+});
+
+businessRoutes.put("/business-profiles/:id/accuracy-alerts/:alertId/acknowledge", (c) => {
+  const id = c.req.param("id");
+  if (!businessProfiles.get(id)) {
+    return c.json({ error: "Business profile not found." }, 404);
+  }
+  const alert = accuracyGuard.acknowledge(id, c.req.param("alertId"));
+  return alert ? c.json(alert) : c.json({ error: "Open alert not found." }, 404);
 });
 
 businessRoutes.get("/business-profiles/:id/recommendation-feedback", (c) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import "./app.css";
 import { API_BASE } from "./api";
+import { AccuracyPage } from "./pages/accuracy";
 import { AdminPage } from "./pages/admin";
 import { CompetitivePage } from "./pages/competitive";
 import { MonitoringPage } from "./pages/monitoring";
@@ -59,6 +60,7 @@ type BusinessProfileInput = Pick<BusinessProfile, "name" | "website" | "descript
 
 const navItems = [
   { key: "monitoring", label: "Monitoring", description: "AI mention frequency, sentiment, and trends." },
+  { key: "accuracy", label: "Accuracy Guard", description: "Ground truth and AI misinformation alerts." },
   { key: "benchmarking", label: "Benchmarking", description: "Compare your brand against competitors in AI answers." },
   { key: "recommendations", label: "Recommendations", description: "Prioritized fix-it ideas from detected gaps." },
   { key: "sources", label: "Sources", description: "Reddit, publications, reviews, and other sources AI cites." },
@@ -210,6 +212,8 @@ export function ProfileDashboard({
 
         {activePage === "monitoring" ? (
           <MonitoringPage profile={profile} />
+        ) : activePage === "accuracy" ? (
+          <AccuracyPage profile={profile} />
         ) : activePage === "recommendations" ? (
           <RecommendationsPage profile={profile} />
         ) : activePage === "sources" ? (

--- a/web/src/pages/accuracy.tsx
+++ b/web/src/pages/accuracy.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from "react";
+import { API_BASE } from "../api";
+import type { AccuracyAlert, BrandFact, BusinessProfile, FactCategory } from "../types";
+
+const emptyFact = { category: "custom" as FactCategory, label: "", value: "" };
+
+function FactEditor({
+  fact,
+  onChanged,
+}: {
+  fact: BrandFact;
+  onChanged: () => Promise<void>;
+}) {
+  const [draft, setDraft] = useState(fact);
+
+  async function save() {
+    const res = await fetch(`${API_BASE}/business-profiles/${fact.businessProfileId}/facts/${fact.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        category: draft.category,
+        label: draft.label,
+        value: draft.value,
+        active: draft.active,
+      }),
+    });
+    if (res.ok) await onChanged();
+  }
+
+  async function remove() {
+    const res = await fetch(`${API_BASE}/business-profiles/${fact.businessProfileId}/facts/${fact.id}`, {
+      method: "DELETE",
+    });
+    if (res.ok) await onChanged();
+  }
+
+  return (
+    <tr>
+      <td>
+        <select
+          value={draft.category}
+          onChange={(event) => setDraft({ ...draft, category: event.target.value as FactCategory })}
+        >
+          <option value="pricing">Pricing</option>
+          <option value="feature">Feature</option>
+          <option value="executive">Executive</option>
+          <option value="company">Company</option>
+          <option value="custom">Custom</option>
+        </select>
+      </td>
+      <td><input value={draft.label} onChange={(event) => setDraft({ ...draft, label: event.target.value })} /></td>
+      <td><input value={draft.value} onChange={(event) => setDraft({ ...draft, value: event.target.value })} /></td>
+      <td>
+        <button type="button" onClick={() => setDraft({ ...draft, active: !draft.active })}>
+          {draft.active ? "Active" : "Inactive"}
+        </button>
+        <button type="button" onClick={save}>Save</button>
+        <button type="button" onClick={remove}>Delete</button>
+      </td>
+    </tr>
+  );
+}
+
+export function AccuracyPage({ profile }: { profile: BusinessProfile }) {
+  const [facts, setFacts] = useState<BrandFact[]>([]);
+  const [alerts, setAlerts] = useState<AccuracyAlert[]>([]);
+  const [delivery, setDelivery] = useState({ inApp: true, emailConfigured: false, slackConfigured: false });
+  const [form, setForm] = useState(emptyFact);
+  const [error, setError] = useState("");
+
+  async function load() {
+    const [factRes, alertRes] = await Promise.all([
+      fetch(`${API_BASE}/business-profiles/${profile.id}/facts`),
+      fetch(`${API_BASE}/business-profiles/${profile.id}/accuracy-alerts`),
+    ]);
+    if (!factRes.ok || !alertRes.ok) throw new Error("Could not load Accuracy Guard.");
+    const factBody = await factRes.json();
+    const alertBody = await alertRes.json();
+    setFacts(factBody.facts);
+    setAlerts(alertBody.alerts);
+    setDelivery(alertBody.delivery);
+  }
+
+  useEffect(() => {
+    setError("");
+    load().catch((err) => setError(err instanceof Error ? err.message : "Could not load Accuracy Guard."));
+  }, [profile.id]);
+
+  async function addFact() {
+    const res = await fetch(`${API_BASE}/business-profiles/${profile.id}/facts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(form),
+    });
+    if (!res.ok) {
+      setError("Could not save ground-truth fact.");
+      return;
+    }
+    setForm(emptyFact);
+    await load();
+  }
+
+  async function acknowledge(alertId: string) {
+    const res = await fetch(`${API_BASE}/business-profiles/${profile.id}/accuracy-alerts/${alertId}/acknowledge`, {
+      method: "PUT",
+    });
+    if (res.ok) await load();
+  }
+
+  return (
+    <div className="block">
+      <div className="stat-row">
+        <div className="stat">
+          <div className="stat__label">Open alerts</div>
+          <div className="stat__value">{alerts.filter((alert) => alert.status === "open").length}</div>
+        </div>
+        <div className="stat">
+          <div className="stat__label">Ground-truth facts</div>
+          <div className="stat__value">{facts.filter((fact) => fact.active).length}</div>
+        </div>
+        <div className="stat">
+          <div className="stat__label">Delivery</div>
+          <div className="stat__value">
+            In-app{delivery.emailConfigured ? " + email" : ""}{delivery.slackConfigured ? " + Slack" : ""}
+          </div>
+        </div>
+      </div>
+
+      <article className="card wide-panel">
+        <h2>Brand fact sheet</h2>
+        <p className="muted">Responses that discuss a fact but conflict with its configured value create an alert.</p>
+        <div className="inline-form">
+          <select
+            value={form.category}
+            onChange={(event) => setForm({ ...form, category: event.target.value as FactCategory })}
+          >
+            <option value="pricing">Pricing</option>
+            <option value="feature">Feature</option>
+            <option value="executive">Executive</option>
+            <option value="company">Company</option>
+            <option value="custom">Custom</option>
+          </select>
+          <input
+            placeholder="Claim label, e.g. starting price"
+            value={form.label}
+            onChange={(event) => setForm({ ...form, label: event.target.value })}
+          />
+          <input
+            placeholder="Ground-truth value"
+            value={form.value}
+            onChange={(event) => setForm({ ...form, value: event.target.value })}
+          />
+          <button type="button" disabled={!form.label.trim() || !form.value.trim()} onClick={addFact}>Add fact</button>
+        </div>
+        <table>
+          <thead><tr><th>Category</th><th>Claim</th><th>Ground truth</th><th>Actions</th></tr></thead>
+          <tbody>
+            {facts.map((fact) => (
+              <FactEditor key={fact.id} fact={fact} onChanged={load} />
+            ))}
+          </tbody>
+        </table>
+      </article>
+
+      <article className="card wide-panel">
+        <h2>Accuracy alerts</h2>
+        {alerts.length === 0 ? <p className="muted">No discrepancies detected yet.</p> : (
+          <table>
+            <thead><tr><th>Severity</th><th>Observed claim</th><th>Expected</th><th>Status</th></tr></thead>
+            <tbody>
+              {alerts.map((alert) => (
+                <tr key={alert.id}>
+                  <td>{alert.severity}</td>
+                  <td>{alert.observedClaim}</td>
+                  <td>{alert.expectedValue}</td>
+                  <td>
+                    {alert.status === "open" ? (
+                      <button type="button" onClick={() => acknowledge(alert.id)}>Acknowledge</button>
+                    ) : "Acknowledged"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </article>
+      {error && <p className="error">{error}</p>}
+    </div>
+  );
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -62,6 +62,33 @@ export interface MonitoringSummary {
   latestAttempts: MonitoringAttempt[];
 }
 
+export type FactCategory = "pricing" | "feature" | "executive" | "company" | "custom";
+
+export interface BrandFact {
+  id: string;
+  businessProfileId: string;
+  category: FactCategory;
+  label: string;
+  value: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AccuracyAlert {
+  id: string;
+  businessProfileId: string;
+  monitoringAttemptId: string;
+  brandFactId: string;
+  severity: "high" | "medium" | "low";
+  status: "open" | "acknowledged";
+  observedClaim: string;
+  expectedValue: string;
+  explanation: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export type RecommendationRating = "good" | "bad";
 
 export interface RecommendationFeedback {


### PR DESCRIPTION
## Summary
- add profile-scoped ground-truth fact CRUD for pricing, features, executives, company details, and custom claims
- evaluate every successful monitoring response against active facts
- persist and deduplicate discrepancy alerts with severity, evidence, expected values, and acknowledgement status
- add an Accuracy Guard dashboard with editable facts and in-app alert triage
- expose email and Slack delivery configuration state without claiming unconfigured delivery

## Tracking
Closes #39

## Dependency
Stacked on #37 because Accuracy Guard consumes its persisted multi-provider monitoring attempts. After #37 merges, this PR can target `main`.

## Verification
- `bun test` (32 passing)
- `bun run build:web`