### PR TITLE
Add benchmark provider and model selection

### DIFF
--- a/server/src/features/competitive/__tests__/pipeline.test.ts
+++ b/server/src/features/competitive/__tests__/pipeline.test.ts
@@ -30,6 +30,7 @@ describe("runCompetitivePipeline", () => {
         competitors[4]!.id,
       ],
       promptSetId: seedPromptSetId,
+      provider: "openai",
       models: ["gpt-4.1-mini"],
       windowStart: new Date(Date.now() - 1000).toISOString(),
       windowEnd: new Date().toISOString(),

--- a/server/src/features/competitive/pipeline.ts
+++ b/server/src/features/competitive/pipeline.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { store, getNowIso } from "../../db/store";
 import type { ProgressReporter } from "./progress";
 import { generateBrandAnswer, judgeComparativeOutputs } from "../../lib/llm";
-import type { AIAnswer, CohortRun, CompetitiveDelta, PromptKind, PromptRun } from "./types";
+import type { AIAnswer, BenchmarkProvider, CohortRun, CompetitiveDelta, PromptKind, PromptRun } from "./types";
 
 const PROMPT_RUN_CONCURRENCY = 4;
 
@@ -10,6 +10,7 @@ const cohortRunSchema = z.object({
   accountBrandId: z.string().min(1),
   competitorBrandIds: z.array(z.string().min(1)).length(5),
   promptSetId: z.string().min(1),
+  provider: z.enum(["openai", "anthropic", "gemini"]).default("openai"),
   models: z.array(z.string().min(1)).min(1),
   windowStart: z.string().datetime(),
   windowEnd: z.string().datetime(),
@@ -34,6 +35,7 @@ function createPromptRuns(
   promptSetId: string,
   brandSpecific: string[],
   domain: string[],
+  provider: BenchmarkProvider,
   models: string[],
 ): PromptRun[] {
   const now = getNowIso();
@@ -47,6 +49,7 @@ function createPromptRuns(
           promptSetId,
           prompt,
           promptKind,
+          provider,
           model,
           createdAt: now,
         };
@@ -128,7 +131,13 @@ export async function runCompetitivePipeline(
   }
 
   const brandIds = [input.accountBrandId, ...input.competitorBrandIds];
-  const promptRuns = createPromptRuns(promptSet.id, promptSet.brandSpecificPrompts, promptSet.domainPrompts, input.models);
+  const promptRuns = createPromptRuns(
+    promptSet.id,
+    promptSet.brandSpecificPrompts,
+    promptSet.domainPrompts,
+    input.provider,
+    input.models,
+  );
 
   const allAnswers: AIAnswer[] = [];
   const comparisons = await mapWithConcurrency(promptRuns, PROMPT_RUN_CONCURRENCY, async (promptRun) => {

--- a/server/src/features/competitive/types.ts
+++ b/server/src/features/competitive/types.ts
@@ -13,6 +13,7 @@ export interface CompetitorSet {
 }
 
 export type PromptKind = "brand_specific" | "domain_general";
+export type BenchmarkProvider = "openai" | "anthropic" | "gemini";
 
 export interface PromptSet {
   id: UUID;
@@ -28,6 +29,7 @@ export interface CohortRun {
   accountBrandId: UUID;
   competitorBrandIds: [UUID, UUID, UUID, UUID, UUID];
   promptSetId: UUID;
+  provider: BenchmarkProvider;
   models: string[];
   windowStart: string;
   windowEnd: string;
@@ -38,6 +40,7 @@ export interface PromptRun {
   promptSetId: UUID;
   prompt: string;
   promptKind: PromptKind;
+  provider?: BenchmarkProvider;
   model: string;
   createdAt: string;
 }

--- a/server/src/lib/llm.ts
+++ b/server/src/lib/llm.ts
@@ -2,14 +2,13 @@ import OpenAI from "openai";
 import { z } from "zod";
 import { store } from "../db/store";
 import type { ProgressReporter } from "../features/competitive/progress";
-import type { AIAnswer, Brand, ComparativeDelta, PromptRun } from "../features/competitive/types";
+import type { AIAnswer, BenchmarkProvider, Brand, ComparativeDelta, PromptRun } from "../features/competitive/types";
 
-type SupportedLLMProvider = "openai";
+type SupportedLLMProvider = BenchmarkProvider;
 
 const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
-const configuredProvider = (env.LLM_PROVIDER ?? "openai") as SupportedLLMProvider;
 const openAIApiKey = env.OPENAI_API_KEY;
-const openAIClient = configuredProvider === "openai" && openAIApiKey ? new OpenAI({ apiKey: openAIApiKey }) : null;
+const openAIClient = openAIApiKey ? new OpenAI({ apiKey: openAIApiKey }) : null;
 
 const mentionSchema = z.object({
   brandId: z.string(),
@@ -32,16 +31,45 @@ const BRAND_ANSWER_MAX_OUTPUT_TOKENS = 220;
 const JUDGE_MAX_OUTPUT_TOKENS = 900;
 const STREAM_FLUSH_CHARS = 140;
 
-function getProviderLabel() {
-  return `llm:${configuredProvider}`;
+function runtimeEnv() {
+  return (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? env;
 }
 
-function getStreamingClient() {
-  if (configuredProvider !== "openai") {
-    throw new Error(`Unsupported LLM provider: ${configuredProvider}`);
+function normalizeProvider(provider: string | undefined): SupportedLLMProvider {
+  if (provider === "anthropic" || provider === "gemini" || provider === "openai") {
+    return provider;
   }
-  const runtimeEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? env;
-  if (runtimeEnv.PERCEPTION_FORCE_MOCK_LLM === "1") {
+  return "openai";
+}
+
+function providerForPromptRun(promptRun: PromptRun): SupportedLLMProvider {
+  return promptRun.provider ?? normalizeProvider(runtimeEnv().LLM_PROVIDER);
+}
+
+function forceMockLLM() {
+  const currentEnv = runtimeEnv();
+  return currentEnv.PERCEPTION_FORCE_MOCK_LLM === "1" ||
+    currentEnv.NODE_ENV === "test" ||
+    currentEnv.BUN_ENV === "test";
+}
+
+function providerConfigured(provider: SupportedLLMProvider) {
+  const currentEnv = runtimeEnv();
+  if (provider === "openai") return Boolean(currentEnv.OPENAI_API_KEY);
+  if (provider === "anthropic") return Boolean(currentEnv.ANTHROPIC_API_KEY);
+  return Boolean(currentEnv.GEMINI_API_KEY);
+}
+
+function shouldUseMock(provider: SupportedLLMProvider) {
+  return forceMockLLM() || !providerConfigured(provider);
+}
+
+function getProviderLabel(provider: SupportedLLMProvider) {
+  return `llm:${provider}`;
+}
+
+function getStreamingClient(provider: SupportedLLMProvider) {
+  if (provider !== "openai" || shouldUseMock(provider)) {
     return null;
   }
   if (!openAIClient) {
@@ -58,30 +86,45 @@ function compactLabel(value: string) {
   return value.replaceAll(/\s+/g, " ").trim().slice(0, 80);
 }
 
-function flushStreamBuffer(label: string, buffer: string, onDelta?: (text: string) => void) {
+function flushStreamBuffer(
+  provider: SupportedLLMProvider,
+  label: string,
+  buffer: string,
+  onDelta?: (text: string) => void,
+) {
   const text = buffer.trim();
   if (!text) {
     return;
   }
-  console.log(`[${getProviderLabel()}] ${label}: ${text}`);
+  console.log(`[${getProviderLabel(provider)}] ${label}: ${text}`);
   onDelta?.(text);
 }
 
-async function createStreamedResponse(input: {
+type CompetitiveLLMResponseInput = {
   label: string;
+  provider: SupportedLLMProvider;
   model: string;
   maxOutputTokens: number;
   messages: Array<{ role: "system" | "user"; content: string }>;
   onStarted?: () => void;
   onDelta?: (text: string) => void;
   onCompleted?: () => void;
-}) {
-  const client = getStreamingClient();
-  if (!client) {
-    throw new Error(`${configuredProvider} client not configured.`);
+};
+
+async function createStreamedResponse(input: CompetitiveLLMResponseInput) {
+  if (input.provider === "anthropic") {
+    return createAnthropicResponse(input);
+  }
+  if (input.provider === "gemini") {
+    return createGeminiResponse(input);
   }
 
-  console.log(`[${getProviderLabel()}] ${input.label}: started`);
+  const client = getStreamingClient(input.provider);
+  if (!client) {
+    throw new Error(`${input.provider} client not configured.`);
+  }
+
+  console.log(`[${getProviderLabel(input.provider)}] ${input.label}: started`);
   input.onStarted?.();
 
   const runner = client.responses.stream({
@@ -99,24 +142,106 @@ async function createStreamedResponse(input: {
 
     let newlineIndex = buffer.indexOf("\n");
     while (newlineIndex !== -1) {
-      flushStreamBuffer(input.label, buffer.slice(0, newlineIndex), input.onDelta);
+      flushStreamBuffer(input.provider, input.label, buffer.slice(0, newlineIndex), input.onDelta);
       buffer = buffer.slice(newlineIndex + 1);
       newlineIndex = buffer.indexOf("\n");
     }
 
     if (buffer.length >= STREAM_FLUSH_CHARS) {
-      flushStreamBuffer(input.label, buffer, input.onDelta);
+      flushStreamBuffer(input.provider, input.label, buffer, input.onDelta);
       buffer = "";
     }
   });
 
   const response = await runner.finalResponse();
-  flushStreamBuffer(input.label, buffer, input.onDelta);
-  console.log(`[${getProviderLabel()}] ${input.label}: completed`);
+  flushStreamBuffer(input.provider, input.label, buffer, input.onDelta);
+  console.log(`[${getProviderLabel(input.provider)}] ${input.label}: completed`);
   input.onCompleted?.();
   return typeof response.output_text === "string" && response.output_text.trim().length > 0
     ? response.output_text
     : fullText;
+}
+
+async function createAnthropicResponse(input: CompetitiveLLMResponseInput) {
+  const apiKey = runtimeEnv().ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error("anthropic client not configured.");
+  }
+
+  console.log(`[${getProviderLabel(input.provider)}] ${input.label}: started`);
+  input.onStarted?.();
+
+  const system = input.messages
+    .filter((message) => message.role === "system")
+    .map((message) => message.content)
+    .join("\n\n");
+  const messages = input.messages
+    .filter((message) => message.role === "user")
+    .map((message) => ({ role: "user" as const, content: message.content }));
+
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: input.model,
+      max_tokens: input.maxOutputTokens,
+      system: system || undefined,
+      messages,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Anthropic request failed (${response.status}).`);
+  }
+
+  const body = await response.json() as { content?: Array<{ type: string; text?: string }> };
+  const text = body.content?.map((item) => item.text ?? "").join("\n").trim() ?? "";
+  flushStreamBuffer(input.provider, input.label, text, input.onDelta);
+  console.log(`[${getProviderLabel(input.provider)}] ${input.label}: completed`);
+  input.onCompleted?.();
+  return text;
+}
+
+async function createGeminiResponse(input: CompetitiveLLMResponseInput) {
+  const apiKey = runtimeEnv().GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error("gemini client not configured.");
+  }
+
+  console.log(`[${getProviderLabel(input.provider)}] ${input.label}: started`);
+  input.onStarted?.();
+
+  const prompt = input.messages
+    .map((message) => `${message.role === "system" ? "System" : "User"}:\n${message.content}`)
+    .join("\n\n");
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${input.model}:generateContent?key=${
+      encodeURIComponent(apiKey)
+    }`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { maxOutputTokens: input.maxOutputTokens },
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Gemini request failed (${response.status}).`);
+  }
+
+  const body = await response.json() as {
+    candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+  };
+  const text = body.candidates?.[0]?.content?.parts?.map((part) => part.text ?? "").join("\n").trim() ?? "";
+  flushStreamBuffer(input.provider, input.label, text, input.onDelta);
+  console.log(`[${getProviderLabel(input.provider)}] ${input.label}: completed`);
+  input.onCompleted?.();
+  return text;
 }
 
 function extractJSONObject(text: string) {
@@ -154,14 +279,16 @@ export async function generateBrandAnswer(input: {
   promptRun: PromptRun;
   reportProgress?: ProgressReporter;
 }): Promise<string> {
+  const provider = providerForPromptRun(input.promptRun);
   const questionText =
     input.promptRun.promptKind === "brand_specific"
       ? interpolateBrand(input.promptRun.prompt, input.brand.name)
       : input.promptRun.prompt;
 
-  if (!getStreamingClient()) {
+  if (shouldUseMock(provider)) {
     const kind = input.promptRun.promptKind;
-    const text = `Mock perception summary for ${input.brand.name} (${kind}). "${questionText.slice(0, 90)}..."`;
+    const text =
+      `Mock ${provider} perception summary for ${input.brand.name} (${kind}). "${questionText.slice(0, 90)}..."`;
     input.reportProgress?.({
       type: "answer_started",
       brandId: input.brand.id,
@@ -211,6 +338,7 @@ Write the perception summary now.`;
 
   return createStreamedResponse({
     label: `answer ${input.promptRun.promptKind} ${input.brand.name} :: ${compactLabel(questionText)}`,
+    provider,
     model: input.promptRun.model,
     maxOutputTokens: BRAND_ANSWER_MAX_OUTPUT_TOKENS,
     onStarted: () => {
@@ -261,7 +389,8 @@ export async function judgeComparativeOutputs(input: {
   answers: AIAnswer[];
   reportProgress?: ProgressReporter;
 }): Promise<ComparativeDelta> {
-  if (!getStreamingClient()) {
+  const provider = providerForPromptRun(input.promptRun);
+  if (shouldUseMock(provider)) {
     input.reportProgress?.({
       type: "judge_started",
       prompt: input.promptRun.prompt,
@@ -289,7 +418,7 @@ export async function judgeComparativeOutputs(input: {
       shareOfVoiceByBrand,
       sentimentByBrand,
       praisedFeaturesByBrand,
-      evidence: [`Mock judge used because ${configuredProvider.toUpperCase()} is not configured; competitors expose fix-it gaps.`],
+      evidence: [`Mock judge used because ${provider.toUpperCase()} is not configured; competitors expose fix-it gaps.`],
     };
     input.reportProgress?.({
       type: "judge_delta",
@@ -367,7 +496,8 @@ Do not include commentary outside the JSON object.`;
 
   const outputText = await createStreamedResponse({
     label: `judge ${input.promptRun.promptKind} :: ${compactLabel(input.promptRun.prompt)}`,
-    model: "gpt-4.1-mini",
+    provider,
+    model: input.promptRun.model,
     maxOutputTokens: JUDGE_MAX_OUTPUT_TOKENS,
     onStarted: () => {
       input.reportProgress?.({

--- a/server/src/routes/competitive.ts
+++ b/server/src/routes/competitive.ts
@@ -10,7 +10,6 @@ import {
 import { runGapAnalysis } from "../features/competitive/gap-analysis.service";
 import { refreshSourcesForBrand } from "../features/competitive/sources.service";
 import { publishGapEventsToRecommendationInputs } from "../features/fixit/signal-bridge";
-import { isLLMProviderConfigured } from "../lib/llm-providers";
 
 const competitorSetSchema = z.object({
   accountBrandName: z.string().min(1),
@@ -23,10 +22,24 @@ const competitiveRunSchema = z.object({
   competitorBrandIds: z.array(z.string().min(1)).length(5),
   promptSetId: z.string().optional(),
   sessionId: z.string().min(1).optional(),
+  provider: z.enum(["openai", "anthropic", "gemini"]).default("openai"),
   models: z.array(z.string().min(1)).min(1).default(["gpt-4.1-mini"]),
   windowStart: z.string().datetime(),
   windowEnd: z.string().datetime(),
 });
+
+function benchmarkProviderConfigured(provider: "openai" | "anthropic" | "gemini") {
+  if (
+    process.env.PERCEPTION_FORCE_MOCK_LLM === "1" ||
+    process.env.NODE_ENV === "test" ||
+    process.env.BUN_ENV === "test"
+  ) {
+    return true;
+  }
+  if (provider === "openai") return Boolean(process.env.OPENAI_API_KEY);
+  if (provider === "anthropic") return Boolean(process.env.ANTHROPIC_API_KEY);
+  return Boolean(process.env.GEMINI_API_KEY);
+}
 
 function ensureBrand(name: string) {
   const existing = Array.from(store.brands.values()).find((brand) => brand.name === name);
@@ -118,12 +131,11 @@ competitiveRoutes.post("/competitive-sets", async (c) => {
 competitiveRoutes.post("/competitive/runs", async (c) => {
   const body = competitiveRunSchema.parse(await c.req.json());
   if (
-    process.env.PERCEPTION_FORCE_MOCK_LLM !== "1" &&
-    process.env.NODE_ENV !== "test" &&
-    process.env.BUN_ENV !== "test" &&
-    !isLLMProviderConfigured("openai")
+    !benchmarkProviderConfigured(body.provider)
   ) {
-    return c.json({ error: "OpenAI is not configured. Set OPENAI_API_KEY to run a live benchmark." }, 503);
+    return c.json({
+      error: `${body.provider} is not configured. Set the provider API key to run a live benchmark.`,
+    }, 503);
   }
   const reportProgress = body.sessionId
     ? (event: Parameters<typeof publishCompetitiveProgress>[1]) => publishCompetitiveProgress(body.sessionId!, event)

--- a/web/src/components/competitive/CompetitiveSetPicker.tsx
+++ b/web/src/components/competitive/CompetitiveSetPicker.tsx
@@ -3,11 +3,21 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select";
 import { Section } from "@/components/dashboard";
 import { PlayIcon, PlusCircleIcon } from "@/components/app-icons";
 
+export type BenchmarkProvider = "openai" | "anthropic" | "gemini";
+
+export interface CompetitiveSetInput {
+  accountBrandName: string;
+  competitorNames: string[];
+  provider: BenchmarkProvider;
+  model: string;
+}
+
 interface Props {
-  onCreate: (input: { accountBrandName: string; competitorNames: string[] }) => Promise<void>;
+  onCreate: (input: CompetitiveSetInput) => Promise<void>;
   accountBrandName?: string;
   busy?: boolean;
   competitorNames?: string[];
@@ -18,6 +28,30 @@ interface Props {
 const DEFAULT_ACCOUNT = "Netflix";
 const DEFAULT_COMPETITORS = ["Disney+", "Max", "Amazon Prime Video", "Apple TV+", "Paramount+"];
 
+const PROVIDER_LABELS: Record<BenchmarkProvider, string> = {
+  openai: "OpenAI",
+  anthropic: "Claude (Anthropic)",
+  gemini: "Gemini",
+};
+
+const BENCHMARK_MODELS: Record<BenchmarkProvider, Array<{ label: string; value: string }>> = {
+  openai: [
+    { label: "GPT-4.1 mini", value: "gpt-4.1-mini" },
+    { label: "GPT-5.5", value: "gpt-5.5" },
+    { label: "GPT-5", value: "gpt-5" },
+  ],
+  anthropic: [
+    { label: "Claude Opus 4.5", value: "claude-opus-4-5" },
+    { label: "Claude Sonnet 4.5", value: "claude-sonnet-4-5" },
+    { label: "Claude Haiku 4.5", value: "claude-haiku-4-5" },
+  ],
+  gemini: [
+    { label: "Gemini 2.5 Pro", value: "gemini-2.5-pro" },
+    { label: "Gemini 2.5 Flash", value: "gemini-2.5-flash" },
+    { label: "Gemini 2.0 Flash", value: "gemini-2.0-flash" },
+  ],
+};
+
 export function CompetitiveSetPicker({
   accountBrandName: initialAccountBrandName = DEFAULT_ACCOUNT,
   busy,
@@ -27,6 +61,8 @@ export function CompetitiveSetPicker({
 }: Props) {
   const [accountBrandName, setAccountBrandName] = useState(initialAccountBrandName);
   const [competitorNames, setCompetitorNames] = useState<string[]>(savedCompetitors ?? DEFAULT_COMPETITORS);
+  const [provider, setProvider] = useState<BenchmarkProvider>("openai");
+  const [model, setModel] = useState(BENCHMARK_MODELS.openai[0]!.value);
 
   useEffect(() => setAccountBrandName(initialAccountBrandName), [initialAccountBrandName]);
   useEffect(() => setCompetitorNames(savedCompetitors ?? DEFAULT_COMPETITORS), [savedCompetitors]);
@@ -74,10 +110,49 @@ export function CompetitiveSetPicker({
           ))}
         </div>
 
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor="benchmark-provider">Provider</Label>
+            <NativeSelect
+              id="benchmark-provider"
+              className="w-full"
+              value={provider}
+              onChange={(event) => {
+                const nextProvider = event.target.value as BenchmarkProvider;
+                setProvider(nextProvider);
+                setModel(BENCHMARK_MODELS[nextProvider][0]!.value);
+              }}
+              disabled={busy}
+            >
+              {(Object.keys(PROVIDER_LABELS) as BenchmarkProvider[]).map((value) => (
+                <NativeSelectOption key={value} value={value}>
+                  {PROVIDER_LABELS[value]}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="benchmark-model">Model</Label>
+            <NativeSelect
+              id="benchmark-model"
+              className="w-full"
+              value={model}
+              onChange={(event) => setModel(event.target.value)}
+              disabled={busy}
+            >
+              {BENCHMARK_MODELS[provider].map((option) => (
+                <NativeSelectOption key={option.value} value={option.value}>
+                  {option.label}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </div>
+        </div>
+
         <div className="flex flex-wrap items-center gap-2">
           <Button
             type="button"
-            onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames })}
+            onClick={() => onCreate({ accountBrandName: accountBrandName.trim(), competitorNames, provider, model })}
             disabled={!canSubmit || busy}
           >
             <PlayIcon data-icon="inline-start" />

--- a/web/src/pages/competitive.tsx
+++ b/web/src/pages/competitive.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { CompetitiveSetPicker } from "../components/competitive/CompetitiveSetPicker";
+import { CompetitiveSetPicker, type CompetitiveSetInput } from "../components/competitive/CompetitiveSetPicker";
 import { FeatureGapTable } from "../components/competitive/FeatureGapTable";
 import { LiveRunTheater } from "../components/competitive/LiveRunTheater";
 import { SentimentComparison } from "../components/competitive/SentimentComparison";
@@ -75,6 +75,10 @@ export function CompetitivePage({
   const [progressByBrand, setProgressByBrand] = useState<Record<string, BrandProgressBox>>({});
 
   const [lastWindow, setLastWindow] = useState<{ windowStart: string; windowEnd: string } | null>(null);
+  const [lastRunConfig, setLastRunConfig] = useState<{ provider: string; model: string }>({
+    provider: "openai",
+    model: "gpt-4.1-mini",
+  });
   const progressSourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
@@ -224,7 +228,7 @@ export function CompetitivePage({
     }
   }
 
-  async function createSet(input: { accountBrandName: string; competitorNames: string[] }) {
+  async function createSet(input: CompetitiveSetInput) {
     setBusy(true);
     setError("");
     try {
@@ -244,6 +248,7 @@ export function CompetitivePage({
       setAccountBrandId(setBody.accountBrandId);
       setAccountBrandName(input.accountBrandName);
       setCompetitorBrandIds(setBody.competitorBrandIds);
+      setLastRunConfig({ provider: input.provider, model: input.model });
       const labels: Record<string, string> = {
         [setBody.accountBrandId]: input.accountBrandName,
       };
@@ -283,7 +288,8 @@ export function CompetitivePage({
           sessionId,
           accountBrandId: setBody.accountBrandId,
           competitorBrandIds: setBody.competitorBrandIds,
-          models: ["gpt-4.1-mini"],
+          provider: input.provider,
+          models: [input.model],
           windowStart,
           windowEnd: windowEndAfterRun(),
         }),
@@ -446,6 +452,14 @@ export function CompetitivePage({
           <div>
             <dt>Window</dt>
             <dd>{lastWindow ? `${lastWindow.windowStart.slice(0, 10)} → ${lastWindow.windowEnd.slice(0, 10)}` : "—"}</dd>
+          </div>
+          <div>
+            <dt>Provider</dt>
+            <dd>{lastRunConfig.provider}</dd>
+          </div>
+          <div>
+            <dt>Model</dt>
+            <dd>{lastRunConfig.model}</dd>
           </div>
         </dl>
       </Section>


### PR DESCRIPTION
## Summary
- Add provider and model dropdowns to the Benchmarking competitive set controls.
- Send the selected provider/model through competitive run creation and display the last run configuration.
- Thread provider/model through the competitive benchmark pipeline, including live provider validation and answer/judge LLM calls.

Closes #70
Relates to #57

## Test plan
- `bun run test`
- `bun run build:web`

## Notes
- The issue is assigned to `ckyy888`, labeled, commented, and attached to the `Getting Started with Github for documentation and project management` milestone per the assignment document.

Made with [Cursor](https://cursor.com)