### PR TITLE
Dashboard: shadcn migration, server-backed data, and UI fixes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState } from "react";
 import "./app.css";
 import { API_BASE } from "./api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { NativeSelect } from "@/components/ui/native-select";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
 import { AccuracyPage } from "./pages/accuracy";
 import { AdminPage } from "./pages/admin";
 import { CompetitivePage } from "./pages/competitive";
@@ -8,6 +16,18 @@ import { MonitoringPage } from "./pages/monitoring";
 import { RecommendationsPage } from "./pages/recommendations";
 import { SourcesPage } from "./pages/sources";
 import type { BusinessProfile, BusinessProfileInput } from "./types";
+import {
+  BinocularsIcon,
+  BuildingsIcon,
+  ChartLineUpIcon,
+  CheckCircleIcon,
+  GearSixIcon,
+  LightbulbIcon,
+  LinkSimpleIcon,
+  PlusIcon,
+  ShieldCheckIcon,
+  TrophyIcon,
+} from "./components/app-icons";
 import logoUrl from "../../assets/logo.svg";
 
 export function OnboardingForm({ onCreate }: { onCreate: (input: BusinessProfileInput) => void }) {
@@ -27,7 +47,7 @@ export function OnboardingForm({ onCreate }: { onCreate: (input: BusinessProfile
 
   return (
     <form
-      className="onboarding"
+      className="w-full max-w-xl"
       onSubmit={(event) => {
         event.preventDefault();
         if (canSubmit) {
@@ -40,53 +60,100 @@ export function OnboardingForm({ onCreate }: { onCreate: (input: BusinessProfile
         }
       }}
     >
-      <h1>Set up your brand</h1>
-      <p className="muted">
-        We&rsquo;ll generate starter monitoring prompts and a competitive set from your website and brand
-        description.
-      </p>
-      <label>
-        Business name
-        <input value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} />
-      </label>
-      <label>
-        Website
-        <input
-          type="url"
-          value={form.website}
-          onChange={(event) => setForm({ ...form, website: event.target.value })}
-        />
-      </label>
-      <label>
-        Description
-        <textarea
-          value={form.description}
-          onChange={(event) => setForm({ ...form, description: event.target.value })}
-          rows={4}
-        />
-      </label>
-      <label>
-        Top 5 competitors (one per line)
-        <textarea
-          value={form.competitors}
-          onChange={(event) => setForm({ ...form, competitors: event.target.value })}
-          rows={5}
-        />
-      </label>
-      <button type="submit" disabled={!canSubmit}>
-        Create profile
-      </button>
+      <Card className="border-border/70 bg-card/95 shadow-sm">
+        <CardHeader>
+          <Badge className="mb-2 w-fit" variant="secondary">
+            <SparkleDot /> Brand setup
+          </Badge>
+          <CardTitle className="text-2xl">Set up your brand</CardTitle>
+          <CardDescription>
+            We&rsquo;ll generate starter monitoring prompts and a competitive set from your website and brand
+            description.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          <div className="grid gap-2">
+            <Label htmlFor="business-name">Business name</Label>
+            <Input
+              id="business-name"
+              value={form.name}
+              onChange={(event) => setForm({ ...form, name: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="business-website">Website</Label>
+            <Input
+              id="business-website"
+              type="url"
+              value={form.website}
+              onChange={(event) => setForm({ ...form, website: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="business-description">Description</Label>
+            <Textarea
+              id="business-description"
+              value={form.description}
+              onChange={(event) => setForm({ ...form, description: event.target.value })}
+              rows={4}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="business-competitors">Top 5 competitors (one per line)</Label>
+            <Textarea
+              id="business-competitors"
+              value={form.competitors}
+              onChange={(event) => setForm({ ...form, competitors: event.target.value })}
+              rows={5}
+            />
+          </div>
+          <Button type="submit" disabled={!canSubmit} className="w-fit">
+            <CheckCircleIcon data-icon="inline-start" />
+            Create profile
+          </Button>
+        </CardContent>
+      </Card>
     </form>
   );
 }
 
 const navItems = [
-  { key: "monitoring", label: "Monitoring", description: "AI mention frequency, sentiment, and trends." },
-  { key: "accuracy", label: "Citation Grounding", description: "Claim-level source coverage and unsupported-claim alerts." },
-  { key: "benchmarking", label: "Benchmarking", description: "Compare your brand against competitors in AI answers." },
-  { key: "recommendations", label: "Recommendations", description: "Prioritized fix-it ideas from detected gaps." },
-  { key: "sources", label: "Sources", description: "Reddit, publications, reviews, and other sources AI cites." },
-  { key: "admin", label: "Admin", description: "Internal feedback quality metrics and system health." },
+  {
+    key: "monitoring",
+    label: "Monitoring",
+    description: "AI mention frequency, sentiment, and trends.",
+    icon: ChartLineUpIcon,
+  },
+  {
+    key: "accuracy",
+    label: "Citation Grounding",
+    description: "Claim-level source coverage and unsupported-claim alerts.",
+    icon: ShieldCheckIcon,
+  },
+  {
+    key: "benchmarking",
+    label: "Benchmarking",
+    description: "Compare your brand against competitors in AI answers.",
+    icon: TrophyIcon,
+  },
+  {
+    key: "recommendations",
+    label: "Recommendations",
+    description: "Prioritized fix-it ideas from detected gaps.",
+    icon: LightbulbIcon,
+  },
+  {
+    key: "sources",
+    label: "Sources",
+    description: "Reddit, publications, reviews, and other sources AI cites.",
+    icon: LinkSimpleIcon,
+  },
+  {
+    key: "admin",
+    label: "Admin",
+    description: "Internal feedback quality metrics and system health.",
+    icon: GearSixIcon,
+  },
 ] as const;
 
 type PageKey = (typeof navItems)[number]["key"];
@@ -177,78 +244,106 @@ export function ProfileDashboard({
   const activeNav = navItems.find((item) => item.key === activePage) ?? navItems[0];
 
   return (
-    <main className="app-shell">
-      <aside className="sidebar" aria-label="Primary navigation">
-        <div className="brand-lockup">
-          <img className="brand-mark" src={logoUrl} alt="" aria-hidden="true" />
-          <div className="brand-lockup__text">
-            <strong>Perception</strong>
-            <span>AI visibility</span>
+    <main className="min-h-screen bg-background text-foreground lg:grid lg:grid-cols-[260px_1fr]">
+      <aside className="sticky top-0 flex h-screen flex-col border-r border-border/70 bg-sidebar px-3 py-4 text-sidebar-foreground" aria-label="Primary navigation">
+        <div className="flex items-center gap-3 px-2 pb-4">
+          <div className="flex size-9 items-center justify-center rounded-2xl bg-background ring-1 ring-border/70">
+            <img className="size-6 object-contain" src={logoUrl} alt="" aria-hidden="true" />
+          </div>
+          <div className="grid leading-tight">
+            <strong className="text-sm font-semibold tracking-tight">Perception</strong>
+            <span className="text-xs text-muted-foreground">AI visibility</span>
           </div>
         </div>
 
-        <nav className="nav-list" aria-label="Sections">
-          {navItems.map((item) => (
-            <button
-              key={item.key}
-              type="button"
-              className={activePage === item.key ? "nav-item active" : "nav-item"}
-              onClick={() => onSelectPage(item.key)}
-            >
-              {item.label}
-            </button>
-          ))}
+        <Separator className="mb-3" />
+
+        <nav className="grid gap-1" aria-label="Sections">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const active = activePage === item.key;
+            return (
+              <Button
+                key={item.key}
+                type="button"
+                variant={active ? "secondary" : "ghost"}
+                className="h-auto justify-start gap-3 rounded-2xl px-3 py-2 text-left"
+                aria-current={active ? "page" : undefined}
+                onClick={() => onSelectPage(item.key)}
+              >
+                <Icon className="size-4 text-muted-foreground" data-icon="inline-start" />
+                <span className="grid">
+                  <span>{item.label}</span>
+                  <span className="line-clamp-1 text-xs font-normal text-muted-foreground">{item.description}</span>
+                </span>
+              </Button>
+            );
+          })}
         </nav>
 
-        <div className="sidebar-footer">
-          <span className="sidebar-footer__label">Active brand</span>
-          <select
-            className="sidebar-profile"
-            aria-label="Active business profile"
-            value={profile.id}
-            onChange={(event) => onSelectProfile(event.target.value)}
-          >
-            {profiles.map((item) => (
-              <option key={item.id} value={item.id}>
-                {item.name}
-              </option>
-            ))}
-          </select>
-          <button type="button" className="sidebar-add" onClick={onAddProfile}>
-            + Add brand
-          </button>
-        </div>
+        <Card className="mt-auto border-border/70 bg-background/80 shadow-none" size="sm">
+          <CardHeader>
+            <CardDescription className="flex items-center gap-2">
+              <BuildingsIcon className="size-4" /> Active brand
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-2">
+            <NativeSelect
+              aria-label="Active business profile"
+              className="w-full"
+              value={profile.id}
+              onChange={(event) => onSelectProfile(event.target.value)}
+            >
+              {profiles.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.name}
+                </option>
+              ))}
+            </NativeSelect>
+            <Button type="button" variant="outline" onClick={onAddProfile}>
+              <PlusIcon data-icon="inline-start" />
+              Add brand
+            </Button>
+          </CardContent>
+        </Card>
       </aside>
 
-      <section className="workspace">
-        <header className="topbar">
-          <div>
-            <p className="topbar__eyebrow">
-              <span className="topbar__brand">{profile.name}</span>
-            </p>
-            <h1>{activeNav.label}</h1>
-            <p className="topbar__sub">{activeNav.description}</p>
-          </div>
-        </header>
+      <section className="min-w-0 bg-background px-5 py-6 md:px-8 lg:px-10">
+        <div className="mx-auto grid w-full max-w-7xl gap-6">
+          <header className="flex flex-wrap items-start justify-between gap-4 border-b border-border/70 pb-5">
+            <div>
+              <Badge variant="outline" className="mb-3">
+                <BinocularsIcon data-icon="inline-start" />
+                {profile.name}
+              </Badge>
+              <h1 className="text-3xl font-semibold tracking-tight">{activeNav.label}</h1>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{activeNav.description}</p>
+            </div>
+          </header>
 
-        <section hidden={activePage !== "benchmarking"}>
-          <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
-        </section>
+          <section hidden={activePage !== "benchmarking"}>
+            <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
+          </section>
 
-        {activePage === "monitoring" ? (
-          <MonitoringPage profile={profile} />
-        ) : activePage === "accuracy" ? (
-          <AccuracyPage profile={profile} />
-        ) : activePage === "recommendations" ? (
-          <RecommendationsPage profile={profile} />
-        ) : activePage === "sources" ? (
-          <SourcesPage profile={profile} />
-        ) : activePage === "admin" ? (
-          <AdminPage profile={profile} />
-        ) : null}
+          {activePage === "monitoring" ? (
+            <MonitoringPage profile={profile} />
+          ) : activePage === "accuracy" ? (
+            <AccuracyPage profile={profile} />
+          ) : activePage === "recommendations" ? (
+            <RecommendationsPage profile={profile} />
+          ) : activePage === "sources" ? (
+            <SourcesPage profile={profile} />
+          ) : activePage === "admin" ? (
+            <AdminPage profile={profile} />
+          ) : null}
 
-        {error && <p className="error">{error}</p>}
+          {error && <p className="error">{error}</p>}
+        </div>
       </section>
     </main>
   );
+}
+
+function SparkleDot() {
+  return <span className="size-1.5 rounded-full bg-primary" aria-hidden="true" />;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,19 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { NativeSelect } from "@/components/ui/native-select";
-import { Separator } from "@/components/ui/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+} from "@/components/ui/sidebar";
 import { Textarea } from "@/components/ui/textarea";
 import { AccuracyPage } from "./pages/accuracy";
 import { AdminPage } from "./pages/admin";
@@ -244,50 +256,54 @@ export function ProfileDashboard({
   const activeNav = navItems.find((item) => item.key === activePage) ?? navItems[0];
 
   return (
-    <main className="min-h-screen bg-background text-foreground lg:grid lg:grid-cols-[260px_1fr]">
-      <aside className="sticky top-0 flex h-screen flex-col border-r border-border/70 bg-sidebar px-3 py-4 text-sidebar-foreground" aria-label="Primary navigation">
-        <div className="flex items-center gap-3 px-2 pb-4">
-          <div className="flex size-9 items-center justify-center rounded-2xl bg-background ring-1 ring-border/70">
-            <img className="size-6 object-contain" src={logoUrl} alt="" aria-hidden="true" />
+    <SidebarProvider>
+      <Sidebar collapsible="none" className="sticky top-0 h-svh border-r">
+        <SidebarHeader>
+          <div className="flex items-center gap-2.5 px-1 py-1">
+            <div className="flex size-8 shrink-0 items-center justify-center rounded-xl bg-background ring-1 ring-border">
+              <img className="size-5 object-contain" src={logoUrl} alt="" aria-hidden="true" />
+            </div>
+            <div className="grid leading-tight">
+              <span className="text-sm font-semibold tracking-tight">Perception</span>
+              <span className="text-xs text-muted-foreground">AI visibility</span>
+            </div>
           </div>
-          <div className="grid leading-tight">
-            <strong className="text-sm font-semibold tracking-tight">Perception</strong>
-            <span className="text-xs text-muted-foreground">AI visibility</span>
-          </div>
-        </div>
+        </SidebarHeader>
 
-        <Separator className="mb-3" />
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {navItems.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <SidebarMenuItem key={item.key}>
+                      <SidebarMenuButton
+                        isActive={activePage === item.key}
+                        onClick={() => onSelectPage(item.key)}
+                        className="h-auto items-start gap-3 py-2 whitespace-normal"
+                      >
+                        <Icon className="mt-0.5" />
+                        <div className="grid gap-0.5">
+                          <span className="font-medium">{item.label}</span>
+                          <span className="text-xs leading-snug font-normal whitespace-normal text-muted-foreground">
+                            {item.description}
+                          </span>
+                        </div>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
 
-        <nav className="grid gap-1" aria-label="Sections">
-          {navItems.map((item) => {
-            const Icon = item.icon;
-            const active = activePage === item.key;
-            return (
-              <Button
-                key={item.key}
-                type="button"
-                variant={active ? "secondary" : "ghost"}
-                className="h-auto justify-start gap-3 rounded-2xl px-3 py-2 text-left"
-                aria-current={active ? "page" : undefined}
-                onClick={() => onSelectPage(item.key)}
-              >
-                <Icon className="size-4 text-muted-foreground" data-icon="inline-start" />
-                <span className="grid">
-                  <span>{item.label}</span>
-                  <span className="line-clamp-1 text-xs font-normal text-muted-foreground">{item.description}</span>
-                </span>
-              </Button>
-            );
-          })}
-        </nav>
-
-        <Card className="mt-auto border-border/70 bg-background/80 shadow-none" size="sm">
-          <CardHeader>
-            <CardDescription className="flex items-center gap-2">
-              <BuildingsIcon className="size-4" /> Active brand
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-2">
+        <SidebarFooter>
+          <div className="grid gap-2">
+            <Label className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground">
+              <BuildingsIcon className="size-3.5" /> Active brand
+            </Label>
             <NativeSelect
               aria-label="Active business profile"
               className="w-full"
@@ -300,28 +316,26 @@ export function ProfileDashboard({
                 </option>
               ))}
             </NativeSelect>
-            <Button type="button" variant="outline" onClick={onAddProfile}>
+            <Button type="button" variant="outline" size="sm" onClick={onAddProfile}>
               <PlusIcon data-icon="inline-start" />
               Add brand
             </Button>
-          </CardContent>
-        </Card>
-      </aside>
+          </div>
+        </SidebarFooter>
+      </Sidebar>
 
-      <section className="min-w-0 bg-background px-5 py-6 md:px-8 lg:px-10">
-        <div className="mx-auto grid w-full max-w-7xl gap-6">
-          <header className="flex flex-wrap items-start justify-between gap-4 border-b border-border/70 pb-5">
-            <div>
-              <Badge variant="outline" className="mb-3">
-                <BinocularsIcon data-icon="inline-start" />
-                {profile.name}
-              </Badge>
-              <h1 className="text-3xl font-semibold tracking-tight">{activeNav.label}</h1>
-              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{activeNav.description}</p>
-            </div>
-          </header>
+      <SidebarInset>
+        <header className="sticky top-0 z-10 border-b bg-background/95 px-4 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:px-6">
+          <Badge variant="outline" className="mb-2">
+            <BinocularsIcon data-icon="inline-start" />
+            {profile.name}
+          </Badge>
+          <h1 className="text-2xl font-semibold tracking-tight">{activeNav.label}</h1>
+          <p className="mt-1.5 max-w-2xl text-sm text-muted-foreground">{activeNav.description}</p>
+        </header>
 
-          <section hidden={activePage !== "benchmarking"}>
+        <div className="mx-auto grid w-full max-w-6xl gap-6 px-4 py-6 md:px-6">
+          <section hidden={activePage !== "benchmarking"} className="grid gap-6">
             <CompetitivePage businessName={profile.name} businessProfileId={profile.id} />
           </section>
 
@@ -339,8 +353,8 @@ export function ProfileDashboard({
 
           {error && <p className="error">{error}</p>}
         </div>
-      </section>
-    </main>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -7,6 +7,7 @@
 @source "./main.tsx";
 @source "./pages";
 @source "./components/app-icons.tsx";
+@source "./components/dashboard.tsx";
 @source "./components/competitive";
 @source "./components/ui/badge.tsx";
 @source "./components/ui/button.tsx";
@@ -16,6 +17,7 @@
 @source "./components/ui/native-select.tsx";
 @source "./components/ui/progress.tsx";
 @source "./components/ui/separator.tsx";
+@source "./components/ui/sidebar.tsx";
 @source "./components/ui/table.tsx";
 @source "./components/ui/textarea.tsx";
 @source "./components/ui/tooltip.tsx";
@@ -110,8 +112,6 @@ body {
   margin: 0;
   font-size: 14px;
   line-height: 1.55;
-  color: var(--ink);
-  background: var(--surface);
 }
 
 button,
@@ -119,87 +119,15 @@ select,
 input,
 textarea { font: inherit; }
 
-.page,
-.app-shell { min-height: 100vh; }
-
 .center-page {
   display: grid;
   place-items: center;
+  min-height: 100vh;
   padding: 28px;
   background: var(--surface-2);
 }
 
-/* ---------- Onboarding ---------- */
-.onboarding {
-  display: grid;
-  gap: 14px;
-  width: min(520px, 100%);
-  padding: 28px;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 12px;
-}
-.onboarding h1 {
-  margin: 0 0 4px;
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.018em;
-  color: var(--ink);
-}
-
-label {
-  display: grid;
-  gap: 5px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--ink-3);
-  letter-spacing: 0;
-  text-transform: none;
-}
-
-input,
-select,
-textarea {
-  width: 100%;
-  border: 1px solid var(--line-strong);
-  border-radius: 6px;
-  padding: 8px 11px;
-  background: var(--surface);
-  font-family: var(--font-body);
-  font-size: 13.5px;
-  font-weight: 400;
-  color: var(--ink);
-  letter-spacing: 0;
-  text-transform: none;
-  transition: border-color 120ms ease, box-shadow 120ms ease;
-}
-input:hover, select:hover, textarea:hover { border-color: var(--ink-3); }
-input:focus, select:focus, textarea:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-glow);
-}
-
-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  border: 0;
-  border-radius: 6px;
-  padding: 8px 14px;
-  color: white;
-  background: var(--ink);
-  cursor: pointer;
-  font-family: var(--font-body);
-  font-weight: 500;
-  font-size: 13.5px;
-  letter-spacing: -0.005em;
-  transition: background 140ms ease, opacity 140ms ease;
-}
-button:hover { background: var(--accent); }
-button:disabled { cursor: not-allowed; opacity: 0.45; }
-
-/* ---------- Shell ---------- */
+/* ---------- Shell (legacy, retained for reference) ---------- */
 .app-shell {
   display: grid;
   grid-template-columns: 232px 1fr;
@@ -414,22 +342,6 @@ button:disabled { cursor: not-allowed; opacity: 0.45; }
 dl { display: grid; gap: 12px; margin: 0; }
 dd { margin: 4px 0 0; font-size: 13.5px; color: var(--ink); }
 dt {
-  color: var(--muted-foreground);
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0;
-  text-transform: none;
-}
-
-table { width: 100%; border-collapse: collapse; font-size: 13.5px; }
-th, td {
-  padding: 10px 12px 10px 0;
-  text-align: left;
-  border-bottom: 1px solid var(--line);
-  vertical-align: middle;
-}
-tr:last-child td { border-bottom: none; }
-th {
   color: var(--muted-foreground);
   font-size: 12px;
   font-weight: 500;
@@ -682,7 +594,7 @@ th {
   line-height: 1.6;
 }
 .bullet-list li + li { margin-top: 6px; }
-.bullet-list em { font-style: italic; color: var(--accent); font-weight: 600; }
+.bullet-list em { font-style: normal; color: var(--foreground); font-weight: 600; }
 
 .stat-row {
   display: grid;
@@ -845,7 +757,7 @@ th {
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--accent);
+  color: var(--primary);
   margin-bottom: 4px;
 }
 .theater__title {
@@ -969,13 +881,8 @@ th {
   gap: 10px;
 }
 .trend-grid__brand {
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 12px 14px;
-  background: var(--surface);
-  transition: border-color 160ms ease;
+  padding: 0;
 }
-.trend-grid__brand:hover { border-color: var(--line-strong); }
 .trend-grid__name {
   font-weight: 600;
   font-size: 12.5px;
@@ -1045,8 +952,8 @@ th {
 }
 
 ::selection {
-  background: var(--accent-soft);
-  color: var(--accent);
+  background: var(--primary);
+  color: var(--primary-foreground);
 }
 
 @media (max-width: 720px) {
@@ -1085,7 +992,7 @@ th {
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted-foreground);
+  --color-muted: var(--muted);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -3,7 +3,22 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/figtree";
 @source "../index.html";
-@source "./";
+@source "./App.tsx";
+@source "./main.tsx";
+@source "./pages";
+@source "./components/app-icons.tsx";
+@source "./components/competitive";
+@source "./components/ui/badge.tsx";
+@source "./components/ui/button.tsx";
+@source "./components/ui/card.tsx";
+@source "./components/ui/input.tsx";
+@source "./components/ui/label.tsx";
+@source "./components/ui/native-select.tsx";
+@source "./components/ui/progress.tsx";
+@source "./components/ui/separator.tsx";
+@source "./components/ui/table.tsx";
+@source "./components/ui/textarea.tsx";
+@source "./components/ui/tooltip.tsx";
 /*
  ---break---
  */
@@ -223,7 +238,7 @@ button:disabled { cursor: not-allowed; opacity: 0.45; }
   font-size: 11px;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-weight: 400;
 }
 .brand-mark {
@@ -273,7 +288,7 @@ button:disabled { cursor: not-allowed; opacity: 0.45; }
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--muted);
+  color: var(--muted-foreground);
   margin-bottom: 1px;
 }
 .sidebar-profile {
@@ -329,7 +344,7 @@ button:disabled { cursor: not-allowed; opacity: 0.45; }
   font-size: 12px;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-weight: 500;
 }
 .topbar__brand { color: var(--ink); font-weight: 600; }
@@ -345,7 +360,7 @@ button:disabled { cursor: not-allowed; opacity: 0.45; }
 .topbar__sub {
   margin: 6px 0 0;
   font-size: 13.5px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   max-width: 60ch;
   line-height: 1.55;
 }
@@ -388,7 +403,7 @@ button:disabled { cursor: not-allowed; opacity: 0.45; }
 .run-meta > div { display: contents; }
 .run-meta dt {
   margin: 0;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 0;
@@ -399,7 +414,7 @@ button:disabled { cursor: not-allowed; opacity: 0.45; }
 dl { display: grid; gap: 12px; margin: 0; }
 dd { margin: 4px 0 0; font-size: 13.5px; color: var(--ink); }
 dt {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 0;
@@ -415,7 +430,7 @@ th, td {
 }
 tr:last-child td { border-bottom: none; }
 th {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 0;
@@ -437,7 +452,7 @@ th {
   font-size: 11px;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-weight: 500;
 }
 .sentiment-chart { display: block; width: 100%; height: auto; }
@@ -449,7 +464,7 @@ th {
 .trend-dot { stroke: white; stroke-width: 2; }
 .trend-dot-positive { fill: var(--success); }
 .trend-dot-negative { fill: var(--danger); }
-.chart-label, .axis-label { fill: var(--muted); font-size: 11px; }
+.chart-label, .axis-label { fill: var(--muted-foreground); font-size: 11px; }
 
 .sentiment {
   display: inline-block;
@@ -467,7 +482,7 @@ th {
 .inline-form { display: flex; gap: 8px; }
 .inline-form input { flex: 1; }
 
-.muted { color: var(--muted); font-weight: 400; }
+.muted { color: var(--muted-foreground); font-weight: 400; }
 .error {
   color: var(--danger);
   font-size: 13px;
@@ -491,7 +506,7 @@ th {
   font-weight: 600;
   letter-spacing: -0.012em;
 }
-.picker__count { font-size: 12px; color: var(--muted); font-weight: 500; }
+.picker__count { font-size: 12px; color: var(--muted-foreground); font-weight: 500; }
 .picker__hint { margin: -8px 0 4px; font-size: 13px; line-height: 1.55; max-width: 64ch; }
 .picker__field { display: grid; gap: 5px; }
 .picker__field--solo { max-width: 480px; }
@@ -501,7 +516,7 @@ th {
   gap: 7px;
   font-size: 11.5px;
   font-weight: 500;
-  color: var(--muted);
+  color: var(--muted-foreground);
   margin: 0;
   letter-spacing: 0;
   text-transform: none;
@@ -567,7 +582,7 @@ th {
   color: var(--ink);
   border-color: var(--ink-3);
 }
-.picker__status { font-size: 12px; color: var(--muted); }
+.picker__status { font-size: 12px; color: var(--muted-foreground); }
 
 .charts-grid {
   display: grid;
@@ -687,7 +702,7 @@ th {
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
-  color: var(--muted);
+  color: var(--muted-foreground);
   margin-bottom: 4px;
 }
 .stat__value {
@@ -717,7 +732,7 @@ th {
 }
 .rec-item__rank {
   font-weight: 500;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-variant-numeric: tabular-nums;
   margin-right: 6px;
 }
@@ -739,7 +754,7 @@ th {
 .rec-feedback__label {
   font-size: 12px;
   font-weight: 500;
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 .rec-feedback__actions {
   display: flex;
@@ -841,7 +856,7 @@ th {
 }
 .theater__status {
   font-size: 12px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   text-align: right;
   max-width: 36ch;
   font-weight: 400;
@@ -857,7 +872,7 @@ th {
   display: block;
   font-size: 11px;
   font-weight: 500;
-  color: var(--muted);
+  color: var(--muted-foreground);
   margin-bottom: 4px;
   letter-spacing: 0;
   text-transform: none;
@@ -901,7 +916,7 @@ th {
 }
 .theater__col-count {
   font-size: 11px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-variant-numeric: tabular-nums;
 }
 .theater__progress {
@@ -918,7 +933,7 @@ th {
 .theater__col-status {
   margin: 0 0 6px;
   font-size: 11px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   min-height: 1.4em;
 }
 .theater__stream {
@@ -970,7 +985,7 @@ th {
 }
 .trend-mini { width: 100%; border-collapse: collapse; font-size: 11px; }
 .trend-mini td { padding: 2px 6px 2px 0; vertical-align: middle; border: none; }
-.trend-mini__day { color: var(--muted); width: 36px; }
+.trend-mini__day { color: var(--muted-foreground); width: 36px; }
 .trend-mini__bar {
   display: block;
   position: relative;
@@ -1070,7 +1085,7 @@ th {
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
+  --color-muted: var(--muted-foreground);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);

--- a/web/src/components/app-icons.tsx
+++ b/web/src/components/app-icons.tsx
@@ -1,0 +1,71 @@
+import type { SVGProps } from "react";
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+function Icon({ children, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
+      {children}
+    </svg>
+  );
+}
+
+export function CaretDownIcon(props: IconProps) {
+  return <Icon {...props}><path d="m6 9 6 6 6-6" /></Icon>;
+}
+
+export function BinocularsIcon(props: IconProps) {
+  return <Icon {...props}><path d="M7 6h3l1 4" /><path d="M17 6h-3l-1 4" /><path d="M5 11h14" /><circle cx="7" cy="15" r="3" /><circle cx="17" cy="15" r="3" /></Icon>;
+}
+
+export function BuildingsIcon(props: IconProps) {
+  return <Icon {...props}><path d="M4 21V5l8-2v18" /><path d="M12 9h8v12" /><path d="M7 8h2M7 12h2M7 16h2M15 12h2M15 16h2" /></Icon>;
+}
+
+export function ChartLineUpIcon(props: IconProps) {
+  return <Icon {...props}><path d="M4 19h16" /><path d="M5 15l4-4 3 3 7-8" /><path d="M15 6h4v4" /></Icon>;
+}
+
+export function CheckCircleIcon(props: IconProps) {
+  return <Icon {...props}><circle cx="12" cy="12" r="9" /><path d="m8.5 12.5 2.2 2.2 4.8-5.2" /></Icon>;
+}
+
+export function GearSixIcon(props: IconProps) {
+  return <Icon {...props}><circle cx="12" cy="12" r="3" /><path d="M12 2v3M12 19v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M2 12h3M19 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1" /></Icon>;
+}
+
+export function LightbulbIcon(props: IconProps) {
+  return <Icon {...props}><path d="M9 18h6" /><path d="M10 22h4" /><path d="M8 14a6 6 0 1 1 8 0c-.8.7-1 1.5-1 2H9c0-.5-.2-1.3-1-2Z" /></Icon>;
+}
+
+export function LinkSimpleIcon(props: IconProps) {
+  return <Icon {...props}><path d="M10 13a5 5 0 0 0 7.1 0l2-2a5 5 0 0 0-7.1-7.1l-1.1 1.1" /><path d="M14 11a5 5 0 0 0-7.1 0l-2 2a5 5 0 1 0 7.1 7.1l1.1-1.1" /></Icon>;
+}
+
+export function PlusIcon(props: IconProps) {
+  return <Icon {...props}><path d="M12 5v14M5 12h14" /></Icon>;
+}
+
+export function PlusCircleIcon(props: IconProps) {
+  return <Icon {...props}><circle cx="12" cy="12" r="9" /><path d="M12 8v8M8 12h8" /></Icon>;
+}
+
+export function PlayIcon(props: IconProps) {
+  return <Icon {...props}><path d="M8 5v14l11-7-11-7Z" /></Icon>;
+}
+
+export function ShieldCheckIcon(props: IconProps) {
+  return <Icon {...props}><path d="M12 3 5 6v5c0 4.5 2.9 8.4 7 10 4.1-1.6 7-5.5 7-10V6l-7-3Z" /><path d="m8.8 12.2 2 2 4.4-4.6" /></Icon>;
+}
+
+export function ThumbsDownIcon(props: IconProps) {
+  return <Icon {...props}><path d="M7 3v11" /><path d="M7 14H4a2 2 0 0 1-2-2v-1l2-6a3 3 0 0 1 3-2h8.5a2 2 0 0 1 2 1.7l1 6A2 2 0 0 1 16.5 13H14l.5 4a3 3 0 0 1-3 4L7 14Z" /></Icon>;
+}
+
+export function ThumbsUpIcon(props: IconProps) {
+  return <Icon {...props}><path d="M7 21V10" /><path d="M7 10h3l-.5-4a3 3 0 0 1 3-4l4.5 7h3a2 2 0 0 1 2 2v1l-2 6a3 3 0 0 1-3 2H7Z" /></Icon>;
+}
+
+export function TrophyIcon(props: IconProps) {
+  return <Icon {...props}><path d="M8 4h8v5a4 4 0 0 1-8 0V4Z" /><path d="M8 6H5a3 3 0 0 0 3 5" /><path d="M16 6h3a3 3 0 0 1-3 5" /><path d="M12 13v4M9 21h6M8 17h8" /></Icon>;
+}

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Section } from "@/components/dashboard";
 import { PlayIcon, PlusCircleIcon } from "@/components/app-icons";
 
 interface Props {
@@ -36,18 +36,12 @@ export function CompetitiveSetPicker({
   }, [accountBrandName, competitorNames]);
 
   return (
-    <Card className="wide-panel border-border/70">
-      <CardHeader className="gap-2">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <CardTitle>Competitive set</CardTitle>
-          <Badge variant="secondary">5 competitors</Badge>
-        </div>
-        <CardDescription>
-          Pick your brand and five competitors. We&rsquo;ll fan twenty perception prompts across every brand and
-          compare the answers.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="grid gap-5">
+    <Section
+      title="Competitive set"
+      description="Pick your brand and five competitors. We'll fan twenty perception prompts across every brand and compare the answers."
+      action={<Badge variant="secondary">5 competitors</Badge>}
+    >
+      <div className="grid gap-5">
         <div className="grid gap-2">
           <Label htmlFor="account-brand">Your brand</Label>
           <Input
@@ -104,7 +98,7 @@ export function CompetitiveSetPicker({
             </span>
           )}
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </Section>
   );
 }

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -1,4 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { PlayIcon, PlusCircleIcon } from "@/components/app-icons";
 
 interface Props {
   onCreate: (input: { accountBrandName: string; competitorNames: string[] }) => Promise<void>;
@@ -30,71 +36,75 @@ export function CompetitiveSetPicker({
   }, [accountBrandName, competitorNames]);
 
   return (
-    <section className="card wide-panel picker">
-      <div className="picker__head">
-        <h3>Competitive set</h3>
-        <span className="picker__count">5 competitors</span>
-      </div>
-      <p className="muted picker__hint">
-        Pick your brand and five competitors. We&rsquo;ll fan twenty perception prompts across every brand and
-        compare the answers.
-      </p>
+    <Card className="wide-panel border-border/70">
+      <CardHeader className="gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle>Competitive set</CardTitle>
+          <Badge variant="secondary">5 competitors</Badge>
+        </div>
+        <CardDescription>
+          Pick your brand and five competitors. We&rsquo;ll fan twenty perception prompts across every brand and
+          compare the answers.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-5">
+        <div className="grid gap-2">
+          <Label htmlFor="account-brand">Your brand</Label>
+          <Input
+            id="account-brand"
+            value={accountBrandName}
+            onChange={(e) => setAccountBrandName(e.target.value)}
+            placeholder="e.g. Netflix"
+            spellCheck={false}
+          />
+        </div>
 
-      <div className="picker__field picker__field--solo">
-        <label className="picker__label">Your brand</label>
-        <input
-          className="picker__input"
-          value={accountBrandName}
-          onChange={(e) => setAccountBrandName(e.target.value)}
-          placeholder="e.g. Netflix"
-          spellCheck={false}
-        />
-      </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+          {competitorNames.map((name, idx) => (
+            <div className="grid gap-2" key={idx}>
+              <Label htmlFor={`competitor-${idx}`} className="flex items-center gap-2">
+                <Badge variant="outline" className="picker__num size-5 rounded-full p-0">{idx + 1}</Badge>
+                Competitor
+              </Label>
+              <Input
+                id={`competitor-${idx}`}
+                value={name}
+                onChange={(e) => {
+                  const next = [...competitorNames];
+                  next[idx] = e.target.value;
+                  setCompetitorNames(next);
+                }}
+                spellCheck={false}
+              />
+            </div>
+          ))}
+        </div>
 
-      <div className="picker__competitors">
-        {competitorNames.map((name, idx) => (
-          <div className="picker__field" key={idx}>
-            <label className="picker__label">
-              <span className="picker__num">{idx + 1}</span>
-              Competitor
-            </label>
-            <input
-              className="picker__input"
-              value={name}
-              onChange={(e) => {
-                const next = [...competitorNames];
-                next[idx] = e.target.value;
-                setCompetitorNames(next);
-              }}
-              spellCheck={false}
-            />
-          </div>
-        ))}
-      </div>
-
-      <div className="picker__actions">
-        <button
-          type="button"
-          className="picker__primary"
-          onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
-          disabled={!canSubmit || busy}
-        >
-          {busy ? "Running benchmark…" : "Run benchmark"}
-        </button>
-        <button
-          type="button"
-          className="picker__secondary"
-          onClick={() => onSave?.(competitorNames)}
-          disabled={!canSubmit || busy || !onSave}
-        >
-          Save competitors
-        </button>
-        {busy && (
-          <span className="picker__status">
-            Streaming brand summaries and judge comparisons in parallel.
-          </span>
-        )}
-      </div>
-    </section>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
+            disabled={!canSubmit || busy}
+          >
+            <PlayIcon data-icon="inline-start" />
+            {busy ? "Running benchmark…" : "Run benchmark"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onSave?.(competitorNames)}
+            disabled={!canSubmit || busy || !onSave}
+          >
+            <PlusCircleIcon data-icon="inline-start" />
+            Save competitors
+          </Button>
+          {busy && (
+            <span className="text-sm text-muted-foreground">
+              Streaming brand summaries and judge comparisons in parallel.
+            </span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/src/components/competitive/FeatureGapTable.tsx
+++ b/web/src/components/competitive/FeatureGapTable.tsx
@@ -1,4 +1,6 @@
 import type { GapEvent, OverviewRow } from "../../types";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 interface Props {
   rows: OverviewRow[];
@@ -13,32 +15,32 @@ export function FeatureGapTable({ rows, gaps, brandLabels, accountBrandName = "Y
 
   return (
     <div className="feature-block">
-      <table className="feature-table">
-        <thead>
-          <tr>
-            <th align="left" style={{ width: "30%" }}>Brand</th>
-            <th align="left">Top features</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[30%]">Brand</TableHead>
+            <TableHead>Top features</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {rows.map((row) => (
-            <tr key={row.brandId}>
-              <td><strong>{label(row.brandId)}</strong></td>
-              <td>
+            <TableRow key={row.brandId}>
+              <TableCell><strong>{label(row.brandId)}</strong></TableCell>
+              <TableCell>
                 {row.topFeatures.length === 0 ? (
                   <span className="muted" style={{ fontStyle: "italic" }}>No feature signal yet</span>
                 ) : (
-                  <span className="chip-row">
+                  <span className="flex flex-wrap gap-1.5">
                     {row.topFeatures.map((feature) => (
-                      <span className="chip" key={feature}>{feature}</span>
+                      <Badge variant="secondary" key={feature}>{feature}</Badge>
                     ))}
                   </span>
                 )}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
 
       {praiseGaps.length > 0 && (
         <>

--- a/web/src/components/competitive/LiveRunTheater.tsx
+++ b/web/src/components/competitive/LiveRunTheater.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 
 const TOTAL_PROMPTS_PER_BRAND = 20;
@@ -37,15 +36,14 @@ export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBra
   }
 
   return (
-    <Card className="theater">
-      <CardHeader className="theater__head">
+    <section className="grid gap-4">
+      <div className="theater__head">
         <div>
           <Badge variant="secondary">Live Run</Badge>
-          <CardTitle className="mt-2">All six brands streaming in parallel</CardTitle>
+          <h2 className="mt-2 text-sm font-semibold tracking-tight">All six brands streaming in parallel</h2>
         </div>
         <Badge variant="outline">{progressStatus}</Badge>
-      </CardHeader>
-      <CardContent className="grid gap-4">
+      </div>
 
       {judgeLines.length > 0 && (
         <aside className="theater__judge">
@@ -81,7 +79,6 @@ export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBra
           );
         })}
       </div>
-      </CardContent>
-    </Card>
+    </section>
   );
 }

--- a/web/src/components/competitive/LiveRunTheater.tsx
+++ b/web/src/components/competitive/LiveRunTheater.tsx
@@ -1,4 +1,7 @@
 import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 
 const TOTAL_PROMPTS_PER_BRAND = 20;
 
@@ -34,14 +37,15 @@ export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBra
   }
 
   return (
-    <section className="card theater">
-      <header className="theater__head">
+    <Card className="theater">
+      <CardHeader className="theater__head">
         <div>
-          <span className="theater__kicker">Live Run</span>
-          <h3 className="theater__title">All six brands streaming in parallel</h3>
+          <Badge variant="secondary">Live Run</Badge>
+          <CardTitle className="mt-2">All six brands streaming in parallel</CardTitle>
         </div>
-        <span className="theater__status">{progressStatus}</span>
-      </header>
+        <Badge variant="outline">{progressStatus}</Badge>
+      </CardHeader>
+      <CardContent className="grid gap-4">
 
       {judgeLines.length > 0 && (
         <aside className="theater__judge">
@@ -67,12 +71,7 @@ export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBra
                   {box.completedPrompts}/{TOTAL_PROMPTS_PER_BRAND}
                 </span>
               </div>
-              <div className="theater__progress" aria-hidden="true">
-                <div
-                  className="theater__progress-fill"
-                  style={{ width: `${pct}%`, background: accent }}
-                />
-              </div>
+              <Progress value={pct} style={{ "--primary": accent } as React.CSSProperties} aria-label={`${box.brandName} progress`} />
               <p className="theater__col-status">{box.status}</p>
               <pre className="theater__stream" data-empty={box.lines.length === 0}>
                 {box.lines.length === 0 ? "Waiting for streamed output…" : box.lines.join("\n")}
@@ -82,6 +81,7 @@ export function LiveRunTheater({ busy, progressStatus, judgeLines, progressByBra
           );
         })}
       </div>
-    </section>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/src/components/competitive/SentimentComparison.tsx
+++ b/web/src/components/competitive/SentimentComparison.tsx
@@ -1,4 +1,5 @@
 import type { OverviewRow } from "../../types";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 export function SentimentComparison({
   rows,
@@ -11,10 +12,13 @@ export function SentimentComparison({
   const sorted = [...rows].sort((a, b) => b.sentiment - a.sentiment);
 
   return (
-    <section className="card">
-      <h3>Sentiment</h3>
-      <p className="muted">Where each brand sits on a -1 to +1 valence axis.</p>
-      <div className="metric-list">
+    <Card>
+      <CardHeader>
+        <CardTitle>Sentiment</CardTitle>
+        <CardDescription>Where each brand sits on a -1 to +1 valence axis.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3">
         {sorted.map((row) => {
           const pct = ((row.sentiment + 1) / 2) * 100;
           const tone =
@@ -24,18 +28,21 @@ export function SentimentComparison({
                 ? "var(--danger)"
                 : "var(--ink)";
           return (
-            <div className="metric-row" key={row.brandId}>
-              <span className="metric-row__label">{label(row.brandId)}</span>
+            <div className="grid gap-1.5" key={row.brandId}>
+              <div className="flex items-center justify-between gap-3 text-sm">
+                <span className="font-medium">{label(row.brandId)}</span>
+                <span className="tabular-nums" style={{ color: tone }}>
+                  {row.sentiment.toFixed(2)}
+                </span>
+              </div>
               <span className="sentiment-gauge" aria-hidden="true">
                 <span className="sentiment-gauge__pin" style={{ left: `${pct}%`, background: tone }} />
-              </span>
-              <span className="metric-row__num" style={{ color: tone }}>
-                {row.sentiment.toFixed(2)}
               </span>
             </div>
           );
         })}
-      </div>
-    </section>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/src/components/competitive/SentimentComparison.tsx
+++ b/web/src/components/competitive/SentimentComparison.tsx
@@ -1,5 +1,5 @@
 import type { OverviewRow } from "../../types";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Section } from "@/components/dashboard";
 
 export function SentimentComparison({
   rows,
@@ -12,13 +12,8 @@ export function SentimentComparison({
   const sorted = [...rows].sort((a, b) => b.sentiment - a.sentiment);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Sentiment</CardTitle>
-        <CardDescription>Where each brand sits on a -1 to +1 valence axis.</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="grid gap-3">
+    <Section title="Sentiment" description="Where each brand sits on a -1 to +1 valence axis.">
+      <div className="grid gap-3">
         {sorted.map((row) => {
           const pct = ((row.sentiment + 1) / 2) * 100;
           const tone =
@@ -41,8 +36,7 @@ export function SentimentComparison({
             </div>
           );
         })}
-        </div>
-      </CardContent>
-    </Card>
+      </div>
+    </Section>
   );
 }

--- a/web/src/components/competitive/ShareOfVoiceChart.tsx
+++ b/web/src/components/competitive/ShareOfVoiceChart.tsx
@@ -1,4 +1,7 @@
 import type { OverviewRow } from "../../types";
+import type { CSSProperties } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 
 const BRAND_VARS = [
   "var(--brand-1)",
@@ -21,26 +24,27 @@ export function ShareOfVoiceChart({
   const max = Math.max(0.001, ...sorted.map((row) => row.shareOfVoice));
 
   return (
-    <section className="card">
-      <h3>Share of voice</h3>
-      <p className="muted">Comparative narrative weight across all 20 perception prompts.</p>
-      <div className="metric-list">
+    <Card>
+      <CardHeader>
+        <CardTitle>Share of voice</CardTitle>
+        <CardDescription>Comparative narrative weight across all 20 perception prompts.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3">
         {sorted.map((row, idx) => (
-          <div className="metric-row" key={row.brandId}>
-            <span className="metric-row__label">{label(row.brandId)}</span>
-            <span className="metric-row__bar">
-              <span
-                className="metric-row__fill"
-                style={{
-                  width: `${Math.max((row.shareOfVoice / max) * 100, 4)}%`,
-                  background: BRAND_VARS[idx % BRAND_VARS.length],
-                }}
-              />
-            </span>
-            <span className="metric-row__num">{(row.shareOfVoice * 100).toFixed(1)}%</span>
+          <div className="grid gap-1.5" key={row.brandId}>
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="font-medium">{label(row.brandId)}</span>
+              <span className="tabular-nums text-muted-foreground">{(row.shareOfVoice * 100).toFixed(1)}%</span>
+            </div>
+            <Progress
+              value={Math.max((row.shareOfVoice / max) * 100, 4)}
+              style={{ "--primary": BRAND_VARS[idx % BRAND_VARS.length] } as CSSProperties}
+            />
           </div>
         ))}
-      </div>
-    </section>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/src/components/competitive/ShareOfVoiceChart.tsx
+++ b/web/src/components/competitive/ShareOfVoiceChart.tsx
@@ -1,7 +1,7 @@
 import type { OverviewRow } from "../../types";
 import type { CSSProperties } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
+import { Section } from "@/components/dashboard";
 
 const BRAND_VARS = [
   "var(--brand-1)",
@@ -24,13 +24,8 @@ export function ShareOfVoiceChart({
   const max = Math.max(0.001, ...sorted.map((row) => row.shareOfVoice));
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Share of voice</CardTitle>
-        <CardDescription>Comparative narrative weight across all 20 perception prompts.</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="grid gap-3">
+    <Section title="Share of voice" description="Comparative narrative weight across all 20 perception prompts.">
+      <div className="grid gap-3">
         {sorted.map((row, idx) => (
           <div className="grid gap-1.5" key={row.brandId}>
             <div className="flex items-center justify-between gap-3 text-sm">
@@ -43,8 +38,7 @@ export function ShareOfVoiceChart({
             />
           </div>
         ))}
-        </div>
-      </CardContent>
-    </Card>
+      </div>
+    </Section>
   );
 }

--- a/web/src/components/competitive/WhitespacePanel.tsx
+++ b/web/src/components/competitive/WhitespacePanel.tsx
@@ -1,4 +1,5 @@
 import type { GapEvent } from "../../types";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
   const whitespace = gaps.filter((gap) => gap.gapType === "whitespace");
@@ -28,9 +29,13 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
 
 function Stat({ label, value }: { label: string; value: number }) {
   return (
-    <div className="stat">
-      <div className="stat__label">{label}</div>
-      <div className="stat__value">{value}</div>
-    </div>
+    <Card size="sm" className="min-w-0">
+      <CardHeader>
+        <CardTitle className="text-sm text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold tracking-tight">{value}</div>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/src/components/competitive/WhitespacePanel.tsx
+++ b/web/src/components/competitive/WhitespacePanel.tsx
@@ -1,5 +1,5 @@
 import type { GapEvent } from "../../types";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Stat, StatRow } from "@/components/dashboard";
 
 export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
   const whitespace = gaps.filter((gap) => gap.gapType === "whitespace");
@@ -7,12 +7,12 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
   const praise = gaps.filter((gap) => gap.gapType === "feature_praise_gap");
 
   return (
-    <div className="whitespace-block">
-      <div className="stat-row">
+    <div className="grid gap-4">
+      <StatRow>
         <Stat label="Whitespace" value={whitespace.length} />
         <Stat label="Exclusion gaps" value={exclusion.length} />
         <Stat label="Praise gaps" value={praise.length} />
-      </div>
+      </StatRow>
       {whitespace.length > 0 && (
         <ul className="bullet-list">
           {whitespace.map((gap) => (
@@ -24,18 +24,5 @@ export function WhitespacePanel({ gaps }: { gaps: GapEvent[] }) {
         </ul>
       )}
     </div>
-  );
-}
-
-function Stat({ label, value }: { label: string; value: number }) {
-  return (
-    <Card size="sm" className="min-w-0">
-      <CardHeader>
-        <CardTitle className="text-sm text-muted-foreground">{label}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-semibold tracking-tight">{value}</div>
-      </CardContent>
-    </Card>
   );
 }

--- a/web/src/components/dashboard.tsx
+++ b/web/src/components/dashboard.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function Section({
+  title,
+  description,
+  action,
+  className,
+  children,
+}: {
+  title?: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <section className={cn("grid gap-3", className)}>
+      {(title || description || action) && (
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="grid gap-0.5">
+            {title && <h2 className="text-sm font-semibold tracking-tight">{title}</h2>}
+            {description && <p className="max-w-2xl text-sm text-muted-foreground">{description}</p>}
+          </div>
+          {action}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}
+
+export function StatRow({ className, children }: { className?: string; children: ReactNode }) {
+  return <dl className={cn("flex flex-wrap gap-x-10 gap-y-4", className)}>{children}</dl>;
+}
+
+export function Stat({ label, value }: { label: ReactNode; value: ReactNode }) {
+  return (
+    <div className="grid gap-1">
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd className="text-2xl font-semibold tracking-tight tabular-nums">{value}</dd>
+    </div>
+  );
+}

--- a/web/src/components/ui/native-select.tsx
+++ b/web/src/components/ui/native-select.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
-import { CaretDownIcon } from "@phosphor-icons/react"
+import { CaretDownIcon } from "@/components/app-icons"
 
 type NativeSelectProps = Omit<React.ComponentProps<"select">, "size"> & {
   size?: "sm" | "default"

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const root = document.getElementById("root");
 if (!root) {
@@ -9,6 +10,8 @@ if (!root) {
 
 createRoot(root).render(
   <React.StrictMode>
-    <App />
+    <TooltipProvider>
+      <App />
+    </TooltipProvider>
   </React.StrictMode>,
 );

--- a/web/src/pages/accuracy.tsx
+++ b/web/src/pages/accuracy.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
 import { API_BASE } from "../api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import type {
   AccuracyAlert,
   AccuracySummary,
@@ -16,6 +20,19 @@ const emptySummary: AccuracySummary = {
 
 function percentage(value: number | null, claims: number) {
   return value === null || claims === 0 ? "—" : `${Math.round(value * 100)}%`;
+}
+
+function SummaryCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold tracking-tight">{value}</div>
+      </CardContent>
+    </Card>
+  );
 }
 
 export function AccuracyPage({ profile }: { profile: BusinessProfile }) {
@@ -53,43 +70,41 @@ export function AccuracyPage({ profile }: { profile: BusinessProfile }) {
   return (
     <div className="block">
       <div className="stat-row">
-        <div className="stat">
-          <div className="stat__label">Responses audited</div>
-          <div className="stat__value">{summary.responsesChecked}</div>
-        </div>
-        <div className="stat">
-          <div className="stat__label">Claims with sources</div>
-          <div className="stat__value">{summary.citedClaims} / {summary.totalClaims}</div>
-        </div>
-        <div className="stat">
-          <div className="stat__label">Citation coverage</div>
-          <div className="stat__value">{percentage(summary.citationCoverage, summary.totalClaims)}</div>
-        </div>
+        <SummaryCard label="Responses audited" value={summary.responsesChecked} />
+        <SummaryCard label="Claims with sources" value={`${summary.citedClaims} / ${summary.totalClaims}`} />
+        <SummaryCard label="Citation coverage" value={percentage(summary.citationCoverage, summary.totalClaims)} />
       </div>
 
-      <article className="card wide-panel">
-        <h2>Evidence coverage by provider</h2>
-        <p className="muted">
-          A citation makes a claim traceable, not automatically true. This audit checks whether each factual claim
-          has an inline source; source quality and contradictions still require review.
-        </p>
-        <table>
-          <thead><tr><th>Provider</th><th>Responses</th><th>Sourced claims</th><th>Coverage</th></tr></thead>
-          <tbody>
+      <Card className="wide-panel">
+        <CardHeader>
+          <CardTitle>Evidence coverage by provider</CardTitle>
+          <CardDescription>
+            A citation makes a claim traceable, not automatically true. This audit checks whether each factual claim
+            has an inline source; source quality and contradictions still require review.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+        <Table>
+          <TableHeader><TableRow><TableHead>Provider</TableHead><TableHead>Responses</TableHead><TableHead>Sourced claims</TableHead><TableHead>Coverage</TableHead></TableRow></TableHeader>
+          <TableBody>
             {providers.map((provider) => (
-              <tr key={provider.provider}>
-                <td>{provider.provider}</td>
-                <td>{provider.responsesChecked}</td>
-                <td>{provider.citedClaims} / {provider.totalClaims}</td>
-                <td>{percentage(provider.citationCoverage, provider.totalClaims)}</td>
-              </tr>
+              <TableRow key={provider.provider}>
+                <TableCell>{provider.provider}</TableCell>
+                <TableCell>{provider.responsesChecked}</TableCell>
+                <TableCell>{provider.citedClaims} / {provider.totalClaims}</TableCell>
+                <TableCell>{percentage(provider.citationCoverage, provider.totalClaims)}</TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
-      </article>
+          </TableBody>
+        </Table>
+        </CardContent>
+      </Card>
 
-      <article className="card wide-panel">
-        <h2>Unsupported factual claims</h2>
+      <Card className="wide-panel">
+        <CardHeader>
+          <CardTitle>Unsupported factual claims</CardTitle>
+        </CardHeader>
+        <CardContent>
         {openAlerts.length === 0 ? (
           <p className="muted">
             {summary.responsesChecked === 0
@@ -97,21 +112,22 @@ export function AccuracyPage({ profile }: { profile: BusinessProfile }) {
               : "Every audited factual claim currently has an inline source."}
           </p>
         ) : (
-          <table>
-            <thead><tr><th>Provider</th><th>Risk</th><th>Claim without a source</th><th>Action</th></tr></thead>
-            <tbody>
+          <Table>
+            <TableHeader><TableRow><TableHead>Provider</TableHead><TableHead>Risk</TableHead><TableHead>Claim without a source</TableHead><TableHead>Action</TableHead></TableRow></TableHeader>
+            <TableBody>
               {openAlerts.map((alert) => (
-                <tr key={alert.id}>
-                  <td>{alert.provider}</td>
-                  <td>{alert.severity}</td>
-                  <td>{alert.claimText}</td>
-                  <td><button type="button" onClick={() => acknowledge(alert.id)}>Acknowledge</button></td>
-                </tr>
+                <TableRow key={alert.id}>
+                  <TableCell>{alert.provider}</TableCell>
+                  <TableCell><Badge variant={alert.severity === "high" ? "destructive" : "outline"}>{alert.severity}</Badge></TableCell>
+                  <TableCell className="whitespace-normal">{alert.claimText}</TableCell>
+                  <TableCell><Button type="button" size="sm" variant="outline" onClick={() => acknowledge(alert.id)}>Acknowledge</Button></TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         )}
-      </article>
+        </CardContent>
+      </Card>
       {error && <p className="error">{error}</p>}
     </div>
   );

--- a/web/src/pages/accuracy.tsx
+++ b/web/src/pages/accuracy.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import { API_BASE } from "../api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Section, Stat, StatRow } from "@/components/dashboard";
 import type {
   AccuracyAlert,
   AccuracySummary,
@@ -20,19 +20,6 @@ const emptySummary: AccuracySummary = {
 
 function percentage(value: number | null, claims: number) {
   return value === null || claims === 0 ? "—" : `${Math.round(value * 100)}%`;
-}
-
-function SummaryCard({ label, value }: { label: string; value: number | string }) {
-  return (
-    <Card size="sm">
-      <CardHeader>
-        <CardDescription>{label}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-semibold tracking-tight">{value}</div>
-      </CardContent>
-    </Card>
-  );
 }
 
 export function AccuracyPage({ profile }: { profile: BusinessProfile }) {
@@ -68,22 +55,17 @@ export function AccuracyPage({ profile }: { profile: BusinessProfile }) {
   const openAlerts = alerts.filter((alert) => alert.status === "open");
 
   return (
-    <div className="block">
-      <div className="stat-row">
-        <SummaryCard label="Responses audited" value={summary.responsesChecked} />
-        <SummaryCard label="Claims with sources" value={`${summary.citedClaims} / ${summary.totalClaims}`} />
-        <SummaryCard label="Citation coverage" value={percentage(summary.citationCoverage, summary.totalClaims)} />
-      </div>
+    <div className="grid gap-8">
+      <StatRow>
+        <Stat label="Responses audited" value={summary.responsesChecked} />
+        <Stat label="Claims with sources" value={`${summary.citedClaims} / ${summary.totalClaims}`} />
+        <Stat label="Citation coverage" value={percentage(summary.citationCoverage, summary.totalClaims)} />
+      </StatRow>
 
-      <Card className="wide-panel">
-        <CardHeader>
-          <CardTitle>Evidence coverage by provider</CardTitle>
-          <CardDescription>
-            A citation makes a claim traceable, not automatically true. This audit checks whether each factual claim
-            has an inline source; source quality and contradictions still require review.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
+      <Section
+        title="Evidence coverage by provider"
+        description="A citation makes a claim traceable, not automatically true. This audit checks whether each factual claim has an inline source; source quality and contradictions still require review."
+      >
         <Table>
           <TableHeader><TableRow><TableHead>Provider</TableHead><TableHead>Responses</TableHead><TableHead>Sourced claims</TableHead><TableHead>Coverage</TableHead></TableRow></TableHeader>
           <TableBody>
@@ -97,14 +79,9 @@ export function AccuracyPage({ profile }: { profile: BusinessProfile }) {
             ))}
           </TableBody>
         </Table>
-        </CardContent>
-      </Card>
+      </Section>
 
-      <Card className="wide-panel">
-        <CardHeader>
-          <CardTitle>Unsupported factual claims</CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Section title="Unsupported factual claims">
         {openAlerts.length === 0 ? (
           <p className="muted">
             {summary.responsesChecked === 0
@@ -126,8 +103,7 @@ export function AccuracyPage({ profile }: { profile: BusinessProfile }) {
             </TableBody>
           </Table>
         )}
-        </CardContent>
-      </Card>
+      </Section>
       {error && <p className="error">{error}</p>}
     </div>
   );

--- a/web/src/pages/admin.tsx
+++ b/web/src/pages/admin.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { API_BASE } from "../api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 import type { AdminMetricsResponse, BusinessProfile, RecommendationFeedbackMetrics } from "../types";
 
 const emptyMetrics: RecommendationFeedbackMetrics = {
@@ -12,10 +14,14 @@ const emptyMetrics: RecommendationFeedbackMetrics = {
 type AdminStatProps = { label: string; value: number | string };
 
 const AdminStat = ({ label, value }: AdminStatProps) => (
-  <div className="stat">
-    <div className="stat__label">{label}</div>
-    <div className="stat__value">{value}</div>
-  </div>
+  <Card size="sm">
+    <CardHeader>
+      <CardDescription>{label}</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="text-2xl font-semibold tracking-tight">{value}</div>
+    </CardContent>
+  </Card>
 );
 
 export const AdminPage = ({ profile }: { profile: BusinessProfile }) => {
@@ -46,9 +52,11 @@ export const AdminPage = ({ profile }: { profile: BusinessProfile }) => {
         </p>
         {error && <p className="error">{error}</p>}
         {loading ? (
-          <article className="card wide-panel">
-            <p className="muted">Loading admin metrics…</p>
-          </article>
+          <Card className="wide-panel">
+            <CardContent>
+              <p className="muted">Loading admin metrics…</p>
+            </CardContent>
+          </Card>
         ) : (
           <>
             <div className="stat-row admin-stat-row">
@@ -57,46 +65,31 @@ export const AdminPage = ({ profile }: { profile: BusinessProfile }) => {
               <AdminStat label="Good rate" value={goodRate} />
             </div>
 
-            <article className="card wide-panel admin-metrics-card">
-              <div>
-                <h3 className="admin-metrics-card__title">Recommendation feedback</h3>
-                <p className="muted">
+            <Card className="wide-panel admin-metrics-card">
+              <CardHeader>
+                <CardTitle>Recommendation feedback</CardTitle>
+                <CardDescription>
                   {metrics.total} of {recommendationCount} recommendations have feedback ({ratedPercent}% rated).
-                </p>
-              </div>
-              <div className="admin-feedback-bars" aria-label="Recommendation feedback breakdown">
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="admin-feedback-bars" aria-label="Recommendation feedback breakdown">
                 <div className="admin-feedback-bars__row">
                   <span>Good</span>
-                  <div className="metric-row__bar">
-                    <span
-                      className="metric-row__fill admin-feedback-bars__good"
-                      style={{ width: `${recommendationCount ? (metrics.good / recommendationCount) * 100 : 0}%` }}
-                    />
-                  </div>
+                  <Progress value={recommendationCount ? (metrics.good / recommendationCount) * 100 : 0} />
                   <strong>{metrics.good}</strong>
                 </div>
                 <div className="admin-feedback-bars__row">
                   <span>Bad</span>
-                  <div className="metric-row__bar">
-                    <span
-                      className="metric-row__fill admin-feedback-bars__bad"
-                      style={{ width: `${recommendationCount ? (metrics.bad / recommendationCount) * 100 : 0}%` }}
-                    />
-                  </div>
+                  <Progress value={recommendationCount ? (metrics.bad / recommendationCount) * 100 : 0} />
                   <strong>{metrics.bad}</strong>
                 </div>
                 <div className="admin-feedback-bars__row">
                   <span>Unrated</span>
-                  <div className="metric-row__bar">
-                    <span
-                      className="metric-row__fill admin-feedback-bars__unrated"
-                      style={{ width: `${recommendationCount ? (metrics.unrated / recommendationCount) * 100 : 0}%` }}
-                    />
-                  </div>
+                  <Progress value={recommendationCount ? (metrics.unrated / recommendationCount) * 100 : 0} />
                   <strong>{metrics.unrated}</strong>
                 </div>
-              </div>
-            </article>
+              </CardContent>
+            </Card>
           </>
         )}
       </div>

--- a/web/src/pages/admin.tsx
+++ b/web/src/pages/admin.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { API_BASE } from "../api";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
+import { Section, Stat, StatRow } from "@/components/dashboard";
 import type { AdminMetricsResponse, BusinessProfile, RecommendationFeedbackMetrics } from "../types";
 
 const emptyMetrics: RecommendationFeedbackMetrics = {
@@ -10,19 +10,6 @@ const emptyMetrics: RecommendationFeedbackMetrics = {
   bad: 0,
   unrated: 0,
 };
-
-type AdminStatProps = { label: string; value: number | string };
-
-const AdminStat = ({ label, value }: AdminStatProps) => (
-  <Card size="sm">
-    <CardHeader>
-      <CardDescription>{label}</CardDescription>
-    </CardHeader>
-    <CardContent>
-      <div className="text-2xl font-semibold tracking-tight">{value}</div>
-    </CardContent>
-  </Card>
-);
 
 export const AdminPage = ({ profile }: { profile: BusinessProfile }) => {
   const [metrics, setMetrics] = useState<RecommendationFeedbackMetrics>(emptyMetrics);
@@ -44,55 +31,48 @@ export const AdminPage = ({ profile }: { profile: BusinessProfile }) => {
   const goodRate = metrics.total === 0 ? "0%" : `${Math.round((metrics.good / metrics.total) * 100)}%`;
 
   return (
-    <>
-      <div className="block">
-        <h2 className="block__title">Feedback metrics</h2>
-        <p className="muted">
-          Admin metrics start with recommendation quality feedback. We can add more feedback surfaces here over time.
-        </p>
-        {error && <p className="error">{error}</p>}
-        {loading ? (
-          <Card className="wide-panel">
-            <CardContent>
-              <p className="muted">Loading admin metrics…</p>
-            </CardContent>
-          </Card>
-        ) : (
-          <>
-            <div className="stat-row admin-stat-row">
-              <AdminStat label="Good recommendations" value={metrics.good} />
-              <AdminStat label="Bad recommendations" value={metrics.bad} />
-              <AdminStat label="Good rate" value={goodRate} />
-            </div>
+    <Section
+      title="Feedback metrics"
+      description="Admin metrics start with recommendation quality feedback. We can add more feedback surfaces here over time."
+    >
+      {error && <p className="error">{error}</p>}
+      {loading ? (
+        <p className="muted">Loading admin metrics…</p>
+      ) : (
+        <div className="grid gap-8">
+          <StatRow>
+            <Stat label="Good recommendations" value={metrics.good} />
+            <Stat label="Bad recommendations" value={metrics.bad} />
+            <Stat label="Good rate" value={goodRate} />
+          </StatRow>
 
-            <Card className="wide-panel admin-metrics-card">
-              <CardHeader>
-                <CardTitle>Recommendation feedback</CardTitle>
-                <CardDescription>
-                  {metrics.total} of {recommendationCount} recommendations have feedback ({ratedPercent}% rated).
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="admin-feedback-bars" aria-label="Recommendation feedback breakdown">
-                <div className="admin-feedback-bars__row">
-                  <span>Good</span>
-                  <Progress value={recommendationCount ? (metrics.good / recommendationCount) * 100 : 0} />
-                  <strong>{metrics.good}</strong>
-                </div>
-                <div className="admin-feedback-bars__row">
-                  <span>Bad</span>
-                  <Progress value={recommendationCount ? (metrics.bad / recommendationCount) * 100 : 0} />
-                  <strong>{metrics.bad}</strong>
-                </div>
-                <div className="admin-feedback-bars__row">
-                  <span>Unrated</span>
-                  <Progress value={recommendationCount ? (metrics.unrated / recommendationCount) * 100 : 0} />
-                  <strong>{metrics.unrated}</strong>
-                </div>
-              </CardContent>
-            </Card>
-          </>
-        )}
-      </div>
-    </>
+          <div className="grid gap-3">
+            <div className="grid gap-0.5">
+              <h3 className="text-sm font-semibold tracking-tight">Recommendation feedback</h3>
+              <p className="text-sm text-muted-foreground">
+                {metrics.total} of {recommendationCount} recommendations have feedback ({ratedPercent}% rated).
+              </p>
+            </div>
+            <div className="admin-feedback-bars" aria-label="Recommendation feedback breakdown">
+              <div className="admin-feedback-bars__row">
+                <span>Good</span>
+                <Progress value={recommendationCount ? (metrics.good / recommendationCount) * 100 : 0} />
+                <strong>{metrics.good}</strong>
+              </div>
+              <div className="admin-feedback-bars__row">
+                <span>Bad</span>
+                <Progress value={recommendationCount ? (metrics.bad / recommendationCount) * 100 : 0} />
+                <strong>{metrics.bad}</strong>
+              </div>
+              <div className="admin-feedback-bars__row">
+                <span>Unrated</span>
+                <Progress value={recommendationCount ? (metrics.unrated / recommendationCount) * 100 : 0} />
+                <strong>{metrics.unrated}</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </Section>
   );
 };

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -6,8 +6,8 @@ import { SentimentComparison } from "../components/competitive/SentimentComparis
 import { ShareOfVoiceChart } from "../components/competitive/ShareOfVoiceChart";
 import { WhitespacePanel } from "../components/competitive/WhitespacePanel";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import { Section } from "@/components/dashboard";
 import type { CompetitiveProgressEvent, GapEvent, OverviewResponse, TrendsResponse } from "../types";
 
 interface SnapshotResponse {
@@ -351,33 +351,29 @@ export function CompetitivePage({
 
       {overview && (
         <>
-          <div className="block">
-            <h2 className="block__title">At a glance</h2>
-            <div className="charts-grid">
+          <Section title="At a glance">
+            <div className="grid gap-x-10 gap-y-8 lg:grid-cols-2">
               <ShareOfVoiceChart rows={overview.rows} brandLabels={brandLabels} />
               <SentimentComparison rows={overview.rows} brandLabels={brandLabels} />
             </div>
-          </div>
+          </Section>
 
-          <div className="block">
-            <h2 className="block__title">Feature signal &amp; gaps</h2>
+          <Section title="Feature signal & gaps">
             <FeatureGapTable
               rows={overview.rows}
               gaps={gaps}
               brandLabels={brandLabels}
               accountBrandName={accountBrandName}
             />
-          </div>
+          </Section>
 
-          <div className="block">
-            <h2 className="block__title">Whitespace</h2>
+          <Section title="Whitespace">
             <WhitespacePanel gaps={gaps} />
-          </div>
+          </Section>
         </>
       )}
 
-      <div className="block">
-        <h2 className="block__title">Trend snapshot</h2>
+      <Section title="Trend snapshot">
         {!trends || Object.keys(trends.seriesByBrand).length === 0 ? (
           <p className="muted">Run a benchmark to populate trend lines.</p>
         ) : (
@@ -398,11 +394,8 @@ export function CompetitivePage({
                 .sort((a, b) => (a.day < b.day ? -1 : 1));
 
               return (
-                <Card className="trend-grid__brand" size="sm" key={id}>
-                  <CardHeader>
-                    <CardTitle>{brandLabels[id] ?? id}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
+                <div className="trend-grid__brand" key={id}>
+                  <div className="trend-grid__name">{brandLabels[id] ?? id}</div>
                   <Table className="trend-mini">
                     <TableBody>
                       {days.map((d) => {
@@ -429,18 +422,14 @@ export function CompetitivePage({
                       })}
                     </TableBody>
                   </Table>
-                  </CardContent>
-                </Card>
+                </div>
               );
             })}
           </div>
         )}
-      </div>
+      </Section>
 
-      <div className="block">
-        <h2 className="block__title">Run configuration</h2>
-        <Card className="wide-panel">
-          <CardContent>
+      <Section title="Run configuration">
         <dl className="run-meta">
           <div>
             <dt>Account</dt>
@@ -459,9 +448,7 @@ export function CompetitivePage({
             <dd>{lastWindow ? `${lastWindow.windowStart.slice(0, 10)} → ${lastWindow.windowEnd.slice(0, 10)}` : "—"}</dd>
           </div>
         </dl>
-          </CardContent>
-        </Card>
-      </div>
+      </Section>
     </>
   );
 }

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -5,6 +5,9 @@ import { LiveRunTheater } from "../components/competitive/LiveRunTheater";
 import { SentimentComparison } from "../components/competitive/SentimentComparison";
 import { ShareOfVoiceChart } from "../components/competitive/ShareOfVoiceChart";
 import { WhitespacePanel } from "../components/competitive/WhitespacePanel";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import type { CompetitiveProgressEvent, GapEvent, OverviewResponse, TrendsResponse } from "../types";
 
 interface SnapshotResponse {
@@ -395,35 +398,39 @@ export function CompetitivePage({
                 .sort((a, b) => (a.day < b.day ? -1 : 1));
 
               return (
-                <div className="trend-grid__brand" key={id}>
-                  <div className="trend-grid__name">{brandLabels[id] ?? id}</div>
-                  <table className="trend-mini">
-                    <tbody>
+                <Card className="trend-grid__brand" size="sm" key={id}>
+                  <CardHeader>
+                    <CardTitle>{brandLabels[id] ?? id}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                  <Table className="trend-mini">
+                    <TableBody>
                       {days.map((d) => {
                         const sentTone =
                           d.sent >= 0.25 ? "var(--success)" : d.sent <= -0.25 ? "var(--danger)" : "var(--muted)";
                         return (
-                          <tr key={d.day}>
-                            <td className="trend-mini__day">{d.day.slice(5)}</td>
-                            <td>
+                          <TableRow key={d.day}>
+                            <TableCell className="trend-mini__day">{d.day.slice(5)}</TableCell>
+                            <TableCell>
                               <span className="trend-mini__bar" aria-hidden="true">
                                 <span
                                   className="trend-mini__bar-fill"
                                   style={{ width: `${Math.min(100, d.sov * 100)}%` }}
                                 />
                               </span>
-                            </td>
-                            <td className="trend-mini__num">{(d.sov * 100).toFixed(0)}%</td>
-                            <td className="trend-mini__sent" style={{ color: sentTone }}>
+                            </TableCell>
+                            <TableCell className="trend-mini__num">{(d.sov * 100).toFixed(0)}%</TableCell>
+                            <TableCell className="trend-mini__sent" style={{ color: sentTone }}>
                               {d.sent >= 0 ? "+" : ""}
                               {d.sent.toFixed(2)}
-                            </td>
-                          </tr>
+                            </TableCell>
+                          </TableRow>
                         );
                       })}
-                    </tbody>
-                  </table>
-                </div>
+                    </TableBody>
+                  </Table>
+                  </CardContent>
+                </Card>
               );
             })}
           </div>
@@ -432,10 +439,12 @@ export function CompetitivePage({
 
       <div className="block">
         <h2 className="block__title">Run configuration</h2>
+        <Card className="wide-panel">
+          <CardContent>
         <dl className="run-meta">
           <div>
             <dt>Account</dt>
-            <dd>{accountBrandName}</dd>
+            <dd><Badge variant="secondary">{accountBrandName}</Badge></dd>
           </div>
           <div>
             <dt>Competitors</dt>
@@ -450,6 +459,8 @@ export function CompetitivePage({
             <dd>{lastWindow ? `${lastWindow.windowStart.slice(0, 10)} → ${lastWindow.windowEnd.slice(0, 10)}` : "—"}</dd>
           </div>
         </dl>
+          </CardContent>
+        </Card>
       </div>
     </>
   );

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import { API_BASE } from "../api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { NativeSelect } from "@/components/ui/native-select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Section, Stat, StatRow } from "@/components/dashboard";
 import { PlayIcon, PlusIcon } from "@/components/app-icons";
 import type { BusinessProfile, MonitoringHistoryPoint, MonitoringResponse } from "../types";
 
@@ -14,19 +14,6 @@ function sentimentLabel(value: string) {
 }
 
 const yTicks = [-1, -0.5, 0, 0.5, 1];
-
-function SummaryCard({ label, value }: { label: string; value: number | string }) {
-  return (
-    <Card size="sm">
-      <CardHeader>
-        <CardDescription>{label}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-semibold tracking-tight">{value}</div>
-      </CardContent>
-    </Card>
-  );
-}
 
 export function SentimentTrend({ history }: { history: MonitoringHistoryPoint[] }) {
   const width = 700;
@@ -59,12 +46,7 @@ export function SentimentTrend({ history }: { history: MonitoringHistoryPoint[] 
   });
 
   return (
-    <Card>
-      <CardHeader>
-        <CardDescription>Overall Sentiment</CardDescription>
-        <CardTitle>Past 7 days</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <Section title="Overall sentiment" description="Past 7 days">
       <svg className="sentiment-chart" viewBox={`0 0 ${width} ${height}`} role="img" aria-label="7 day sentiment trend">
         {points.map((point) => (
           <line
@@ -115,8 +97,7 @@ export function SentimentTrend({ history }: { history: MonitoringHistoryPoint[] 
           </text>
         )}
       </svg>
-      </CardContent>
-    </Card>
+    </Section>
   );
 }
 
@@ -206,91 +187,111 @@ export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
 
   if (!data || (data.status === "generating" && data.prompts.length === 0)) {
     return (
-      <Card>
-        <CardHeader>
-          <CardDescription>Monitoring</CardDescription>
-          <CardTitle>Generating starter prompts...</CardTitle>
-          <CardDescription>
-            Perception is creating chatbot queries for {profile.name} from the website and business description.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <Section
+        title="Generating starter prompts…"
+        description={`Perception is creating chatbot queries for ${profile.name} from the website and business description.`}
+      />
     );
   }
 
   return (
-    <Card className="wide-panel">
-      <CardHeader>
-        <CardDescription>Monitoring</CardDescription>
-        <CardTitle>{profile.name}</CardTitle>
-        <CardDescription>Track the prompts where this business should appear in chatbot answers.</CardDescription>
-      </CardHeader>
-      <CardContent className="grid gap-5">
-      <div className="stat-row">
-        <SummaryCard label="Stored responses" value={data.summary.totalResponses} />
-        <SummaryCard label="Mention frequency" value={`${Math.round(data.summary.mentionFrequency * 100)}%`} />
-        <SummaryCard label="Recommended responses" value={data.summary.recommendedResponses} />
-      </div>
+    <div className="grid gap-8">
+      <StatRow>
+        <Stat label="Stored responses" value={data.summary.totalResponses} />
+        <Stat label="Mention frequency" value={`${Math.round(data.summary.mentionFrequency * 100)}%`} />
+        <Stat label="Recommended responses" value={data.summary.recommendedResponses} />
+      </StatRow>
+
       <SentimentTrend history={data.history} />
-      <div className="flex flex-wrap gap-2">
-        <Button type="button" onClick={runLiveMonitoring} disabled={running || data.prompts.length === 0}>
-          <PlayIcon data-icon="inline-start" />
-          {running ? "Running monitoring…" : "Run live monitoring"}
-        </Button>
-      </div>
 
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Prompt</TableHead>
-            <TableHead>Category</TableHead>
-            <TableHead>Cadence</TableHead>
-            <TableHead>Mention</TableHead>
-            <TableHead>Status</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data.prompts.map((item) => (
-            <TableRow key={item.id}>
-              <TableCell className="whitespace-normal">{item.prompt}</TableCell>
-              <TableCell>{item.category}</TableCell>
-              <TableCell>{item.cadence}</TableCell>
-              <TableCell>
-                <Badge variant={item.mentionSentiment === "negative" ? "destructive" : item.mentionSentiment === "positive" ? "default" : "outline"}>
-                  {sentimentLabel(item.mentionSentiment)}
-                </Badge>
-              </TableCell>
-              <TableCell>
-                <Button type="button" variant="outline" size="sm" onClick={() => togglePrompt(item)}>
-                  {item.active ? "Active" : "Paused"}
-                </Button>
-              </TableCell>
+      <Section
+        title="Tracked prompts"
+        description={`Track the prompts where ${profile.name} should appear in chatbot answers.`}
+        action={
+          <Button type="button" onClick={runLiveMonitoring} disabled={running || data.prompts.length === 0}>
+            <PlayIcon data-icon="inline-start" />
+            {running ? "Running monitoring…" : "Run live monitoring"}
+          </Button>
+        }
+      >
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Prompt</TableHead>
+              <TableHead>Category</TableHead>
+              <TableHead>Cadence</TableHead>
+              <TableHead>Mention</TableHead>
+              <TableHead>Status</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {data.prompts.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell className="whitespace-normal">{item.prompt}</TableCell>
+                <TableCell>{item.category}</TableCell>
+                <TableCell>{item.cadence}</TableCell>
+                <TableCell>
+                  <Badge variant={item.mentionSentiment === "negative" ? "destructive" : item.mentionSentiment === "positive" ? "default" : "outline"}>
+                    {sentimentLabel(item.mentionSentiment)}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Button type="button" variant="outline" size="sm" onClick={() => togglePrompt(item)}>
+                    {item.active ? "Active" : "Paused"}
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
 
-      <h3>Provider health</h3>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Provider</TableHead>
-            <TableHead>Successful</TableHead>
-            <TableHead>Mentions</TableHead>
-            <TableHead>Errors</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data.summary.providerBreakdown.map((item) => (
-            <TableRow key={item.provider}>
-              <TableCell>{sentimentLabel(item.provider)}</TableCell>
-              <TableCell>{item.successes} / {item.attempts}</TableCell>
-              <TableCell>{item.mentions}</TableCell>
-              <TableCell>{item.errors}</TableCell>
+        <div className="flex flex-wrap gap-2">
+          <Input
+            className="w-full min-w-72 flex-1"
+            placeholder="Add a prompt to monitor"
+            value={newPrompt}
+            onChange={(event) => setNewPrompt(event.target.value)}
+          />
+          <NativeSelect value={newCategory} onChange={(event) => setNewCategory(event.target.value as typeof newCategory)}>
+            <option value="comparison">Comparison</option>
+            <option value="recommendation">Recommendation</option>
+            <option value="feature">Feature</option>
+            <option value="pricing">Pricing</option>
+            <option value="custom">Custom</option>
+          </NativeSelect>
+          <NativeSelect value={newCadence} onChange={(event) => setNewCadence(event.target.value as typeof newCadence)}>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+          </NativeSelect>
+          <Button type="button" onClick={addPrompt} disabled={!newPrompt.trim()}>
+            <PlusIcon data-icon="inline-start" />
+            Add prompt
+          </Button>
+        </div>
+      </Section>
+
+      <Section title="Provider health">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Provider</TableHead>
+              <TableHead>Successful</TableHead>
+              <TableHead>Mentions</TableHead>
+              <TableHead>Errors</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {data.summary.providerBreakdown.map((item) => (
+              <TableRow key={item.provider}>
+                <TableCell>{sentimentLabel(item.provider)}</TableCell>
+                <TableCell>{item.successes} / {item.attempts}</TableCell>
+                <TableCell>{item.mentions}</TableCell>
+                <TableCell>{item.errors}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Section>
 
       {data.summary.latestAttempts.some((attempt) => attempt.status === "error") && (
         <div className="error">
@@ -301,33 +302,8 @@ export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
         </div>
       )}
 
-      <div className="flex flex-wrap gap-2">
-        <Input
-          className="w-full min-w-72 flex-1"
-          placeholder="Add a prompt to monitor"
-          value={newPrompt}
-          onChange={(event) => setNewPrompt(event.target.value)}
-        />
-        <NativeSelect value={newCategory} onChange={(event) => setNewCategory(event.target.value as typeof newCategory)}>
-          <option value="comparison">Comparison</option>
-          <option value="recommendation">Recommendation</option>
-          <option value="feature">Feature</option>
-          <option value="pricing">Pricing</option>
-          <option value="custom">Custom</option>
-        </NativeSelect>
-        <NativeSelect value={newCadence} onChange={(event) => setNewCadence(event.target.value as typeof newCadence)}>
-          <option value="daily">Daily</option>
-          <option value="weekly">Weekly</option>
-        </NativeSelect>
-        <Button type="button" onClick={addPrompt} disabled={!newPrompt.trim()}>
-          <PlusIcon data-icon="inline-start" />
-          Add prompt
-        </Button>
-      </div>
-
       {data.status === "error" && <p className="error">{data.error ?? "Prompt generation fell back to sample data."}</p>}
       {error && <p className="error">{error}</p>}
-      </CardContent>
-    </Card>
+    </div>
   );
 }

--- a/web/src/pages/monitoring.tsx
+++ b/web/src/pages/monitoring.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
 import { API_BASE } from "../api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { NativeSelect } from "@/components/ui/native-select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { PlayIcon, PlusIcon } from "@/components/app-icons";
 import type { BusinessProfile, MonitoringHistoryPoint, MonitoringResponse } from "../types";
 
 function sentimentLabel(value: string) {
@@ -7,6 +14,19 @@ function sentimentLabel(value: string) {
 }
 
 const yTicks = [-1, -0.5, 0, 0.5, 1];
+
+function SummaryCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold tracking-tight">{value}</div>
+      </CardContent>
+    </Card>
+  );
+}
 
 export function SentimentTrend({ history }: { history: MonitoringHistoryPoint[] }) {
   const width = 700;
@@ -39,11 +59,12 @@ export function SentimentTrend({ history }: { history: MonitoringHistoryPoint[] 
   });
 
   return (
-    <section className="sentiment-card">
-      <div>
-        <p className="muted">Overall Sentiment</p>
-        <h3>Past 7 days</h3>
-      </div>
+    <Card>
+      <CardHeader>
+        <CardDescription>Overall Sentiment</CardDescription>
+        <CardTitle>Past 7 days</CardTitle>
+      </CardHeader>
+      <CardContent>
       <svg className="sentiment-chart" viewBox={`0 0 ${width} ${height}`} role="img" aria-label="7 day sentiment trend">
         {points.map((point) => (
           <line
@@ -94,7 +115,8 @@ export function SentimentTrend({ history }: { history: MonitoringHistoryPoint[] 
           </text>
         )}
       </svg>
-    </section>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -184,88 +206,91 @@ export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
 
   if (!data || (data.status === "generating" && data.prompts.length === 0)) {
     return (
-      <article className="panel">
-        <p className="muted">Monitoring</p>
-        <h2>Generating starter prompts...</h2>
-        <p>Perception is creating chatbot queries for {profile.name} from the website and business description.</p>
-      </article>
+      <Card>
+        <CardHeader>
+          <CardDescription>Monitoring</CardDescription>
+          <CardTitle>Generating starter prompts...</CardTitle>
+          <CardDescription>
+            Perception is creating chatbot queries for {profile.name} from the website and business description.
+          </CardDescription>
+        </CardHeader>
+      </Card>
     );
   }
 
   return (
-    <article className="panel wide-panel">
-      <p className="muted">Monitoring</p>
-      <h2>{profile.name}</h2>
-      <p>Track the prompts where this business should appear in chatbot answers.</p>
+    <Card className="wide-panel">
+      <CardHeader>
+        <CardDescription>Monitoring</CardDescription>
+        <CardTitle>{profile.name}</CardTitle>
+        <CardDescription>Track the prompts where this business should appear in chatbot answers.</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-5">
       <div className="stat-row">
-        <div className="stat">
-          <div className="stat__label">Stored responses</div>
-          <div className="stat__value">{data.summary.totalResponses}</div>
-        </div>
-        <div className="stat">
-          <div className="stat__label">Mention frequency</div>
-          <div className="stat__value">{Math.round(data.summary.mentionFrequency * 100)}%</div>
-        </div>
-        <div className="stat">
-          <div className="stat__label">Recommended responses</div>
-          <div className="stat__value">{data.summary.recommendedResponses}</div>
-        </div>
+        <SummaryCard label="Stored responses" value={data.summary.totalResponses} />
+        <SummaryCard label="Mention frequency" value={`${Math.round(data.summary.mentionFrequency * 100)}%`} />
+        <SummaryCard label="Recommended responses" value={data.summary.recommendedResponses} />
       </div>
       <SentimentTrend history={data.history} />
-      <div className="inline-form">
-        <button type="button" onClick={runLiveMonitoring} disabled={running || data.prompts.length === 0}>
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" onClick={runLiveMonitoring} disabled={running || data.prompts.length === 0}>
+          <PlayIcon data-icon="inline-start" />
           {running ? "Running monitoring…" : "Run live monitoring"}
-        </button>
+        </Button>
       </div>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Prompt</th>
-            <th>Category</th>
-            <th>Cadence</th>
-            <th>Mention</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Prompt</TableHead>
+            <TableHead>Category</TableHead>
+            <TableHead>Cadence</TableHead>
+            <TableHead>Mention</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {data.prompts.map((item) => (
-            <tr key={item.id}>
-              <td>{item.prompt}</td>
-              <td>{item.category}</td>
-              <td>{item.cadence}</td>
-              <td>
-                <span className={`sentiment sentiment-${item.mentionSentiment}`}>
+            <TableRow key={item.id}>
+              <TableCell className="whitespace-normal">{item.prompt}</TableCell>
+              <TableCell>{item.category}</TableCell>
+              <TableCell>{item.cadence}</TableCell>
+              <TableCell>
+                <Badge variant={item.mentionSentiment === "negative" ? "destructive" : item.mentionSentiment === "positive" ? "default" : "outline"}>
                   {sentimentLabel(item.mentionSentiment)}
-                </span>
-              </td>
-              <td><button type="button" onClick={() => togglePrompt(item)}>{item.active ? "Active" : "Paused"}</button></td>
-            </tr>
+                </Badge>
+              </TableCell>
+              <TableCell>
+                <Button type="button" variant="outline" size="sm" onClick={() => togglePrompt(item)}>
+                  {item.active ? "Active" : "Paused"}
+                </Button>
+              </TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
 
       <h3>Provider health</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Provider</th>
-            <th>Successful</th>
-            <th>Mentions</th>
-            <th>Errors</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Provider</TableHead>
+            <TableHead>Successful</TableHead>
+            <TableHead>Mentions</TableHead>
+            <TableHead>Errors</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {data.summary.providerBreakdown.map((item) => (
-            <tr key={item.provider}>
-              <td>{sentimentLabel(item.provider)}</td>
-              <td>{item.successes} / {item.attempts}</td>
-              <td>{item.mentions}</td>
-              <td>{item.errors}</td>
-            </tr>
+            <TableRow key={item.provider}>
+              <TableCell>{sentimentLabel(item.provider)}</TableCell>
+              <TableCell>{item.successes} / {item.attempts}</TableCell>
+              <TableCell>{item.mentions}</TableCell>
+              <TableCell>{item.errors}</TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
 
       {data.summary.latestAttempts.some((attempt) => attempt.status === "error") && (
         <div className="error">
@@ -276,30 +301,33 @@ export function MonitoringPage({ profile }: { profile: BusinessProfile }) {
         </div>
       )}
 
-      <div className="inline-form">
-        <input
+      <div className="flex flex-wrap gap-2">
+        <Input
+          className="w-full min-w-72 flex-1"
           placeholder="Add a prompt to monitor"
           value={newPrompt}
           onChange={(event) => setNewPrompt(event.target.value)}
         />
-        <select value={newCategory} onChange={(event) => setNewCategory(event.target.value as typeof newCategory)}>
+        <NativeSelect value={newCategory} onChange={(event) => setNewCategory(event.target.value as typeof newCategory)}>
           <option value="comparison">Comparison</option>
           <option value="recommendation">Recommendation</option>
           <option value="feature">Feature</option>
           <option value="pricing">Pricing</option>
           <option value="custom">Custom</option>
-        </select>
-        <select value={newCadence} onChange={(event) => setNewCadence(event.target.value as typeof newCadence)}>
+        </NativeSelect>
+        <NativeSelect value={newCadence} onChange={(event) => setNewCadence(event.target.value as typeof newCadence)}>
           <option value="daily">Daily</option>
           <option value="weekly">Weekly</option>
-        </select>
-        <button type="button" onClick={addPrompt} disabled={!newPrompt.trim()}>
+        </NativeSelect>
+        <Button type="button" onClick={addPrompt} disabled={!newPrompt.trim()}>
+          <PlusIcon data-icon="inline-start" />
           Add prompt
-        </button>
+        </Button>
       </div>
 
       {data.status === "error" && <p className="error">{data.error ?? "Prompt generation fell back to sample data."}</p>}
       {error && <p className="error">{error}</p>}
-    </article>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/src/pages/recommendations.tsx
+++ b/web/src/pages/recommendations.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from "react"
 import { API_BASE } from "../api"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { NativeSelect } from "@/components/ui/native-select"
+import { ThumbsDownIcon, ThumbsUpIcon } from "@/components/app-icons"
 import type {
   BusinessProfile,
   Recommendation,
@@ -39,10 +44,14 @@ const normalizeEvidence = (text: string) =>
 type SummaryStatProps = { label: string; value: number }
 
 const SummaryStat = ({ label, value }: SummaryStatProps) => (
-  <div className="stat">
-    <div className="stat__label">{label}</div>
-    <div className="stat__value">{value}</div>
-  </div>
+  <Card size="sm">
+    <CardHeader>
+      <CardDescription>{label}</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="text-2xl font-semibold tracking-tight">{value}</div>
+    </CardContent>
+  </Card>
 )
 
 type RecommendationItemProps = {
@@ -56,63 +65,73 @@ type RecommendationItemProps = {
 const RecommendationItem = ({ rec, rank, rating, onRate, onStatus }: RecommendationItemProps) => {
   const titleId = `rec-title-${rec.id}`
   return (
-    <article className="card" aria-labelledby={titleId}>
-      <div className="chip-row" aria-label="Category, impact, and effort">
-        <span className="chip">{categoryLabel(rec.category)}</span>
-        <span className="chip">{rec.impact} impact</span>
-        <span className="chip">{rec.effort} effort</span>
-      </div>
-      <h3 className="rec-item__title" id={titleId}>
-        <span className="rec-item__rank">{rank}.</span>
-        {rec.title}
-      </h3>
-      <p className="subhead">Signal</p>
-      <p className="rec-item__body">{normalizeEvidence(rec.evidence)}</p>
-      <p className="subhead">Suggested action</p>
-      <p className="rec-item__body">{rec.action}</p>
-      <div className="inline-form">
-        <label>
-          Status
-          <select
-            value={rec.status}
-            onChange={(event) => onStatus(rec.id, event.target.value as RecommendationStatus)}
-          >
+    <Card aria-labelledby={titleId}>
+      <CardHeader>
+        <div className="flex flex-wrap gap-1.5" aria-label="Category, impact, and effort">
+          <Badge variant="secondary">{categoryLabel(rec.category)}</Badge>
+          <Badge variant={rec.impact === "high" ? "default" : "outline"}>{rec.impact} impact</Badge>
+          <Badge variant="outline">{rec.effort} effort</Badge>
+        </div>
+        <CardTitle id={titleId} className="flex items-center gap-2">
+          <span className="text-muted-foreground">{rank}.</span>
+          {rec.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <div>
+          <p className="subhead">Signal</p>
+          <p className="rec-item__body">{normalizeEvidence(rec.evidence)}</p>
+        </div>
+        <div>
+          <p className="subhead">Suggested action</p>
+          <p className="rec-item__body">{rec.action}</p>
+        </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium">Status</span>
+        <NativeSelect
+          value={rec.status}
+          onChange={(event) => onStatus(rec.id, event.target.value as RecommendationStatus)}
+        >
             <option value="proposed">Proposed</option>
             <option value="planned">Planned</option>
             <option value="in_progress">In progress</option>
             <option value="completed">Completed</option>
             <option value="dismissed">Dismissed</option>
-          </select>
-        </label>
-        {rec.targetProvider && <span className="chip">Target: {rec.targetProvider}</span>}
+        </NativeSelect>
+        {rec.targetProvider && <Badge variant="outline">Target: {rec.targetProvider}</Badge>}
         {rec.lift.delta !== null && (
-          <span className="chip">
+          <Badge variant="secondary">
             Measured lift: {rec.lift.delta >= 0 ? "+" : ""}{rec.lift.delta.toFixed(2)}
-          </span>
+          </Badge>
         )}
       </div>
       <div className="rec-feedback" aria-label={`Feedback for ${rec.title}`}>
         <span className="rec-feedback__label">Was this recommendation useful?</span>
         <div className="rec-feedback__actions">
-          <button
+          <Button
             type="button"
-            className={rating === "good" ? "feedback-button feedback-button--good active" : "feedback-button feedback-button--good"}
+            variant={rating === "good" ? "default" : "outline"}
+            size="sm"
             aria-pressed={rating === "good"}
             onClick={() => onRate(rec.id, "good")}
           >
+            <ThumbsUpIcon data-icon="inline-start" />
             Good
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            className={rating === "bad" ? "feedback-button feedback-button--bad active" : "feedback-button feedback-button--bad"}
+            variant={rating === "bad" ? "destructive" : "outline"}
+            size="sm"
             aria-pressed={rating === "bad"}
             onClick={() => onRate(rec.id, "bad")}
           >
+            <ThumbsDownIcon data-icon="inline-start" />
             Bad
-          </button>
+          </Button>
         </div>
       </div>
-    </article>
+      </CardContent>
+    </Card>
   )
 }
 
@@ -191,23 +210,29 @@ export const RecommendationsPage = ({ profile }: { profile: BusinessProfile }) =
 
   if (loading) {
     return (
-      <article className="panel wide-panel">
-        <p className="muted">Recommendations</p>
-        <h2>Loading recommendations…</h2>
-      </article>
+      <Card className="wide-panel">
+        <CardHeader>
+          <CardDescription>Recommendations</CardDescription>
+          <CardTitle>Loading recommendations…</CardTitle>
+        </CardHeader>
+      </Card>
     )
   }
 
   if (recs.length === 0) {
     return (
-      <article className="panel wide-panel">
-        <p className="muted">Recommendations</p>
-        <h2>No recommendations for {profile.name} yet</h2>
+      <Card className="wide-panel">
+        <CardHeader>
+          <CardDescription>Recommendations</CardDescription>
+          <CardTitle>No recommendations for {profile.name} yet</CardTitle>
+        </CardHeader>
+        <CardContent>
         {loadError && <p className="error">{loadError}</p>}
         <p className="muted">
           Run a live benchmark on Benchmarking to surface gaps; we&rsquo;ll prioritise fix-it ideas here.
         </p>
-      </article>
+        </CardContent>
+      </Card>
     )
   }
 

--- a/web/src/pages/recommendations.tsx
+++ b/web/src/pages/recommendations.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useState } from "react"
 import { API_BASE } from "../api"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { NativeSelect } from "@/components/ui/native-select"
+import { Section, Stat, StatRow } from "@/components/dashboard"
 import { ThumbsDownIcon, ThumbsUpIcon } from "@/components/app-icons"
 import type {
   BusinessProfile,
@@ -41,19 +41,6 @@ const normalizeEvidence = (text: string) =>
     .replaceAll(/\s+/g, " ")
     .trim()
 
-type SummaryStatProps = { label: string; value: number }
-
-const SummaryStat = ({ label, value }: SummaryStatProps) => (
-  <Card size="sm">
-    <CardHeader>
-      <CardDescription>{label}</CardDescription>
-    </CardHeader>
-    <CardContent>
-      <div className="text-2xl font-semibold tracking-tight">{value}</div>
-    </CardContent>
-  </Card>
-)
-
 type RecommendationItemProps = {
   rec: Recommendation
   rank: number
@@ -65,38 +52,37 @@ type RecommendationItemProps = {
 const RecommendationItem = ({ rec, rank, rating, onRate, onStatus }: RecommendationItemProps) => {
   const titleId = `rec-title-${rec.id}`
   return (
-    <Card aria-labelledby={titleId}>
-      <CardHeader>
+    <article aria-labelledby={titleId} className="grid gap-4 py-6 first:pt-0">
+      <div className="grid gap-2">
         <div className="flex flex-wrap gap-1.5" aria-label="Category, impact, and effort">
           <Badge variant="secondary">{categoryLabel(rec.category)}</Badge>
           <Badge variant={rec.impact === "high" ? "default" : "outline"}>{rec.impact} impact</Badge>
           <Badge variant="outline">{rec.effort} effort</Badge>
         </div>
-        <CardTitle id={titleId} className="flex items-center gap-2">
+        <h3 id={titleId} className="flex items-center gap-2 text-base font-semibold tracking-tight">
           <span className="text-muted-foreground">{rank}.</span>
           {rec.title}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="grid gap-4">
-        <div>
-          <p className="subhead">Signal</p>
-          <p className="rec-item__body">{normalizeEvidence(rec.evidence)}</p>
-        </div>
-        <div>
-          <p className="subhead">Suggested action</p>
-          <p className="rec-item__body">{rec.action}</p>
-        </div>
+        </h3>
+      </div>
+      <div>
+        <p className="subhead">Signal</p>
+        <p className="rec-item__body">{normalizeEvidence(rec.evidence)}</p>
+      </div>
+      <div>
+        <p className="subhead">Suggested action</p>
+        <p className="rec-item__body">{rec.action}</p>
+      </div>
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-sm font-medium">Status</span>
         <NativeSelect
           value={rec.status}
           onChange={(event) => onStatus(rec.id, event.target.value as RecommendationStatus)}
         >
-            <option value="proposed">Proposed</option>
-            <option value="planned">Planned</option>
-            <option value="in_progress">In progress</option>
-            <option value="completed">Completed</option>
-            <option value="dismissed">Dismissed</option>
+          <option value="proposed">Proposed</option>
+          <option value="planned">Planned</option>
+          <option value="in_progress">In progress</option>
+          <option value="completed">Completed</option>
+          <option value="dismissed">Dismissed</option>
         </NativeSelect>
         {rec.targetProvider && <Badge variant="outline">Target: {rec.targetProvider}</Badge>}
         {rec.lift.delta !== null && (
@@ -130,8 +116,7 @@ const RecommendationItem = ({ rec, rank, rating, onRate, onStatus }: Recommendat
           </Button>
         </div>
       </div>
-      </CardContent>
-    </Card>
+    </article>
   )
 }
 
@@ -209,30 +194,17 @@ export const RecommendationsPage = ({ profile }: { profile: BusinessProfile }) =
   }
 
   if (loading) {
-    return (
-      <Card className="wide-panel">
-        <CardHeader>
-          <CardDescription>Recommendations</CardDescription>
-          <CardTitle>Loading recommendations…</CardTitle>
-        </CardHeader>
-      </Card>
-    )
+    return <Section title="Loading recommendations…" />
   }
 
   if (recs.length === 0) {
     return (
-      <Card className="wide-panel">
-        <CardHeader>
-          <CardDescription>Recommendations</CardDescription>
-          <CardTitle>No recommendations for {profile.name} yet</CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Section title={`No recommendations for ${profile.name} yet`}>
         {loadError && <p className="error">{loadError}</p>}
         <p className="muted">
           Run a live benchmark on Benchmarking to surface gaps; we&rsquo;ll prioritise fix-it ideas here.
         </p>
-        </CardContent>
-      </Card>
+      </Section>
     )
   }
 
@@ -243,23 +215,25 @@ export const RecommendationsPage = ({ profile }: { profile: BusinessProfile }) =
   ).length
 
   return (
-    <>
-      <div className="block">
-        <h2 className="block__title">At a glance</h2>
-        <p className="muted">Initiative counts for {profile.name}, ranked like the benchmarking tabs.</p>
-        <div className="stat-row">
-          <SummaryStat label="Active initiatives" value={activeRecs.length} />
-          <SummaryStat label="High impact" value={highImpact} />
-          <SummaryStat label="Quick wins" value={quickWins} />
-        </div>
-      </div>
+    <div className="grid gap-8">
+      <Section
+        title="At a glance"
+        description={`Initiative counts for ${profile.name}, ranked like the benchmarking tabs.`}
+      >
+        <StatRow>
+          <Stat label="Active initiatives" value={activeRecs.length} />
+          <Stat label="High impact" value={highImpact} />
+          <Stat label="Quick wins" value={quickWins} />
+        </StatRow>
+      </Section>
 
-      <div className="block">
-        <h2 className="block__title">Prioritised actions</h2>
-        <p className="muted">High impact first. Each card maps to a detected gap or whitespace cue.</p>
+      <Section
+        title="Prioritised actions"
+        description="High impact first. Each item maps to a detected gap or whitespace cue."
+      >
         {loadError && <p className="error">{loadError}</p>}
         {feedbackError && <p className="error">{feedbackError}</p>}
-        <div className="rec-stack">
+        <div className="divide-y divide-border">
           {recs.map((rec, i) => (
             <RecommendationItem
               key={rec.id}
@@ -271,7 +245,7 @@ export const RecommendationsPage = ({ profile }: { profile: BusinessProfile }) =
             />
           ))}
         </div>
-      </div>
-    </>
+      </Section>
+    </div>
   )
 }

--- a/web/src/pages/sources.tsx
+++ b/web/src/pages/sources.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { API_BASE } from "../api";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { NativeSelect } from "@/components/ui/native-select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Section, Stat, StatRow } from "@/components/dashboard";
 import type { BusinessProfile, CitedSource, SourcesResponse } from "../types";
 
 function sourceBadge(type: CitedSource["sourceType"]) {
@@ -16,19 +16,6 @@ function sourceBadge(type: CitedSource["sourceType"]) {
     other: "Other",
   };
   return map[type];
-}
-
-function SummaryCard({ label, value }: { label: string; value: number | string }) {
-  return (
-    <Card size="sm">
-      <CardHeader>
-        <CardDescription>{label}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-semibold tracking-tight">{value}</div>
-      </CardContent>
-    </Card>
-  );
 }
 
 export function SourcesPage({ profile }: { profile: BusinessProfile }) {
@@ -55,31 +42,18 @@ export function SourcesPage({ profile }: { profile: BusinessProfile }) {
   }, [profile.id, provider, type, sentiment]);
 
   if (loading) {
-    return (
-      <Card className="wide-panel">
-        <CardHeader>
-          <CardDescription>Sources</CardDescription>
-          <CardTitle>Loading source attributions…</CardTitle>
-        </CardHeader>
-      </Card>
-    );
+    return <Section title="Loading source attributions…" />;
   }
 
   if (sources.length === 0 && !provider && !type && !sentiment) {
     return (
-      <Card className="wide-panel">
-        <CardHeader>
-          <CardDescription>Sources</CardDescription>
-          <CardTitle>No source attributions for {profile.name} yet</CardTitle>
-        </CardHeader>
-        <CardContent>
+      <Section title={`No source attributions for ${profile.name} yet`}>
         {error && <p className="error">{error}</p>}
-        <p>
+        <p className="text-sm text-muted-foreground">
           Run a live benchmark with citation tracking enabled to surface the third-party sources AI assistants
           cite when answering about this brand.
         </p>
-        </CardContent>
-      </Card>
+      </Section>
     );
   }
 
@@ -92,17 +66,8 @@ export function SourcesPage({ profile }: { profile: BusinessProfile }) {
     .reduce((acc, s) => acc + s.citationsThisWeek, 0);
 
   return (
-    <Card className="wide-panel">
-      <CardHeader>
-        <CardDescription>Sources</CardDescription>
-        <CardTitle>What AI cites about {profile.name}</CardTitle>
-        <CardDescription>
-          The third-party sources frontier models reach for when answering questions about this brand.
-          Counts are citations across the last 7 days of monitoring runs.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="grid gap-5">
-        {error && <p className="error">{error}</p>}
+    <div className="grid gap-8">
+      {error && <p className="error">{error}</p>}
 
       <div className="flex flex-wrap gap-2">
         <NativeSelect aria-label="Filter sources by provider" value={provider} onChange={(event) => setProvider(event.target.value)}>
@@ -128,43 +93,47 @@ export function SourcesPage({ profile }: { profile: BusinessProfile }) {
         </NativeSelect>
       </div>
 
-      <div className="stat-row">
-        <SummaryCard label="Citations / week" value={totalCitations} />
-        <SummaryCard label="Reddit" value={reddit} />
-        <SummaryCard label="News & reviews" value={newsAndReviews} />
-      </div>
+      <StatRow>
+        <Stat label="Citations / week" value={totalCitations} />
+        <Stat label="Reddit" value={reddit} />
+        <Stat label="News & reviews" value={newsAndReviews} />
+      </StatRow>
 
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Source</TableHead>
-            <TableHead className="w-[12%]">Type</TableHead>
-            <TableHead className="w-[26%]">Brands mentioned</TableHead>
-            <TableHead className="w-[14%]">Sentiment</TableHead>
-            <TableHead className="w-[10%] text-right">Citations</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {sources.map((s) => (
-            <TableRow key={s.id}>
-              <TableCell className="whitespace-normal">
-                <div className="sources-row__title"><a href={s.url} target="_blank" rel="noreferrer">{s.title}</a></div>
-                <div className="sources-row__domain">{s.domain}</div>
-                <div className="muted">{s.providers.join(", ")} · {s.relatedRecommendationIds.length} related actions</div>
-              </TableCell>
-              <TableCell><Badge variant="secondary">{sourceBadge(s.sourceType)}</Badge></TableCell>
-              <TableCell className="whitespace-normal">{s.brandsMentioned.join(", ")}</TableCell>
-              <TableCell>
-                <Badge variant={s.sentiment === "negative" ? "destructive" : s.sentiment === "positive" ? "default" : "outline"}>
-                  {s.sentiment}
-                </Badge>
-              </TableCell>
-              <TableCell className="text-right font-semibold">{s.citationsThisWeek}</TableCell>
+      <Section
+        title={`What AI cites about ${profile.name}`}
+        description="The third-party sources frontier models reach for when answering questions about this brand. Counts are citations across the last 7 days of monitoring runs."
+      >
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Source</TableHead>
+              <TableHead className="w-[12%]">Type</TableHead>
+              <TableHead className="w-[26%]">Brands mentioned</TableHead>
+              <TableHead className="w-[14%]">Sentiment</TableHead>
+              <TableHead className="w-[10%] text-right">Citations</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      </CardContent>
-    </Card>
+          </TableHeader>
+          <TableBody>
+            {sources.map((s) => (
+              <TableRow key={s.id}>
+                <TableCell className="whitespace-normal">
+                  <div className="sources-row__title"><a href={s.url} target="_blank" rel="noreferrer">{s.title}</a></div>
+                  <div className="sources-row__domain">{s.domain}</div>
+                  <div className="muted">{s.providers.join(", ")} · {s.relatedRecommendationIds.length} related actions</div>
+                </TableCell>
+                <TableCell><Badge variant="secondary">{sourceBadge(s.sourceType)}</Badge></TableCell>
+                <TableCell className="whitespace-normal">{s.brandsMentioned.join(", ")}</TableCell>
+                <TableCell>
+                  <Badge variant={s.sentiment === "negative" ? "destructive" : s.sentiment === "positive" ? "default" : "outline"}>
+                    {s.sentiment}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right font-semibold">{s.citationsThisWeek}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Section>
+    </div>
   );
 }

--- a/web/src/pages/sources.tsx
+++ b/web/src/pages/sources.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
 import { API_BASE } from "../api";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { NativeSelect } from "@/components/ui/native-select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import type { BusinessProfile, CitedSource, SourcesResponse } from "../types";
 
 function sourceBadge(type: CitedSource["sourceType"]) {
@@ -12,6 +16,19 @@ function sourceBadge(type: CitedSource["sourceType"]) {
     other: "Other",
   };
   return map[type];
+}
+
+function SummaryCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold tracking-tight">{value}</div>
+      </CardContent>
+    </Card>
+  );
 }
 
 export function SourcesPage({ profile }: { profile: BusinessProfile }) {
@@ -39,24 +56,30 @@ export function SourcesPage({ profile }: { profile: BusinessProfile }) {
 
   if (loading) {
     return (
-      <article className="panel wide-panel">
-        <p className="muted">Sources</p>
-        <h2>Loading source attributions…</h2>
-      </article>
+      <Card className="wide-panel">
+        <CardHeader>
+          <CardDescription>Sources</CardDescription>
+          <CardTitle>Loading source attributions…</CardTitle>
+        </CardHeader>
+      </Card>
     );
   }
 
   if (sources.length === 0 && !provider && !type && !sentiment) {
     return (
-      <article className="panel wide-panel">
-        <p className="muted">Sources</p>
-        <h2>No source attributions for {profile.name} yet</h2>
+      <Card className="wide-panel">
+        <CardHeader>
+          <CardDescription>Sources</CardDescription>
+          <CardTitle>No source attributions for {profile.name} yet</CardTitle>
+        </CardHeader>
+        <CardContent>
         {error && <p className="error">{error}</p>}
         <p>
           Run a live benchmark with citation tracking enabled to surface the third-party sources AI assistants
           cite when answering about this brand.
         </p>
-      </article>
+        </CardContent>
+      </Card>
     );
   }
 
@@ -69,23 +92,26 @@ export function SourcesPage({ profile }: { profile: BusinessProfile }) {
     .reduce((acc, s) => acc + s.citationsThisWeek, 0);
 
   return (
-    <article className="panel wide-panel">
-      <p className="muted">Sources</p>
-      <h2>What AI cites about {profile.name}</h2>
-      <p className="muted">
-        The third-party sources frontier models reach for when answering questions about this brand.
-        Counts are citations across the last 7 days of monitoring runs.
-      </p>
-      {error && <p className="error">{error}</p>}
+    <Card className="wide-panel">
+      <CardHeader>
+        <CardDescription>Sources</CardDescription>
+        <CardTitle>What AI cites about {profile.name}</CardTitle>
+        <CardDescription>
+          The third-party sources frontier models reach for when answering questions about this brand.
+          Counts are citations across the last 7 days of monitoring runs.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-5">
+        {error && <p className="error">{error}</p>}
 
-      <div className="inline-form">
-        <select aria-label="Filter sources by provider" value={provider} onChange={(event) => setProvider(event.target.value)}>
+      <div className="flex flex-wrap gap-2">
+        <NativeSelect aria-label="Filter sources by provider" value={provider} onChange={(event) => setProvider(event.target.value)}>
           <option value="">All providers</option>
           <option value="openai">OpenAI</option>
           <option value="anthropic">Claude</option>
           <option value="gemini">Gemini</option>
-        </select>
-        <select aria-label="Filter sources by type" value={type} onChange={(event) => setType(event.target.value)}>
+        </NativeSelect>
+        <NativeSelect aria-label="Filter sources by type" value={type} onChange={(event) => setType(event.target.value)}>
           <option value="">All source types</option>
           <option value="reddit">Reddit</option>
           <option value="publication">News</option>
@@ -93,58 +119,52 @@ export function SourcesPage({ profile }: { profile: BusinessProfile }) {
           <option value="video">Video</option>
           <option value="wiki">Wiki</option>
           <option value="other">Other</option>
-        </select>
-        <select aria-label="Filter sources by sentiment" value={sentiment} onChange={(event) => setSentiment(event.target.value)}>
+        </NativeSelect>
+        <NativeSelect aria-label="Filter sources by sentiment" value={sentiment} onChange={(event) => setSentiment(event.target.value)}>
           <option value="">All sentiment</option>
           <option value="positive">Positive</option>
           <option value="neutral">Neutral</option>
           <option value="negative">Negative</option>
-        </select>
+        </NativeSelect>
       </div>
 
       <div className="stat-row">
-        <div className="stat">
-          <div className="stat__label">Citations / week</div>
-          <div className="stat__value">{totalCitations}</div>
-        </div>
-        <div className="stat">
-          <div className="stat__label">Reddit</div>
-          <div className="stat__value">{reddit}</div>
-        </div>
-        <div className="stat">
-          <div className="stat__label">News & reviews</div>
-          <div className="stat__value">{newsAndReviews}</div>
-        </div>
+        <SummaryCard label="Citations / week" value={totalCitations} />
+        <SummaryCard label="Reddit" value={reddit} />
+        <SummaryCard label="News & reviews" value={newsAndReviews} />
       </div>
 
-      <table>
-        <thead>
-          <tr>
-            <th align="left">Source</th>
-            <th align="left" style={{ width: "12%" }}>Type</th>
-            <th align="left" style={{ width: "26%" }}>Brands mentioned</th>
-            <th align="left" style={{ width: "14%" }}>Sentiment</th>
-            <th align="right" style={{ width: "10%" }}>Citations</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Source</TableHead>
+            <TableHead className="w-[12%]">Type</TableHead>
+            <TableHead className="w-[26%]">Brands mentioned</TableHead>
+            <TableHead className="w-[14%]">Sentiment</TableHead>
+            <TableHead className="w-[10%] text-right">Citations</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {sources.map((s) => (
-            <tr key={s.id}>
-              <td>
+            <TableRow key={s.id}>
+              <TableCell className="whitespace-normal">
                 <div className="sources-row__title"><a href={s.url} target="_blank" rel="noreferrer">{s.title}</a></div>
                 <div className="sources-row__domain">{s.domain}</div>
                 <div className="muted">{s.providers.join(", ")} · {s.relatedRecommendationIds.length} related actions</div>
-              </td>
-              <td><span className="source-badge">{sourceBadge(s.sourceType)}</span></td>
-              <td>{s.brandsMentioned.join(", ")}</td>
-              <td>
-                <span className={`sentiment sentiment-${s.sentiment}`}>{s.sentiment}</span>
-              </td>
-              <td style={{ textAlign: "right", fontWeight: 600 }}>{s.citationsThisWeek}</td>
-            </tr>
+              </TableCell>
+              <TableCell><Badge variant="secondary">{sourceBadge(s.sourceType)}</Badge></TableCell>
+              <TableCell className="whitespace-normal">{s.brandsMentioned.join(", ")}</TableCell>
+              <TableCell>
+                <Badge variant={s.sentiment === "negative" ? "destructive" : s.sentiment === "positive" ? "default" : "outline"}>
+                  {s.sentiment}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-right font-semibold">{s.citationsThisWeek}</TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
-    </article>
+        </TableBody>
+      </Table>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
Merges the full dashboard stack into `main`. This brings the server-backed dashboard, live data wiring, monitoring/benchmarking/accuracy/recommendations/sources features, the shadcn component migration, and the recent UI fixes (broken global CSS, shadcn sidebar, flattened card-free layout).

## Test plan
- [x] `bun test` web suites pass (9/9)
- [ ] Manual smoke test of the dashboard end-to-end

Made with [Cursor](https://cursor.com)